### PR TITLE
Fix RectTransformSetters

### DIFF
--- a/Assets/Plugins/Aspid/MVVM/StarterKit/Unity/Runtime/Binders/Graphics/Mono/GraphicColorSwitcherMonoBinder.cs
+++ b/Assets/Plugins/Aspid/MVVM/StarterKit/Unity/Runtime/Binders/Graphics/Mono/GraphicColorSwitcherMonoBinder.cs
@@ -21,5 +21,4 @@ namespace Aspid.MVVM.StarterKit
         protected override void SetValue(Color value) =>
             CachedComponent.color = _converter?.Convert(value) ?? value;
     }
-
 }

--- a/Assets/Plugins/Aspid/MVVM/StarterKit/Unity/Runtime/Binders/Transforms/RectTransforms/Extensions/RectTransformSetters.cs
+++ b/Assets/Plugins/Aspid/MVVM/StarterKit/Unity/Runtime/Binders/Transforms/RectTransforms/Extensions/RectTransformSetters.cs
@@ -15,7 +15,7 @@ namespace Aspid.MVVM.StarterKit
             var height = mode is not SizeDeltaMode.Width ? value.y : transform.sizeDelta.y;
             
             value = new Vector2(width, height);
-            transform.anchoredPosition = value;
+            transform.sizeDelta = value;
         }
         
         [MethodImpl(MethodImplOptions.AggressiveInlining)]


### PR DESCRIPTION
Fixes incorrect value application in `RectTransform` setter binders — position, size delta, anchors, and pivot values were being applied to wrong properties or silently ignored.