### PR TITLE
Add new text binders

### DIFF
--- a/Assets/Plugins/Aspid/MVVM/StarterKit/Unity/Runtime/Binders/LocalizeStringEvents/Mono/LocalizeStringEventVariableMonoBinder.cs
+++ b/Assets/Plugins/Aspid/MVVM/StarterKit/Unity/Runtime/Binders/LocalizeStringEvents/Mono/LocalizeStringEventVariableMonoBinder.cs
@@ -11,83 +11,96 @@ namespace Aspid.MVVM.StarterKit
     [AddComponentMenu("Aspid/MVVM/Binders/UI/LocalizeStringEvent/LocalizeStringEvent Binder - Variable")]
     [AddPropertyContextMenu(typeof(LocalizeStringEvent), "m_StringReference")]
     [AddComponentContextMenu(typeof(LocalizeStringEvent),"Add LocalizeStringEvent Binder/LocalizeStringEvent Binder - Variable")]
-    public class LocalizeStringEventVariableMonoBinder : ComponentMonoBinder<LocalizeStringEvent>,
+    public partial class LocalizeStringEventVariableMonoBinder : ComponentMonoBinder<LocalizeStringEvent>,
         IBinder<bool>, IBinder<string>, IBinder<Object>, INumberBinder
     {
         [SerializeField] private string _variableName;
         
+        [BinderLog]
         public void SetValue(bool value)
         {
             GetSpecificVariable<BoolVariable>().Value = value;
             CachedComponent.RefreshString();
         }
 
+        [BinderLog]
         public void SetValue(string value)
         {
             GetSpecificVariable<StringVariable>().Value = value;
             CachedComponent.RefreshString();
         }
 
+        [BinderLog]
         public void SetValue(Object value)
         {
             GetSpecificVariable<ObjectVariable>().Value = value;
             CachedComponent.RefreshString();
         }
 
+        [BinderLog]
         public void SetValue(int value)
         {
             GetSpecificVariable<IntVariable>().Value = value;
             CachedComponent.RefreshString();
         }
         
+        [BinderLog]
         public void SetValue(uint value)
         {
             GetSpecificVariable<UIntVariable>().Value = value;
             CachedComponent.RefreshString();
         }
 
+        [BinderLog]
         public void SetValue(long value)
         {
             GetSpecificVariable<LongVariable>().Value = value;
             CachedComponent.RefreshString();
         }
         
+        [BinderLog]
         public void SetValue(ulong value)
         {
             GetSpecificVariable<ULongVariable>().Value = value;
             CachedComponent.RefreshString();
         }
         
+        [BinderLog]
         public void SetValue(byte value)
         {
             GetSpecificVariable<ByteVariable>().Value = value;
             CachedComponent.RefreshString();
         }
         
+        [BinderLog]
         public void SetValue(sbyte value)
         {
             GetSpecificVariable<SByteVariable>().Value = value;
             CachedComponent.RefreshString();
         }
         
+        [BinderLog]
         public void SetValue(short value)
         {
             GetSpecificVariable<ShortVariable>().Value = value;
             CachedComponent.RefreshString();
         }
         
+        [BinderLog]
         public void SetValue(ushort value)
         {
             GetSpecificVariable<UShortVariable>().Value = value;
             CachedComponent.RefreshString();
         }
 
+        [BinderLog]
         public void SetValue(float value)
         {
             GetSpecificVariable<FloatVariable>().Value = value;
             CachedComponent.RefreshString();
         }
 
+        [BinderLog]
         public void SetValue(double value)
         {
             GetSpecificVariable<DoubleVariable>().Value = value;

--- a/Assets/Plugins/Aspid/MVVM/StarterKit/Unity/Runtime/Binders/Texts/Mono/Localizations/TextLocalizationEntryMonoBinder.cs
+++ b/Assets/Plugins/Aspid/MVVM/StarterKit/Unity/Runtime/Binders/Texts/Mono/Localizations/TextLocalizationEntryMonoBinder.cs
@@ -16,7 +16,7 @@ namespace Aspid.MVVM.StarterKit
     [AddComponentMenu("Aspid/MVVM/Binders/UI/Text/Text Binder - Localization Entry")]
     [AddPropertyContextMenu(typeof(TMP_Text), "m_text")]
     [AddComponentContextMenu(typeof(TMP_Text),"Add Text Binder/Text Binder - Localization Entry")]
-    public class TextLocalizationEntryMonoBinder : ComponentMonoBinder<TMP_Text>, IBinder<string>
+    public partial class TextLocalizationEntryMonoBinder : ComponentMonoBinder<TMP_Text>, IBinder<string>
     {
         [SerializeField] private LocalizedString _stringReference = new();
         [SerializeField] private List<Object> _formatArguments = new();
@@ -43,6 +43,7 @@ namespace Aspid.MVVM.StarterKit
         private void Unsubscribe() =>
             _stringReference.Unsubscribe(UpdateString);
         
+        [BinderLog]
         public void SetValue(string value) =>
             _stringReference.TableEntryReference = _converter?.Convert(value) ?? value;
 

--- a/Assets/Plugins/Aspid/MVVM/StarterKit/Unity/Runtime/Binders/Texts/Mono/TextFontEnumGroupMonoBinder.cs
+++ b/Assets/Plugins/Aspid/MVVM/StarterKit/Unity/Runtime/Binders/Texts/Mono/TextFontEnumGroupMonoBinder.cs
@@ -1,0 +1,24 @@
+#if UNITY_2023_1_OR_NEWER || ASPID_MVVM_TEXT_MESH_PRO_INTEGRATION
+using TMPro;
+using UnityEngine;
+
+// ReSharper disable once CheckNamespace
+namespace Aspid.MVVM.StarterKit
+{
+    [AddComponentMenu("Aspid/MVVM/Binders/UI/Text/Text Binder - Font Enum Group")]
+    [AddPropertyContextMenu(typeof(TMP_Text), "m_text")]
+    [AddComponentContextMenu(typeof(TMP_Text),"Add Text Binder/Text Binder - Font Enum Group")]
+    public sealed class TextFontEnumGroupMonoBinder : EnumGroupMonoBinder<TMP_Text>
+    {
+        [Header("Parameters")]
+        [SerializeField] private TMP_FontAsset _defaultValue;
+        [SerializeField] private TMP_FontAsset _selectedValue;
+            
+        protected override void SetDefaultValue(TMP_Text element) =>
+            element.font = _defaultValue;
+
+        protected override void SetSelectedValue(TMP_Text element) =>
+            element.font = _selectedValue;
+    }
+}
+#endif

--- a/Assets/Plugins/Aspid/MVVM/StarterKit/Unity/Runtime/Binders/Texts/Mono/TextFontEnumGroupMonoBinder.cs.meta
+++ b/Assets/Plugins/Aspid/MVVM/StarterKit/Unity/Runtime/Binders/Texts/Mono/TextFontEnumGroupMonoBinder.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: f7dc765b62a3476fb33b27ece361d4a0
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {fileID: 2800000, guid: 3f246f77b3b5a4b6ba0ab47ff519a0a9, type: 3}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Plugins/Aspid/MVVM/StarterKit/Unity/Runtime/Binders/Texts/Mono/TextFontEnumMonoBinder.cs
+++ b/Assets/Plugins/Aspid/MVVM/StarterKit/Unity/Runtime/Binders/Texts/Mono/TextFontEnumMonoBinder.cs
@@ -1,0 +1,17 @@
+#if UNITY_2023_1_OR_NEWER || ASPID_MVVM_TEXT_MESH_PRO_INTEGRATION
+using TMPro;
+using UnityEngine;
+
+// ReSharper disable once CheckNamespace
+namespace Aspid.MVVM.StarterKit
+{
+    [AddComponentMenu("Aspid/MVVM/Binders/UI/Text/Text Binder - Font Enum")]
+    [AddPropertyContextMenu(typeof(TMP_Text), "m_text")]
+    [AddComponentContextMenu(typeof(TMP_Text),"Add Text Binder/Text Binder - Font Enum")]
+    public sealed class TextFontEnumMonoBinder : EnumMonoBinder<TMP_Text, TMP_FontAsset>
+    {
+        protected override void SetValue(TMP_FontAsset value) =>
+            CachedComponent.font = value;
+    }
+}
+#endif

--- a/Assets/Plugins/Aspid/MVVM/StarterKit/Unity/Runtime/Binders/Texts/Mono/TextFontEnumMonoBinder.cs.meta
+++ b/Assets/Plugins/Aspid/MVVM/StarterKit/Unity/Runtime/Binders/Texts/Mono/TextFontEnumMonoBinder.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: a257cc614190456eb6fa716da5d48ee3
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {fileID: 2800000, guid: 3f246f77b3b5a4b6ba0ab47ff519a0a9, type: 3}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Plugins/Aspid/MVVM/StarterKit/Unity/Runtime/Binders/Texts/Mono/TextFontMonoBinder.cs
+++ b/Assets/Plugins/Aspid/MVVM/StarterKit/Unity/Runtime/Binders/Texts/Mono/TextFontMonoBinder.cs
@@ -1,0 +1,19 @@
+#if UNITY_2023_1_OR_NEWER || ASPID_MVVM_TEXT_MESH_PRO_INTEGRATION
+using System.Collections.Generic;
+using TMPro;
+using UnityEngine;
+
+// ReSharper disable once CheckNamespace
+namespace Aspid.MVVM.StarterKit
+{
+    [AddComponentMenu("Aspid/MVVM/Binders/UI/Text/Text Binder - Font")]
+    [AddPropertyContextMenu(typeof(TMP_Text), "m_text")]
+    [AddComponentContextMenu(typeof(TMP_Text),"Add Text Binder/Text Binder - Font")]
+    public partial class TextFontMonoBinder : ComponentMonoBinder<TMP_Text>, IBinder<TMP_FontAsset>
+    {
+        [BinderLog]
+        public void SetValue(TMP_FontAsset value) =>
+            CachedComponent.font = value;
+    }
+}
+#endif

--- a/Assets/Plugins/Aspid/MVVM/StarterKit/Unity/Runtime/Binders/Texts/Mono/TextFontMonoBinder.cs.meta
+++ b/Assets/Plugins/Aspid/MVVM/StarterKit/Unity/Runtime/Binders/Texts/Mono/TextFontMonoBinder.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: c91f74dbf45748d5bb1c4a91380404a6
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {fileID: 2800000, guid: 3f246f77b3b5a4b6ba0ab47ff519a0a9, type: 3}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Plugins/Aspid/MVVM/StarterKit/Unity/Runtime/Binders/Texts/Mono/TextFontSwitcherMonoBinder.cs
+++ b/Assets/Plugins/Aspid/MVVM/StarterKit/Unity/Runtime/Binders/Texts/Mono/TextFontSwitcherMonoBinder.cs
@@ -1,0 +1,17 @@
+#if UNITY_2023_1_OR_NEWER || ASPID_MVVM_TEXT_MESH_PRO_INTEGRATION
+using TMPro;
+using UnityEngine;
+
+// ReSharper disable once CheckNamespace
+namespace Aspid.MVVM.StarterKit
+{
+    [AddComponentMenu("Aspid/MVVM/Binders/UI/Text/Text Binder - Font Switcher")]
+    [AddPropertyContextMenu(typeof(TMP_Text), "m_text")]
+    [AddComponentContextMenu(typeof(TMP_Text),"Add Text Binder/Text Binder - Font Switcher")]
+    public sealed class TextFontSwitcherMonoBinder : SwitcherMonoBinder<TMP_Text, TMP_FontAsset>
+    {
+        protected override void SetValue(TMP_FontAsset value) =>
+            CachedComponent.font = value;
+    }
+}
+#endif

--- a/Assets/Plugins/Aspid/MVVM/StarterKit/Unity/Runtime/Binders/Texts/Mono/TextFontSwitcherMonoBinder.cs.meta
+++ b/Assets/Plugins/Aspid/MVVM/StarterKit/Unity/Runtime/Binders/Texts/Mono/TextFontSwitcherMonoBinder.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 11efed18074445ee964046ea975aee19
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {fileID: 2800000, guid: 3f246f77b3b5a4b6ba0ab47ff519a0a9, type: 3}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Plugins/Aspid/MVVM/StarterKit/Unity/Runtime/Binders/Texts/TextAlignmentBinder.cs
+++ b/Assets/Plugins/Aspid/MVVM/StarterKit/Unity/Runtime/Binders/Texts/TextAlignmentBinder.cs
@@ -1,0 +1,20 @@
+#if UNITY_2023_1_OR_NEWER || ASPID_MVVM_TEXT_MESH_PRO_INTEGRATION
+#nullable enable
+using TMPro;
+
+// ReSharper disable once CheckNamespace
+namespace Aspid.MVVM.StarterKit
+{
+    public class TextAlignmentBinder : TargetBinder<TMP_Text>, IBinder<TextAlignmentOptions>
+    {
+        public TextAlignmentBinder(TMP_Text target, BindMode mode = BindMode.OneWay)
+            : base(target, mode)
+        {
+            mode.ThrowExceptionIfTwo();
+        }
+
+        public void SetValue(TextAlignmentOptions value) =>
+            Target.alignment = value;
+    }
+}
+#endif

--- a/Assets/Plugins/Aspid/MVVM/StarterKit/Unity/Runtime/Binders/Texts/TextAlignmentBinder.cs.meta
+++ b/Assets/Plugins/Aspid/MVVM/StarterKit/Unity/Runtime/Binders/Texts/TextAlignmentBinder.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: c1592e1cf6044fccbc665fc94b9cebed
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {fileID: 2800000, guid: 3f246f77b3b5a4b6ba0ab47ff519a0a9, type: 3}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Plugins/Aspid/MVVM/StarterKit/Unity/Runtime/Binders/Texts/TextAlignmentSwitcherBinder.cs
+++ b/Assets/Plugins/Aspid/MVVM/StarterKit/Unity/Runtime/Binders/Texts/TextAlignmentSwitcherBinder.cs
@@ -1,0 +1,21 @@
+#if UNITY_2023_1_OR_NEWER || ASPID_MVVM_TEXT_MESH_PRO_INTEGRATION
+#nullable enable
+using TMPro;
+
+// ReSharper disable once CheckNamespace
+namespace Aspid.MVVM.StarterKit
+{
+    public sealed class TextAlignmentSwitcherBinder : SwitcherBinder<TMP_Text, TextAlignmentOptions>
+    {
+        public TextAlignmentSwitcherBinder(
+            TMP_Text target,
+            TextAlignmentOptions trueValue,
+            TextAlignmentOptions falseValue,
+            BindMode mode = BindMode.OneWay)
+            : base(target, trueValue, falseValue, mode) { }
+
+        protected override void SetValue(TextAlignmentOptions value) =>
+            Target.alignment = value;
+    }
+}
+#endif

--- a/Assets/Plugins/Aspid/MVVM/StarterKit/Unity/Runtime/Binders/Texts/TextAlignmentSwitcherBinder.cs.meta
+++ b/Assets/Plugins/Aspid/MVVM/StarterKit/Unity/Runtime/Binders/Texts/TextAlignmentSwitcherBinder.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 321ba63921df4181b77837f29b19b152
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {fileID: 2800000, guid: 3f246f77b3b5a4b6ba0ab47ff519a0a9, type: 3}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Plugins/Aspid/MVVM/StarterKit/Unity/Runtime/Binders/Texts/TextFontBinder.cs
+++ b/Assets/Plugins/Aspid/MVVM/StarterKit/Unity/Runtime/Binders/Texts/TextFontBinder.cs
@@ -1,0 +1,20 @@
+#if UNITY_2023_1_OR_NEWER || ASPID_MVVM_TEXT_MESH_PRO_INTEGRATION
+#nullable enable
+using TMPro;
+
+// ReSharper disable once CheckNamespace
+namespace Aspid.MVVM.StarterKit
+{
+    public class TextFontBinder : TargetBinder<TMP_Text>, IBinder<TMP_FontAsset?>
+    {
+        public TextFontBinder(TMP_Text target, BindMode mode = BindMode.OneWay)
+            : base(target, mode)
+        {
+            mode.ThrowExceptionIfTwo();
+        }
+        
+        public void SetValue(TMP_FontAsset? value) =>
+            Target.font = value;
+    }
+}
+#endif

--- a/Assets/Plugins/Aspid/MVVM/StarterKit/Unity/Runtime/Binders/Texts/TextFontBinder.cs.meta
+++ b/Assets/Plugins/Aspid/MVVM/StarterKit/Unity/Runtime/Binders/Texts/TextFontBinder.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: e0c1767e47944620929612e558c8c7df
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {fileID: 2800000, guid: 3f246f77b3b5a4b6ba0ab47ff519a0a9, type: 3}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Plugins/Aspid/MVVM/StarterKit/Unity/Runtime/Binders/Texts/TextFontSwitcherBinder.cs
+++ b/Assets/Plugins/Aspid/MVVM/StarterKit/Unity/Runtime/Binders/Texts/TextFontSwitcherBinder.cs
@@ -1,0 +1,21 @@
+#if UNITY_2023_1_OR_NEWER || ASPID_MVVM_TEXT_MESH_PRO_INTEGRATION
+#nullable enable
+using TMPro;
+
+// ReSharper disable once CheckNamespace
+namespace Aspid.MVVM.StarterKit
+{
+    public sealed class TextFontSwitcherBinder : SwitcherBinder<TMP_Text, TMP_FontAsset>
+    {
+        public TextFontSwitcherBinder(
+            TMP_Text target, 
+            TMP_FontAsset trueValue, 
+            TMP_FontAsset falseValue, 
+            BindMode mode = BindMode.OneWay) 
+            : base(target, trueValue, falseValue, mode) { }
+
+        protected override void SetValue(TMP_FontAsset value) =>
+            Target.font = value;
+    }
+}
+#endif

--- a/Assets/Plugins/Aspid/MVVM/StarterKit/Unity/Runtime/Binders/Texts/TextFontSwitcherBinder.cs.meta
+++ b/Assets/Plugins/Aspid/MVVM/StarterKit/Unity/Runtime/Binders/Texts/TextFontSwitcherBinder.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 2cffb1d920b94f7982f47945c4d0c725
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {fileID: 2800000, guid: 3f246f77b3b5a4b6ba0ab47ff519a0a9, type: 3}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 


### PR DESCRIPTION
Adds new binder components for Unity UI text elements, extending bindable surface coverage for `TextMeshProUGUI` and legacy `Text` components with additional properties (font size, color, character spacing, etc.).