### PR TITLE
Upgrade visual for binders

### DIFF
--- a/Assets/Plugins/Aspid/MVVM/StarterKit/Runtime/Binders/SwitcherBinder.cs
+++ b/Assets/Plugins/Aspid/MVVM/StarterKit/Runtime/Binders/SwitcherBinder.cs
@@ -7,7 +7,7 @@ namespace Aspid.MVVM.StarterKit
     public abstract class SwitcherBinder<T> : Binder, IBinder<bool>
     {
 #if UNITY_2022_1_OR_NEWER
-        [UnityEngine.Header("Parameters")]
+        [UnityEngine.Header("Values")]
         [UnityEngine.SerializeField] 
 #endif
         private T _trueValue;
@@ -39,7 +39,7 @@ namespace Aspid.MVVM.StarterKit
     public abstract class SwitcherBinder<TTarget, T> : TargetBinder<TTarget>, IBinder<bool>
     {
 #if UNITY_2022_1_OR_NEWER
-        [UnityEngine.Header("Parameters")]
+        [UnityEngine.Header("Values")]
         [UnityEngine.SerializeField] 
 #endif
         private T _trueValue; 

--- a/Assets/Plugins/Aspid/MVVM/StarterKit/Unity/Runtime/Binders/Animators/AnimatorSetBoolBinder.cs
+++ b/Assets/Plugins/Aspid/MVVM/StarterKit/Unity/Runtime/Binders/Animators/AnimatorSetBoolBinder.cs
@@ -8,7 +8,6 @@ namespace Aspid.MVVM.StarterKit
     [Serializable]
     public class AnimatorSetBoolBinder : AnimatorSetParameterBinder<bool>
     {
-        [Header("Converter")]
         [SerializeField] private bool _isInvert;
 
         public AnimatorSetBoolBinder(Animator animator, string parameterName, BindMode mode)

--- a/Assets/Plugins/Aspid/MVVM/StarterKit/Unity/Runtime/Binders/Animators/AnimatorSetFloatBinder.cs
+++ b/Assets/Plugins/Aspid/MVVM/StarterKit/Unity/Runtime/Binders/Animators/AnimatorSetFloatBinder.cs
@@ -13,7 +13,6 @@ namespace Aspid.MVVM.StarterKit
     [Serializable]
     public class AnimatorSetFloatBinder : AnimatorSetParameterBinder<float>
     {
-        [Header("Converter")]
         [SerializeReferenceDropdown]
         [SerializeReference] private Converter? _converter;
 

--- a/Assets/Plugins/Aspid/MVVM/StarterKit/Unity/Runtime/Binders/Animators/AnimatorSetIntBinder.cs
+++ b/Assets/Plugins/Aspid/MVVM/StarterKit/Unity/Runtime/Binders/Animators/AnimatorSetIntBinder.cs
@@ -13,7 +13,6 @@ namespace Aspid.MVVM.StarterKit
     [Serializable]
     public class AnimatorSetIntBinder : AnimatorSetParameterBinder<int>
     {
-        [Header("Converter")]
         [SerializeReferenceDropdown]
         [SerializeReference] private Converter? _converter;
 

--- a/Assets/Plugins/Aspid/MVVM/StarterKit/Unity/Runtime/Binders/Animators/AnimatorSetParameterBinder.cs
+++ b/Assets/Plugins/Aspid/MVVM/StarterKit/Unity/Runtime/Binders/Animators/AnimatorSetParameterBinder.cs
@@ -11,7 +11,6 @@ namespace Aspid.MVVM.StarterKit
     {
         public event Action<IRelayCommand<T>>? ValueChanged;
         
-        [field: Header("Parameters")]
         [field: SerializeField]
         protected string ParameterName { get; private set; }
         

--- a/Assets/Plugins/Aspid/MVVM/StarterKit/Unity/Runtime/Binders/Animators/AnimatorSetTriggerBinder.cs
+++ b/Assets/Plugins/Aspid/MVVM/StarterKit/Unity/Runtime/Binders/Animators/AnimatorSetTriggerBinder.cs
@@ -11,7 +11,6 @@ namespace Aspid.MVVM.StarterKit
     {
         public event Action<IRelayCommand>? ValueChanged;
         
-        [field: Header("Parameters")]
         [field: SerializeField]
         protected string TriggerName { get; private set; }
         

--- a/Assets/Plugins/Aspid/MVVM/StarterKit/Unity/Runtime/Binders/Animators/Mono/AnimatorSetBoolMonoBinder.cs
+++ b/Assets/Plugins/Aspid/MVVM/StarterKit/Unity/Runtime/Binders/Animators/Mono/AnimatorSetBoolMonoBinder.cs
@@ -7,7 +7,6 @@ namespace Aspid.MVVM.StarterKit
     [AddComponentContextMenu(typeof(Animator),"Add Animator Binder/Animator Binder - Set Bool")]
     public class AnimatorSetBoolMonoBinder : AnimatorSetParameterMonoBinder<bool>
     {
-        [Header("Converter")]
         [SerializeField] private bool _isInvert;
         
         protected sealed override void SetParameter(bool value)

--- a/Assets/Plugins/Aspid/MVVM/StarterKit/Unity/Runtime/Binders/Animators/Mono/AnimatorSetFloatMonoBinder.cs
+++ b/Assets/Plugins/Aspid/MVVM/StarterKit/Unity/Runtime/Binders/Animators/Mono/AnimatorSetFloatMonoBinder.cs
@@ -12,7 +12,6 @@ namespace Aspid.MVVM.StarterKit
     [AddComponentContextMenu(typeof(Animator),"Add Animator Binder/Animator Binder - Set Float")]
     public partial class AnimatorSetFloatMonoBinder : AnimatorSetParameterMonoBinder<float>, INumberBinder
     {
-        [Header("Converter")]
         [SerializeReferenceDropdown]
         [SerializeReference] private Converter _converter;
         

--- a/Assets/Plugins/Aspid/MVVM/StarterKit/Unity/Runtime/Binders/Animators/Mono/AnimatorSetIntMonoBinder.cs
+++ b/Assets/Plugins/Aspid/MVVM/StarterKit/Unity/Runtime/Binders/Animators/Mono/AnimatorSetIntMonoBinder.cs
@@ -12,7 +12,6 @@ namespace Aspid.MVVM.StarterKit
     [AddComponentContextMenu(typeof(Animator),"Add Animator Binder/Animator Binder - Set Int")]
     public partial class AnimatorSetIntMonoBinder : AnimatorSetParameterMonoBinder<int>, INumberBinder
     {
-        [Header("Converter")]
         [SerializeReferenceDropdown]
         [SerializeReference] private Converter _converter;
         

--- a/Assets/Plugins/Aspid/MVVM/StarterKit/Unity/Runtime/Binders/Animators/Mono/AnimatorSetParameterMonoBinder.cs
+++ b/Assets/Plugins/Aspid/MVVM/StarterKit/Unity/Runtime/Binders/Animators/Mono/AnimatorSetParameterMonoBinder.cs
@@ -11,7 +11,6 @@ namespace Aspid.MVVM.StarterKit
         
         private T _value;
         
-        [field: Header("Parameters")]
         [field: SerializeField] 
         protected string ParameterName { get; private set; }
         

--- a/Assets/Plugins/Aspid/MVVM/StarterKit/Unity/Runtime/Binders/Animators/Mono/AnimatorSetTriggerMonoBinder.cs
+++ b/Assets/Plugins/Aspid/MVVM/StarterKit/Unity/Runtime/Binders/Animators/Mono/AnimatorSetTriggerMonoBinder.cs
@@ -10,8 +10,7 @@ namespace Aspid.MVVM.StarterKit
     public class AnimatorSetTriggerMonoBinder : ComponentMonoBinder<Animator>, IReverseBinder<IRelayCommand>
     {
         public event Action<IRelayCommand> ValueChanged;
-
-        [field: Header("Parameters")]
+        
         [field: SerializeField] 
         protected string TriggerName { get; private set; }
         

--- a/Assets/Plugins/Aspid/MVVM/StarterKit/Unity/Runtime/Binders/Behaviours/BehaviourEnabledBinder.cs
+++ b/Assets/Plugins/Aspid/MVVM/StarterKit/Unity/Runtime/Binders/Behaviours/BehaviourEnabledBinder.cs
@@ -8,7 +8,6 @@ namespace Aspid.MVVM.StarterKit
     [Serializable]
     public class BehaviourEnabledBinder : TargetBinder<Behaviour>, IBinder<bool>
     {
-        [Header("Converter")]
         [SerializeField] private bool _isInvert;
 
         public BehaviourEnabledBinder(Behaviour target, BindMode mode)

--- a/Assets/Plugins/Aspid/MVVM/StarterKit/Unity/Runtime/Binders/Behaviours/Mono/BehaviourEnabledEnumGroupMonoBinder.cs
+++ b/Assets/Plugins/Aspid/MVVM/StarterKit/Unity/Runtime/Binders/Behaviours/Mono/BehaviourEnabledEnumGroupMonoBinder.cs
@@ -7,7 +7,7 @@ namespace Aspid.MVVM.StarterKit
     [AddComponentContextMenu(typeof(Behaviour),"Add Behaviour Binder/Behaviour Binder - Enabled EnumGroup")]
     public sealed class BehaviourEnabledEnumGroupMonoBinder : EnumGroupMonoBinder<Behaviour>
     {
-        [Header("Parameters")]
+        [Header("Values")]
         [SerializeField] private bool _defaultValue;
         [SerializeField] private bool _selectedValue;
         

--- a/Assets/Plugins/Aspid/MVVM/StarterKit/Unity/Runtime/Binders/Behaviours/Mono/BehaviourEnabledMonoBinder.cs
+++ b/Assets/Plugins/Aspid/MVVM/StarterKit/Unity/Runtime/Binders/Behaviours/Mono/BehaviourEnabledMonoBinder.cs
@@ -7,7 +7,6 @@ namespace Aspid.MVVM.StarterKit
     [AddComponentContextMenu(typeof(Behaviour),"Add Behaviour Binder/Behaviour Binder - Enabled")]
     public partial class BehaviourEnabledMonoBinder : ComponentMonoBinder<Behaviour>, IBinder<bool>
     {
-        [Header("Converter")]
         [SerializeField] private bool _isInvert;
         
         [BinderLog]

--- a/Assets/Plugins/Aspid/MVVM/StarterKit/Unity/Runtime/Binders/CanvasGroups/CanvasGroupAlphaBinder.cs
+++ b/Assets/Plugins/Aspid/MVVM/StarterKit/Unity/Runtime/Binders/CanvasGroups/CanvasGroupAlphaBinder.cs
@@ -13,7 +13,6 @@ namespace Aspid.MVVM.StarterKit
     [Serializable]
     public class CanvasGroupAlphaBinder : TargetBinder<CanvasGroup>, INumberBinder
     {
-        [Header("Converter")]
         [SerializeReferenceDropdown]
         [SerializeReference] private Converter? _converter;
 

--- a/Assets/Plugins/Aspid/MVVM/StarterKit/Unity/Runtime/Binders/CanvasGroups/CanvasGroupAlphaSwitcherBinder.cs
+++ b/Assets/Plugins/Aspid/MVVM/StarterKit/Unity/Runtime/Binders/CanvasGroups/CanvasGroupAlphaSwitcherBinder.cs
@@ -13,7 +13,7 @@ namespace Aspid.MVVM.StarterKit
     [Serializable]
     public sealed class CanvasGroupAlphaSwitcherBinder : SwitcherBinder<CanvasGroup, float>
     {
-        [Header("Converter")]
+        [Header("Converters")]
         [SerializeReferenceDropdown]
         [SerializeReference] private Converter? _converter;
         

--- a/Assets/Plugins/Aspid/MVVM/StarterKit/Unity/Runtime/Binders/CanvasGroups/CanvasGroupBlocksRaycastsBinder.cs
+++ b/Assets/Plugins/Aspid/MVVM/StarterKit/Unity/Runtime/Binders/CanvasGroups/CanvasGroupBlocksRaycastsBinder.cs
@@ -8,7 +8,6 @@ namespace Aspid.MVVM.StarterKit
     [Serializable]
     public class CanvasGroupBlocksRaycastsBinder : TargetBinder<CanvasGroup>, IBinder<bool>
     {
-        [Header("Converter")]
         [SerializeField] private bool _isInvert;
 
         public CanvasGroupBlocksRaycastsBinder(CanvasGroup target, BindMode mode)

--- a/Assets/Plugins/Aspid/MVVM/StarterKit/Unity/Runtime/Binders/CanvasGroups/CanvasGroupIgnoreParentGroupsBinder.cs
+++ b/Assets/Plugins/Aspid/MVVM/StarterKit/Unity/Runtime/Binders/CanvasGroups/CanvasGroupIgnoreParentGroupsBinder.cs
@@ -8,7 +8,6 @@ namespace Aspid.MVVM.StarterKit
     [Serializable]
     public class CanvasGroupIgnoreParentGroupsBinder : TargetBinder<CanvasGroup>, IBinder<bool>
     {
-        [Header("Converter")]
         [SerializeField] private bool _isInvert;
 
         public CanvasGroupIgnoreParentGroupsBinder(CanvasGroup target, BindMode mode)

--- a/Assets/Plugins/Aspid/MVVM/StarterKit/Unity/Runtime/Binders/CanvasGroups/CanvasGroupInteractableBinder.cs
+++ b/Assets/Plugins/Aspid/MVVM/StarterKit/Unity/Runtime/Binders/CanvasGroups/CanvasGroupInteractableBinder.cs
@@ -8,7 +8,6 @@ namespace Aspid.MVVM.StarterKit
     [Serializable]
     public class CanvasGroupInteractableBinder : TargetBinder<CanvasGroup>, IBinder<bool>
     {
-        [Header("Converter")]
         [SerializeField] private bool _isInvert;
 
         public CanvasGroupInteractableBinder(CanvasGroup target, BindMode mode)

--- a/Assets/Plugins/Aspid/MVVM/StarterKit/Unity/Runtime/Binders/CanvasGroups/Mono/CanvasGroupAlphaEnumGroupMonoBinder.cs
+++ b/Assets/Plugins/Aspid/MVVM/StarterKit/Unity/Runtime/Binders/CanvasGroups/Mono/CanvasGroupAlphaEnumGroupMonoBinder.cs
@@ -14,7 +14,7 @@ namespace Aspid.MVVM.StarterKit
     [AddComponentContextMenu(typeof(CanvasGroup),"Add CanvasGroup Binder/CanvasGroup Binder - Alpha EnumGroup")]
     public sealed class CanvasGroupAlphaEnumGroupMonoBinder : EnumGroupMonoBinder<CanvasGroup>
     {
-        [Header("Parameters")]
+        [Header("Values")]
         [SerializeField] [Range(0f, 1f)] private float _defaultValue;
         [SerializeField] [Range(0f, 1f)] private float _selectedValue;
         

--- a/Assets/Plugins/Aspid/MVVM/StarterKit/Unity/Runtime/Binders/CanvasGroups/Mono/CanvasGroupAlphaEnumMonoBinder.cs
+++ b/Assets/Plugins/Aspid/MVVM/StarterKit/Unity/Runtime/Binders/CanvasGroups/Mono/CanvasGroupAlphaEnumMonoBinder.cs
@@ -13,7 +13,6 @@ namespace Aspid.MVVM.StarterKit
     [AddComponentContextMenu(typeof(CanvasGroup),"Add CanvasGroup Binder/CanvasGroup Binder - Alpha Enum")]
     public sealed class CanvasGroupAlphaEnumMonoBinder : EnumMonoBinder<CanvasGroup, float>
     {
-        [Header("Converter")]
         [SerializeReferenceDropdown]
         [SerializeReference] private Converter _converter;
         

--- a/Assets/Plugins/Aspid/MVVM/StarterKit/Unity/Runtime/Binders/CanvasGroups/Mono/CanvasGroupAlphaMonoBinder.cs
+++ b/Assets/Plugins/Aspid/MVVM/StarterKit/Unity/Runtime/Binders/CanvasGroups/Mono/CanvasGroupAlphaMonoBinder.cs
@@ -13,7 +13,6 @@ namespace Aspid.MVVM.StarterKit
     [AddComponentContextMenu(typeof(CanvasGroup),"Add CanvasGroup Binder/CanvasGroup Binder - Alpha")]
     public partial class CanvasGroupAlphaMonoBinder : ComponentMonoBinder<CanvasGroup>, INumberBinder
     {
-        [Header("Converter")]
         [SerializeReferenceDropdown]
         [SerializeReference] private Converter _converter;
         

--- a/Assets/Plugins/Aspid/MVVM/StarterKit/Unity/Runtime/Binders/CanvasGroups/Mono/CanvasGroupAlphaSwitcherMonoBinder.cs
+++ b/Assets/Plugins/Aspid/MVVM/StarterKit/Unity/Runtime/Binders/CanvasGroups/Mono/CanvasGroupAlphaSwitcherMonoBinder.cs
@@ -13,7 +13,7 @@ namespace Aspid.MVVM.StarterKit
     [AddComponentContextMenu(typeof(CanvasGroup),"Add CanvasGroup Binder/CanvasGroup Binder - Alpha Switcher")]
     public sealed class CanvasGroupAlphaSwitcherMonoBinder : SwitcherMonoBinder<CanvasGroup, float>
     {
-        [Header("Converter")]
+        [Header("Converters")]
         [SerializeReferenceDropdown]
         [SerializeReference] private Converter _converter;
         

--- a/Assets/Plugins/Aspid/MVVM/StarterKit/Unity/Runtime/Binders/CanvasGroups/Mono/CanvasGroupBlocksRaycastsEnumGroupMonoBinder.cs
+++ b/Assets/Plugins/Aspid/MVVM/StarterKit/Unity/Runtime/Binders/CanvasGroups/Mono/CanvasGroupBlocksRaycastsEnumGroupMonoBinder.cs
@@ -8,7 +8,7 @@ namespace Aspid.MVVM.StarterKit
     [AddComponentContextMenu(typeof(CanvasGroup),"Add CanvasGroup Binder/CanvasGroup Binder - BlocksRaycasts EnumGroup")]
     public sealed class CanvasGroupBlocksRaycastsEnumGroupMonoBinder : EnumGroupMonoBinder<CanvasGroup>
     {
-        [Header("Parameters")]
+        [Header("Values")]
         [SerializeField] private bool _defaultValue;
         [SerializeField] private bool _selectedValue;
         

--- a/Assets/Plugins/Aspid/MVVM/StarterKit/Unity/Runtime/Binders/CanvasGroups/Mono/CanvasGroupBlocksRaycastsMonoBinder.cs
+++ b/Assets/Plugins/Aspid/MVVM/StarterKit/Unity/Runtime/Binders/CanvasGroups/Mono/CanvasGroupBlocksRaycastsMonoBinder.cs
@@ -8,7 +8,6 @@ namespace Aspid.MVVM.StarterKit
     [AddComponentContextMenu(typeof(CanvasGroup),"Add CanvasGroup Binder/CanvasGroup Binder - BlocksRaycasts")]
     public partial class CanvasGroupBlocksRaycastsMonoBinder : ComponentMonoBinder<CanvasGroup>, IBinder<bool>
     {
-        [Header("Converter")]
         [SerializeField] private bool _isInvert;
         
         [BinderLog]

--- a/Assets/Plugins/Aspid/MVVM/StarterKit/Unity/Runtime/Binders/CanvasGroups/Mono/CanvasGroupIgnoreParentGroupsEnumGroupMonoBinder.cs
+++ b/Assets/Plugins/Aspid/MVVM/StarterKit/Unity/Runtime/Binders/CanvasGroups/Mono/CanvasGroupIgnoreParentGroupsEnumGroupMonoBinder.cs
@@ -8,7 +8,7 @@ namespace Aspid.MVVM.StarterKit
     [AddComponentContextMenu(typeof(CanvasGroup),"Add CanvasGroup Binder/CanvasGroup Binder - IgnoreParentGroups EnumGroup")]
     public sealed class CanvasGroupIgnoreParentGroupsEnumGroupMonoBinder : EnumGroupMonoBinder<CanvasGroup>
     {
-        [Header("Parameters")]
+        [Header("Values")]
         [SerializeField] private bool _defaultValue;
         [SerializeField] private bool _selectedValue;
         

--- a/Assets/Plugins/Aspid/MVVM/StarterKit/Unity/Runtime/Binders/CanvasGroups/Mono/CanvasGroupIgnoreParentGroupsMonoBinder.cs
+++ b/Assets/Plugins/Aspid/MVVM/StarterKit/Unity/Runtime/Binders/CanvasGroups/Mono/CanvasGroupIgnoreParentGroupsMonoBinder.cs
@@ -8,7 +8,6 @@ namespace Aspid.MVVM.StarterKit
     [AddComponentContextMenu(typeof(CanvasGroup),"Add CanvasGroup Binder/CanvasGroup Binder - IgnoreParentGroups")]
     public partial class CanvasGroupIgnoreParentGroupsMonoBinder : ComponentMonoBinder<CanvasGroup>, IBinder<bool>
     {
-        [Header("Converter")]
         [SerializeField] private bool _isInvert;
         
         [BinderLog]

--- a/Assets/Plugins/Aspid/MVVM/StarterKit/Unity/Runtime/Binders/CanvasGroups/Mono/CanvasGroupInteractableEnumGroupMonoBinder.cs
+++ b/Assets/Plugins/Aspid/MVVM/StarterKit/Unity/Runtime/Binders/CanvasGroups/Mono/CanvasGroupInteractableEnumGroupMonoBinder.cs
@@ -8,7 +8,7 @@ namespace Aspid.MVVM.StarterKit
     [AddComponentContextMenu(typeof(CanvasGroup),"Add CanvasGroup Binder/CanvasGroup Binder - Interactable EnumGroup")]
     public sealed class CanvasGroupInteractableEnumGroupMonoBinder : EnumGroupMonoBinder<CanvasGroup>
     {
-        [Header("Parameters")]
+        [Header("Values")]
         [SerializeField] private bool _defaultValue;
         [SerializeField] private bool _selectedValue;
         

--- a/Assets/Plugins/Aspid/MVVM/StarterKit/Unity/Runtime/Binders/CanvasGroups/Mono/CanvasGroupInteractableMonoBinder.cs
+++ b/Assets/Plugins/Aspid/MVVM/StarterKit/Unity/Runtime/Binders/CanvasGroups/Mono/CanvasGroupInteractableMonoBinder.cs
@@ -8,7 +8,6 @@ namespace Aspid.MVVM.StarterKit
     [AddComponentContextMenu(typeof(CanvasGroup),"Add CanvasGroup Binder/CanvasGroup Binder - Interactable")]
     public partial class CanvasGroupInteractableMonoBinder : ComponentMonoBinder<CanvasGroup>, IBinder<bool>
     {
-        [Header("Converter")]
         [SerializeField] private bool _isInvert;
         
         [BinderLog]

--- a/Assets/Plugins/Aspid/MVVM/StarterKit/Unity/Runtime/Binders/Casters/Mono/AnyToStringCasterMonoBinder.cs
+++ b/Assets/Plugins/Aspid/MVVM/StarterKit/Unity/Runtime/Binders/Casters/Mono/AnyToStringCasterMonoBinder.cs
@@ -14,7 +14,6 @@ namespace Aspid.MVVM.StarterKit
     [AddComponentContextMenu(typeof(Component),"Add General Binder/Casters/Any To String Caster Binder")]
     public sealed class AnyToStringCasterMonoBinder : MonoBinder, IAnyBinder 
     {
-        [Header("Converter")]
         [SerializeReferenceDropdown]
         [SerializeReference] private Converter _converter = new ObjectToStringConverter();
         

--- a/Assets/Plugins/Aspid/MVVM/StarterKit/Unity/Runtime/Binders/Casters/Mono/GenericToStringCasterMonoBinder.cs
+++ b/Assets/Plugins/Aspid/MVVM/StarterKit/Unity/Runtime/Binders/Casters/Mono/GenericToStringCasterMonoBinder.cs
@@ -8,7 +8,6 @@ namespace Aspid.MVVM.StarterKit
 #if UNITY_2023_1_OR_NEWER
     public abstract partial class GenericToStringCasterMonoBinder<T> : MonoBinder, IBinder<T>
     {
-        [Header("Converter")]
         [SerializeReferenceDropdown]
         [SerializeReference] private IConverter<T, string> _converter;
         

--- a/Assets/Plugins/Aspid/MVVM/StarterKit/Unity/Runtime/Binders/Casters/Mono/StringToBoolCasterMonoBinder.cs
+++ b/Assets/Plugins/Aspid/MVVM/StarterKit/Unity/Runtime/Binders/Casters/Mono/StringToBoolCasterMonoBinder.cs
@@ -14,7 +14,6 @@ namespace Aspid.MVVM.StarterKit
     [AddComponentContextMenu(typeof(Component),"Add General Binder/Casters/String To Bool Caster Binder")]
     public sealed partial class StringToBoolCasterMonoBinder : MonoBinder, IBinder<string>
     {
-        [Header("Converter")]
         [SerializeReferenceDropdown]
         [SerializeReference] private Converter _converter = new StringEmptyToBoolConverter();
         

--- a/Assets/Plugins/Aspid/MVVM/StarterKit/Unity/Runtime/Binders/Casters/Mono/TimeSpanToStringCasterMonoBinder.cs
+++ b/Assets/Plugins/Aspid/MVVM/StarterKit/Unity/Runtime/Binders/Casters/Mono/TimeSpanToStringCasterMonoBinder.cs
@@ -12,7 +12,6 @@ namespace Aspid.MVVM.StarterKit
 #else
     public sealed class TimeSpanToStringCasterMonoBinder : GenericToStringCasterMonoBinder<TimeSpan>
     {
-        [Header("Converter")]
         [SerializeReferenceDropdown]
         [SerializeReference] private IConverterTimeSpanToString _converter = new TimeSpanToStringConverter();
 

--- a/Assets/Plugins/Aspid/MVVM/StarterKit/Unity/Runtime/Binders/Casters/Mono/Vector2ToVector3CasterMonoBinder.cs
+++ b/Assets/Plugins/Aspid/MVVM/StarterKit/Unity/Runtime/Binders/Casters/Mono/Vector2ToVector3CasterMonoBinder.cs
@@ -14,7 +14,6 @@ namespace Aspid.MVVM.StarterKit
     [AddComponentContextMenu(typeof(Component),"Add General Binder/Casters/Vector2 To Vector3 Caster Binder")]
     public sealed partial class Vector2ToVector3CasterMonoBinder : MonoBinder, IBinder<Vector2>
     {
-        [Header("Converter")]
         [SerializeReferenceDropdown]
         [SerializeReference] private Converter _converter = new Vector2ToVector3Converter();
         

--- a/Assets/Plugins/Aspid/MVVM/StarterKit/Unity/Runtime/Binders/Casters/Mono/Vector3ToVector2CasterMonoBinder.cs
+++ b/Assets/Plugins/Aspid/MVVM/StarterKit/Unity/Runtime/Binders/Casters/Mono/Vector3ToVector2CasterMonoBinder.cs
@@ -14,7 +14,6 @@ namespace Aspid.MVVM.StarterKit
     [AddComponentContextMenu(typeof(Component),"Add General Binder/Casters/Vector3 To Vector2 Caster Binder")]
     public sealed partial class Vector3ToVector2CasterMonoBinder : MonoBinder, IBinder<Vector3>
     {
-        [Header("Converter")]
         [SerializeReferenceDropdown]
         [SerializeReference] private Converter _converter = new Vector3ToVector2Converter();
         

--- a/Assets/Plugins/Aspid/MVVM/StarterKit/Unity/Runtime/Binders/Colliders/BoxColliders/BoxColliderCenterBinder.cs
+++ b/Assets/Plugins/Aspid/MVVM/StarterKit/Unity/Runtime/Binders/Colliders/BoxColliders/BoxColliderCenterBinder.cs
@@ -9,7 +9,6 @@ namespace Aspid.MVVM.StarterKit
     public class BoxColliderCenterBinder : TargetBinder<BoxCollider>, IVectorBinder, INumberBinder
     {
         // ReSharper disable once MemberInitializerValueIgnored
-        [Header("Converter")]
         [SerializeField] private Vector3CombineConverter? _converter = Vector3CombineConverter.Default;
         
         public BoxColliderCenterBinder(BoxCollider target, BindMode mode)

--- a/Assets/Plugins/Aspid/MVVM/StarterKit/Unity/Runtime/Binders/Colliders/BoxColliders/BoxColliderCenterSwitcherBinder.cs
+++ b/Assets/Plugins/Aspid/MVVM/StarterKit/Unity/Runtime/Binders/Colliders/BoxColliders/BoxColliderCenterSwitcherBinder.cs
@@ -9,7 +9,6 @@ namespace Aspid.MVVM.StarterKit
     public sealed class BoxColliderCenterSwitcherBinder : SwitcherBinder<BoxCollider, Vector3>
     {
         // ReSharper disable once MemberInitializerValueIgnored
-        [Header("Converter")]
         [SerializeField] private Vector3CombineConverter? _converter = Vector3CombineConverter.Default;
         
         public BoxColliderCenterSwitcherBinder(

--- a/Assets/Plugins/Aspid/MVVM/StarterKit/Unity/Runtime/Binders/Colliders/BoxColliders/BoxColliderSizeBinder.cs
+++ b/Assets/Plugins/Aspid/MVVM/StarterKit/Unity/Runtime/Binders/Colliders/BoxColliders/BoxColliderSizeBinder.cs
@@ -9,7 +9,6 @@ namespace Aspid.MVVM.StarterKit
     public class BoxColliderSizeBinder : TargetBinder<BoxCollider>, IVectorBinder, INumberBinder
     {
         // ReSharper disable once MemberInitializerValueIgnored
-        [Header("Converter")]
         [SerializeField] private Vector3CombineConverter? _converter = Vector3CombineConverter.Default;
 
         public BoxColliderSizeBinder(BoxCollider target, BindMode mode)

--- a/Assets/Plugins/Aspid/MVVM/StarterKit/Unity/Runtime/Binders/Colliders/BoxColliders/BoxColliderSizeSwitcherBinder.cs
+++ b/Assets/Plugins/Aspid/MVVM/StarterKit/Unity/Runtime/Binders/Colliders/BoxColliders/BoxColliderSizeSwitcherBinder.cs
@@ -9,7 +9,7 @@ namespace Aspid.MVVM.StarterKit
     public sealed class BoxColliderSizeSwitcherBinder : SwitcherBinder<BoxCollider, Vector3>
     {
         // ReSharper disable once MemberInitializerValueIgnored
-        [Header("Converter")]
+        [Header("Converters")]
         [SerializeField] private Vector3CombineConverter? _converter = Vector3CombineConverter.Default;
         
         public BoxColliderSizeSwitcherBinder(

--- a/Assets/Plugins/Aspid/MVVM/StarterKit/Unity/Runtime/Binders/Colliders/BoxColliders/Mono/BoxColliderCenterEnumGroupMonoBinder.cs
+++ b/Assets/Plugins/Aspid/MVVM/StarterKit/Unity/Runtime/Binders/Colliders/BoxColliders/Mono/BoxColliderCenterEnumGroupMonoBinder.cs
@@ -8,7 +8,7 @@ namespace Aspid.MVVM.StarterKit
     [AddComponentContextMenu(typeof(BoxCollider),"Add BoxCollider Binder/BoxCollider Binder - Center EnumGroup")]
     public sealed class BoxColliderCenterEnumGroupMonoBinder : EnumGroupMonoBinder<BoxCollider>
     {
-        [Header("Parameters")]
+        [Header("Values")]
         [SerializeField] private Vector3 _defaultValue;
         [SerializeField] private Vector3 _selectedValue;
         

--- a/Assets/Plugins/Aspid/MVVM/StarterKit/Unity/Runtime/Binders/Colliders/BoxColliders/Mono/BoxColliderCenterEnumMonoBinder.cs
+++ b/Assets/Plugins/Aspid/MVVM/StarterKit/Unity/Runtime/Binders/Colliders/BoxColliders/Mono/BoxColliderCenterEnumMonoBinder.cs
@@ -8,7 +8,6 @@ namespace Aspid.MVVM.StarterKit
     [AddComponentContextMenu(typeof(BoxCollider),"Add BoxCollider Binder/BoxCollider Binder - Center Enum")]
     public sealed class BoxColliderCenterEnumMonoBinder : EnumMonoBinder<BoxCollider, Vector3>
     {
-        [Header("Converter")]
         [SerializeField] private Vector3CombineConverter _converter = Vector3CombineConverter.Default;
 
         protected override void SetValue(Vector3 value) =>

--- a/Assets/Plugins/Aspid/MVVM/StarterKit/Unity/Runtime/Binders/Colliders/BoxColliders/Mono/BoxColliderCenterMonoBinder.cs
+++ b/Assets/Plugins/Aspid/MVVM/StarterKit/Unity/Runtime/Binders/Colliders/BoxColliders/Mono/BoxColliderCenterMonoBinder.cs
@@ -8,7 +8,6 @@ namespace Aspid.MVVM.StarterKit
     [AddComponentContextMenu(typeof(BoxCollider),"Add BoxCollider Binder/BoxCollider Binder - Center")]
     public partial class BoxColliderCenterMonoBinder : ComponentMonoBinder<BoxCollider>, IVectorBinder, INumberBinder
     {
-        [Header("Converter")]
         [SerializeField] private Vector3CombineConverter _converter = Vector3CombineConverter.Default;
 
         [BinderLog]

--- a/Assets/Plugins/Aspid/MVVM/StarterKit/Unity/Runtime/Binders/Colliders/BoxColliders/Mono/BoxColliderCenterSwitcherMonoBinder.cs
+++ b/Assets/Plugins/Aspid/MVVM/StarterKit/Unity/Runtime/Binders/Colliders/BoxColliders/Mono/BoxColliderCenterSwitcherMonoBinder.cs
@@ -8,7 +8,7 @@ namespace Aspid.MVVM.StarterKit
     [AddComponentContextMenu(typeof(BoxCollider),"Add BoxCollider Binder/BoxCollider Binder - Center Switcher")]
     public sealed class BoxColliderCenterSwitcherMonoBinder : SwitcherMonoBinder<BoxCollider, Vector3>
     {
-        [Header("Converter")]
+        [Header("Converters")]
         [SerializeField] private Vector3CombineConverter _converter = Vector3CombineConverter.Default;
         
         protected override void SetValue(Vector3 value) =>

--- a/Assets/Plugins/Aspid/MVVM/StarterKit/Unity/Runtime/Binders/Colliders/BoxColliders/Mono/BoxColliderSizeEnumGroupMonoBinder.cs
+++ b/Assets/Plugins/Aspid/MVVM/StarterKit/Unity/Runtime/Binders/Colliders/BoxColliders/Mono/BoxColliderSizeEnumGroupMonoBinder.cs
@@ -8,7 +8,7 @@ namespace Aspid.MVVM.StarterKit
     [AddComponentContextMenu(typeof(BoxCollider),"Add BoxCollider Binder/BoxCollider Binder - Size EnumGroup")]
     public sealed class BoxColliderSizeEnumGroupMonoBinder : EnumGroupMonoBinder<BoxCollider>
     {
-        [Header("Parameters")]
+        [Header("Values")]
         [SerializeField] private Vector3 _defaultValue;
         [SerializeField] private Vector3 _selectedValue;
         

--- a/Assets/Plugins/Aspid/MVVM/StarterKit/Unity/Runtime/Binders/Colliders/BoxColliders/Mono/BoxColliderSizeEnumMonoBinder.cs
+++ b/Assets/Plugins/Aspid/MVVM/StarterKit/Unity/Runtime/Binders/Colliders/BoxColliders/Mono/BoxColliderSizeEnumMonoBinder.cs
@@ -8,7 +8,6 @@ namespace Aspid.MVVM.StarterKit
     [AddComponentContextMenu(typeof(BoxCollider),"Add BoxCollider Binder/BoxCollider Binder - Size Enum")]
     public sealed class BoxColliderSizeEnumMonoBinder : EnumMonoBinder<BoxCollider, Vector3>
     {
-        [Header("Converter")]
         [SerializeField] private Vector3CombineConverter _converter = Vector3CombineConverter.Default;
         
         protected override void SetValue(Vector3 value) =>

--- a/Assets/Plugins/Aspid/MVVM/StarterKit/Unity/Runtime/Binders/Colliders/BoxColliders/Mono/BoxColliderSizeMonoBinder.cs
+++ b/Assets/Plugins/Aspid/MVVM/StarterKit/Unity/Runtime/Binders/Colliders/BoxColliders/Mono/BoxColliderSizeMonoBinder.cs
@@ -8,7 +8,6 @@ namespace Aspid.MVVM.StarterKit
     [AddComponentContextMenu(typeof(BoxCollider),"Add BoxCollider Binder/BoxCollider Binder - Size")]
     public partial class BoxColliderSizeMonoBinder : ComponentMonoBinder<BoxCollider>, IVectorBinder, INumberBinder
     {
-        [Header("Converter")]
         [SerializeField] private Vector3CombineConverter _converter = Vector3CombineConverter.Default;
         
         [BinderLog]

--- a/Assets/Plugins/Aspid/MVVM/StarterKit/Unity/Runtime/Binders/Colliders/BoxColliders/Mono/BoxColliderSizeSwitcherMonoBinder.cs
+++ b/Assets/Plugins/Aspid/MVVM/StarterKit/Unity/Runtime/Binders/Colliders/BoxColliders/Mono/BoxColliderSizeSwitcherMonoBinder.cs
@@ -8,7 +8,7 @@ namespace Aspid.MVVM.StarterKit
     [AddComponentContextMenu(typeof(BoxCollider),"Add BoxCollider Binder/BoxCollider Binder - Size Switcher")]
     public sealed class BoxColliderSizeSwitcherMonoBinder : SwitcherMonoBinder<BoxCollider, Vector3>
     {
-        [Header("Converter")]
+        [Header("Converters")]
         [SerializeField] private Vector3CombineConverter _converter = Vector3CombineConverter.Default;
         
         protected override void SetValue(Vector3 value) =>

--- a/Assets/Plugins/Aspid/MVVM/StarterKit/Unity/Runtime/Binders/Colliders/CapsuleColliders/CapsuleColliderCenterBinder.cs
+++ b/Assets/Plugins/Aspid/MVVM/StarterKit/Unity/Runtime/Binders/Colliders/CapsuleColliders/CapsuleColliderCenterBinder.cs
@@ -9,7 +9,6 @@ namespace Aspid.MVVM.StarterKit
     public class CapsuleColliderCenterBinder : TargetBinder<CapsuleCollider>, IVectorBinder, INumberBinder
     {
         // ReSharper disable once MemberInitializerValueIgnored
-        [Header("Converter")]
         [SerializeField] private Vector3CombineConverter? _converter = Vector3CombineConverter.Default;
 
         public CapsuleColliderCenterBinder(CapsuleCollider target, BindMode mode)

--- a/Assets/Plugins/Aspid/MVVM/StarterKit/Unity/Runtime/Binders/Colliders/CapsuleColliders/CapsuleColliderCenterSwitcherBinder.cs
+++ b/Assets/Plugins/Aspid/MVVM/StarterKit/Unity/Runtime/Binders/Colliders/CapsuleColliders/CapsuleColliderCenterSwitcherBinder.cs
@@ -9,7 +9,7 @@ namespace Aspid.MVVM.StarterKit
     public sealed class CapsuleColliderCenterSwitcherBinder : SwitcherBinder<CapsuleCollider, Vector3>
     {
         // ReSharper disable once MemberInitializerValueIgnored
-        [Header("Converter")]
+        [Header("Converters")]
         [SerializeField] private Vector3CombineConverter? _converter = Vector3CombineConverter.Default;
         
         public CapsuleColliderCenterSwitcherBinder(

--- a/Assets/Plugins/Aspid/MVVM/StarterKit/Unity/Runtime/Binders/Colliders/CapsuleColliders/CapsuleColliderRadiusBinder.cs
+++ b/Assets/Plugins/Aspid/MVVM/StarterKit/Unity/Runtime/Binders/Colliders/CapsuleColliders/CapsuleColliderRadiusBinder.cs
@@ -13,7 +13,6 @@ namespace Aspid.MVVM.StarterKit
     [Serializable]
     public class CapsuleColliderRadiusBinder : TargetBinder<CapsuleCollider>, INumberBinder
     {
-        [Header("Converter")]
         [SerializeReferenceDropdown]
         [SerializeReference] private Converter? _converter;
         

--- a/Assets/Plugins/Aspid/MVVM/StarterKit/Unity/Runtime/Binders/Colliders/CapsuleColliders/CapsuleColliderRadiusSwitcherBinder.cs
+++ b/Assets/Plugins/Aspid/MVVM/StarterKit/Unity/Runtime/Binders/Colliders/CapsuleColliders/CapsuleColliderRadiusSwitcherBinder.cs
@@ -13,7 +13,7 @@ namespace Aspid.MVVM.StarterKit
     [Serializable]
     public sealed class CapsuleColliderRadiusSwitcherBinder : SwitcherBinder<CapsuleCollider, float>
     {
-        [Header("Converter")]
+        [Header("Converters")]
         [SerializeReferenceDropdown]
         [SerializeReference] private Converter? _converter;
 

--- a/Assets/Plugins/Aspid/MVVM/StarterKit/Unity/Runtime/Binders/Colliders/CapsuleColliders/Mono/CapsuleColliderCenterEnumGroupMonoBinder.cs
+++ b/Assets/Plugins/Aspid/MVVM/StarterKit/Unity/Runtime/Binders/Colliders/CapsuleColliders/Mono/CapsuleColliderCenterEnumGroupMonoBinder.cs
@@ -8,7 +8,7 @@ namespace Aspid.MVVM.StarterKit
     [AddComponentContextMenu(typeof(CapsuleCollider),"Add CapsuleCollider Binder/CapsuleCollider Binder - Center EnumGroup")]
     public sealed class CapsuleColliderCenterEnumGroupMonoBinder : EnumGroupMonoBinder<CapsuleCollider>
     {
-        [Header("Parameters")]
+        [Header("Values")]
         [SerializeField] private Vector3 _defaultValue;
         [SerializeField] private Vector3 _selectedValue;
         

--- a/Assets/Plugins/Aspid/MVVM/StarterKit/Unity/Runtime/Binders/Colliders/CapsuleColliders/Mono/CapsuleColliderCenterEnumMonoBinder.cs
+++ b/Assets/Plugins/Aspid/MVVM/StarterKit/Unity/Runtime/Binders/Colliders/CapsuleColliders/Mono/CapsuleColliderCenterEnumMonoBinder.cs
@@ -8,7 +8,6 @@ namespace Aspid.MVVM.StarterKit
     [AddComponentContextMenu(typeof(CapsuleCollider),"Add CapsuleCollider Binder/CapsuleCollider Binder - Center Enum")]
     public sealed class CapsuleColliderCenterEnumMonoBinder : EnumMonoBinder<CapsuleCollider, Vector3>
     {
-        [Header("Converter")]
         [SerializeField] private Vector3CombineConverter _converter = Vector3CombineConverter.Default;
         
         protected override void SetValue(Vector3 value) =>

--- a/Assets/Plugins/Aspid/MVVM/StarterKit/Unity/Runtime/Binders/Colliders/CapsuleColliders/Mono/CapsuleColliderCenterMonoBinder.cs
+++ b/Assets/Plugins/Aspid/MVVM/StarterKit/Unity/Runtime/Binders/Colliders/CapsuleColliders/Mono/CapsuleColliderCenterMonoBinder.cs
@@ -8,7 +8,6 @@ namespace Aspid.MVVM.StarterKit
     [AddComponentContextMenu(typeof(CapsuleCollider),"Add CapsuleCollider Binder/CapsuleCollider Binder - Center")]
     public partial class CapsuleColliderCenterMonoBinder : ComponentMonoBinder<CapsuleCollider>, IVectorBinder, INumberBinder
     {
-        [Header("Converter")]
         [SerializeField] private Vector3CombineConverter _converter = Vector3CombineConverter.Default;
         
         [BinderLog]

--- a/Assets/Plugins/Aspid/MVVM/StarterKit/Unity/Runtime/Binders/Colliders/CapsuleColliders/Mono/CapsuleColliderCenterSwitcherMonoBinder.cs
+++ b/Assets/Plugins/Aspid/MVVM/StarterKit/Unity/Runtime/Binders/Colliders/CapsuleColliders/Mono/CapsuleColliderCenterSwitcherMonoBinder.cs
@@ -8,7 +8,7 @@ namespace Aspid.MVVM.StarterKit
     [AddComponentContextMenu(typeof(CapsuleCollider),"Add CapsuleCollider Binder/CapsuleCollider Binder - Center Switcher")]
     public sealed class CapsuleColliderCenterSwitcherMonoBinder : SwitcherMonoBinder<CapsuleCollider, Vector3>
     {
-        [Header("Converter")]
+        [Header("Converters")]
         [SerializeField] private Vector3CombineConverter _converter = Vector3CombineConverter.Default;
         
         protected override void SetValue(Vector3 value) =>

--- a/Assets/Plugins/Aspid/MVVM/StarterKit/Unity/Runtime/Binders/Colliders/CapsuleColliders/Mono/CapsuleColliderRadiusEnumGroupMonoBinder.cs
+++ b/Assets/Plugins/Aspid/MVVM/StarterKit/Unity/Runtime/Binders/Colliders/CapsuleColliders/Mono/CapsuleColliderRadiusEnumGroupMonoBinder.cs
@@ -13,7 +13,7 @@ namespace Aspid.MVVM.StarterKit
     [AddComponentContextMenu(typeof(CapsuleCollider),"Add CapsuleCollider Binder/CapsuleCollider Binder - Radius EnumGroup")]
     public sealed class CapsuleColliderRadiusEnumGroupMonoBinder : EnumGroupMonoBinder<CapsuleCollider>
     {
-        [Header("Parameters")]
+        [Header("Values")]
         [SerializeField] private float _defaultValue;
         [SerializeField] private float _selectedValue;
         

--- a/Assets/Plugins/Aspid/MVVM/StarterKit/Unity/Runtime/Binders/Colliders/CapsuleColliders/Mono/CapsuleColliderRadiusEnumMonoBinder.cs
+++ b/Assets/Plugins/Aspid/MVVM/StarterKit/Unity/Runtime/Binders/Colliders/CapsuleColliders/Mono/CapsuleColliderRadiusEnumMonoBinder.cs
@@ -13,7 +13,6 @@ namespace Aspid.MVVM.StarterKit
     [AddComponentContextMenu(typeof(CapsuleCollider),"Add CapsuleCollider Binder/CapsuleCollider Binder - Radius Enum")]
     public sealed class CapsuleColliderRadiusEnumMonoBinder : EnumMonoBinder<CapsuleCollider, float>
     {
-        [Header("Converter")]
         [SerializeReferenceDropdown]
         [SerializeReference] private Converter _converter;
 

--- a/Assets/Plugins/Aspid/MVVM/StarterKit/Unity/Runtime/Binders/Colliders/CapsuleColliders/Mono/CapsuleColliderRadiusMonoBinder.cs
+++ b/Assets/Plugins/Aspid/MVVM/StarterKit/Unity/Runtime/Binders/Colliders/CapsuleColliders/Mono/CapsuleColliderRadiusMonoBinder.cs
@@ -13,7 +13,6 @@ namespace Aspid.MVVM.StarterKit
     [AddComponentContextMenu(typeof(CapsuleCollider),"Add CapsuleCollider Binder/CapsuleCollider Binder - Radius")]
     public partial class CapsuleColliderRadiusMonoBinder : ComponentMonoBinder<CapsuleCollider>, INumberBinder
     {
-        [Header("Converter")]
         [SerializeReferenceDropdown]
         [SerializeReference] private Converter _converter;
 

--- a/Assets/Plugins/Aspid/MVVM/StarterKit/Unity/Runtime/Binders/Colliders/CapsuleColliders/Mono/CapsuleColliderRadiusSwitcherMonoBinder.cs
+++ b/Assets/Plugins/Aspid/MVVM/StarterKit/Unity/Runtime/Binders/Colliders/CapsuleColliders/Mono/CapsuleColliderRadiusSwitcherMonoBinder.cs
@@ -13,7 +13,7 @@ namespace Aspid.MVVM.StarterKit
     [AddComponentContextMenu(typeof(CapsuleCollider),"Add CapsuleCollider Binder/CapsuleCollider Binder - Radius Switcher")]
     public sealed class CapsuleColliderRadiusSwitcherMonoBinder : SwitcherMonoBinder<CapsuleCollider, float>
     {
-        [Header("Converter")]
+        [Header("Converters")]
         [SerializeReferenceDropdown]
         [SerializeReference] private Converter _converter;
         

--- a/Assets/Plugins/Aspid/MVVM/StarterKit/Unity/Runtime/Binders/Colliders/ColliderEnabledBinder.cs
+++ b/Assets/Plugins/Aspid/MVVM/StarterKit/Unity/Runtime/Binders/Colliders/ColliderEnabledBinder.cs
@@ -8,7 +8,6 @@ namespace Aspid.MVVM.StarterKit
     [Serializable]
     public class ColliderEnabledBinder : TargetBinder<Collider>, IBinder<bool>
     {
-        [Header("Converter")]
         [SerializeField] private bool _isInvert;
 
         public ColliderEnabledBinder(Collider target, BindMode mode)

--- a/Assets/Plugins/Aspid/MVVM/StarterKit/Unity/Runtime/Binders/Colliders/ColliderIsTriggerBinder.cs
+++ b/Assets/Plugins/Aspid/MVVM/StarterKit/Unity/Runtime/Binders/Colliders/ColliderIsTriggerBinder.cs
@@ -8,7 +8,6 @@ namespace Aspid.MVVM.StarterKit
     [Serializable]
     public class ColliderIsTriggerBinder : TargetBinder<Collider>, IBinder<bool>
     {
-        [Header("Converter")]
         [SerializeField] private bool _isInvert;
 
         public ColliderIsTriggerBinder(Collider target, BindMode mode)

--- a/Assets/Plugins/Aspid/MVVM/StarterKit/Unity/Runtime/Binders/Colliders/ColliderMaterialBinder.cs
+++ b/Assets/Plugins/Aspid/MVVM/StarterKit/Unity/Runtime/Binders/Colliders/ColliderMaterialBinder.cs
@@ -15,7 +15,6 @@ namespace Aspid.MVVM.StarterKit
     [Serializable]
     public class ColliderMaterialBinder : TargetBinder<Collider>, IBinder<PhysicsMaterial>
     {
-        [Header("Converter")]
         [SerializeReferenceDropdown] 
         [SerializeReference] private Converter? _converter;
         

--- a/Assets/Plugins/Aspid/MVVM/StarterKit/Unity/Runtime/Binders/Colliders/ColliderMaterialSwitcherBinder.cs
+++ b/Assets/Plugins/Aspid/MVVM/StarterKit/Unity/Runtime/Binders/Colliders/ColliderMaterialSwitcherBinder.cs
@@ -15,7 +15,7 @@ namespace Aspid.MVVM.StarterKit
     [Serializable]
     public sealed class ColliderMaterialSwitcherBinder : SwitcherBinder<Collider, PhysicsMaterial>
     {
-        [Header("Converter")]
+        [Header("Converters")]
         [SerializeReferenceDropdown]
         [SerializeReference] private Converter? _converter;
         

--- a/Assets/Plugins/Aspid/MVVM/StarterKit/Unity/Runtime/Binders/Colliders/ColliderProvidesContactsBinder.cs
+++ b/Assets/Plugins/Aspid/MVVM/StarterKit/Unity/Runtime/Binders/Colliders/ColliderProvidesContactsBinder.cs
@@ -8,7 +8,6 @@ namespace Aspid.MVVM.StarterKit
     [Serializable]
     public class ColliderProvidesContactsBinder : TargetBinder<Collider>, IBinder<bool>
     {
-        [Header("Converter")]
         [SerializeField] private bool _isInvert;
 
         public ColliderProvidesContactsBinder(Collider target, BindMode mode)

--- a/Assets/Plugins/Aspid/MVVM/StarterKit/Unity/Runtime/Binders/Colliders/MeshColliders/MeshColliderConvexBinder.cs
+++ b/Assets/Plugins/Aspid/MVVM/StarterKit/Unity/Runtime/Binders/Colliders/MeshColliders/MeshColliderConvexBinder.cs
@@ -8,7 +8,6 @@ namespace Aspid.MVVM.StarterKit
     [Serializable]
     public class MeshColliderConvexBinder : TargetBinder<MeshCollider>, IBinder<bool>
     {
-        [Header("Converter")]
         [SerializeField] private bool _isInvert;
 
         public MeshColliderConvexBinder(MeshCollider target, BindMode bindMode)

--- a/Assets/Plugins/Aspid/MVVM/StarterKit/Unity/Runtime/Binders/Colliders/MeshColliders/MeshColliderMeshBinder.cs
+++ b/Assets/Plugins/Aspid/MVVM/StarterKit/Unity/Runtime/Binders/Colliders/MeshColliders/MeshColliderMeshBinder.cs
@@ -13,7 +13,6 @@ namespace Aspid.MVVM.StarterKit
     [Serializable]
     public class MeshColliderMeshBinder : TargetBinder<MeshCollider>, IBinder<Mesh>
     {
-        [Header("Converter")]
         [SerializeReferenceDropdown]
         [SerializeReference] private Converter? _converter;
         

--- a/Assets/Plugins/Aspid/MVVM/StarterKit/Unity/Runtime/Binders/Colliders/MeshColliders/MeshColliderMeshSwitcherBinder.cs
+++ b/Assets/Plugins/Aspid/MVVM/StarterKit/Unity/Runtime/Binders/Colliders/MeshColliders/MeshColliderMeshSwitcherBinder.cs
@@ -13,7 +13,7 @@ namespace Aspid.MVVM.StarterKit
     [Serializable]
     public sealed class MeshColliderMeshSwitcherBinder : SwitcherBinder<MeshCollider, Mesh>
     {
-        [Header("Converter")]
+        [Header("Converters")]
         [SerializeReferenceDropdown]
         [SerializeReference] private Converter? _converter;
         

--- a/Assets/Plugins/Aspid/MVVM/StarterKit/Unity/Runtime/Binders/Colliders/MeshColliders/Mono/MeshColliderConvexEnumGroupMonoBinder.cs
+++ b/Assets/Plugins/Aspid/MVVM/StarterKit/Unity/Runtime/Binders/Colliders/MeshColliders/Mono/MeshColliderConvexEnumGroupMonoBinder.cs
@@ -8,7 +8,7 @@ namespace Aspid.MVVM.StarterKit
     [AddComponentContextMenu(typeof(MeshCollider),"Add MeshCollider Binder/MeshCollider Binder - Convex EnumGroup")]
     public sealed class MeshColliderConvexEnumGroupMonoBinder : EnumGroupMonoBinder<MeshCollider>
     {
-        [Header("Parameters")]
+        [Header("Values")]
         [SerializeField] private bool _defaultValue;
         [SerializeField] private bool _selectedValue;
 

--- a/Assets/Plugins/Aspid/MVVM/StarterKit/Unity/Runtime/Binders/Colliders/MeshColliders/Mono/MeshColliderConvexMonoBinder.cs
+++ b/Assets/Plugins/Aspid/MVVM/StarterKit/Unity/Runtime/Binders/Colliders/MeshColliders/Mono/MeshColliderConvexMonoBinder.cs
@@ -8,7 +8,6 @@ namespace Aspid.MVVM.StarterKit
     [AddComponentContextMenu(typeof(MeshCollider),"Add MeshCollider Binder/MeshCollider Binder - Convex")]
     public partial class MeshColliderConvexMonoBinder : ComponentMonoBinder<MeshCollider>, IBinder<bool>
     {
-        [Header("Converter")]
         [SerializeField] private bool _isInvert;
 
         [BinderLog]

--- a/Assets/Plugins/Aspid/MVVM/StarterKit/Unity/Runtime/Binders/Colliders/MeshColliders/Mono/MeshColliderMeshEnumGroupMonoBinder.cs
+++ b/Assets/Plugins/Aspid/MVVM/StarterKit/Unity/Runtime/Binders/Colliders/MeshColliders/Mono/MeshColliderMeshEnumGroupMonoBinder.cs
@@ -13,7 +13,7 @@ namespace Aspid.MVVM.StarterKit
     [AddComponentContextMenu(typeof(MeshCollider),"Add MeshCollider Binder/MeshCollider Binder - Mesh EnumGroup")]
     public sealed class MeshColliderMeshEnumGroupMonoBinder : EnumGroupMonoBinder<MeshCollider>
     {
-        [Header("Parameters")]
+        [Header("Values")]
         [SerializeField] private Mesh _defaultValue;
         [SerializeField] private Mesh _selectedValue;
         

--- a/Assets/Plugins/Aspid/MVVM/StarterKit/Unity/Runtime/Binders/Colliders/MeshColliders/Mono/MeshColliderMeshEnumMonoBinder.cs
+++ b/Assets/Plugins/Aspid/MVVM/StarterKit/Unity/Runtime/Binders/Colliders/MeshColliders/Mono/MeshColliderMeshEnumMonoBinder.cs
@@ -13,7 +13,6 @@ namespace Aspid.MVVM.StarterKit
     [AddComponentContextMenu(typeof(MeshCollider),"Add MeshCollider Binder/MeshCollider Binder - Mesh Enum")]
     public sealed class MeshColliderMeshEnumMonoBinder : EnumMonoBinder<MeshCollider, Mesh>
     {
-        [Header("Converter")]
         [SerializeReferenceDropdown]
         [SerializeReference] private Converter _converter;
         

--- a/Assets/Plugins/Aspid/MVVM/StarterKit/Unity/Runtime/Binders/Colliders/MeshColliders/Mono/MeshColliderMeshMonoBinder.cs
+++ b/Assets/Plugins/Aspid/MVVM/StarterKit/Unity/Runtime/Binders/Colliders/MeshColliders/Mono/MeshColliderMeshMonoBinder.cs
@@ -13,7 +13,6 @@ namespace Aspid.MVVM.StarterKit
     [AddComponentContextMenu(typeof(MeshCollider),"Add MeshCollider Binder/MeshCollider Binder - Mesh")]
     public partial class MeshColliderMeshMonoBinder : ComponentMonoBinder<MeshCollider>, IBinder<Mesh>
     {
-        [Header("Converter")]
         [SerializeReferenceDropdown]
         [SerializeReference] private Converter _converter;
 

--- a/Assets/Plugins/Aspid/MVVM/StarterKit/Unity/Runtime/Binders/Colliders/MeshColliders/Mono/MeshColliderMeshSwitcherMonoBinder.cs
+++ b/Assets/Plugins/Aspid/MVVM/StarterKit/Unity/Runtime/Binders/Colliders/MeshColliders/Mono/MeshColliderMeshSwitcherMonoBinder.cs
@@ -13,7 +13,7 @@ namespace Aspid.MVVM.StarterKit
     [AddComponentContextMenu(typeof(MeshCollider),"Add MeshCollider Binder/MeshCollider Binder - Mesh Switcher")]
     public sealed class MeshColliderMeshSwitcherMonoBinder : SwitcherMonoBinder<MeshCollider, Mesh>
     {
-        [Header("Converter")]
+        [Header("Converters")]
         [SerializeReferenceDropdown]
         [SerializeReference] private Converter _converter;
         

--- a/Assets/Plugins/Aspid/MVVM/StarterKit/Unity/Runtime/Binders/Colliders/Mono/ColliderEnabledEnumGroupMonoBinder.cs
+++ b/Assets/Plugins/Aspid/MVVM/StarterKit/Unity/Runtime/Binders/Colliders/Mono/ColliderEnabledEnumGroupMonoBinder.cs
@@ -7,7 +7,7 @@ namespace Aspid.MVVM.StarterKit
     [AddComponentContextMenu(typeof(Collider),"Add Binder/Collider Binder - Enabled EnumGroup")]
     public sealed class ColliderEnabledEnumGroupMonoBinder : EnumGroupMonoBinder<Collider>
     {
-        [Header("Parameters")]
+        [Header("Values")]
         [SerializeField] private bool _defaultValue;
         [SerializeField] private bool _selectedValue;
         

--- a/Assets/Plugins/Aspid/MVVM/StarterKit/Unity/Runtime/Binders/Colliders/Mono/ColliderEnabledMonoBinder.cs
+++ b/Assets/Plugins/Aspid/MVVM/StarterKit/Unity/Runtime/Binders/Colliders/Mono/ColliderEnabledMonoBinder.cs
@@ -7,7 +7,6 @@ namespace Aspid.MVVM.StarterKit
     [AddComponentContextMenu(typeof(Collider),"Add Binder/Collider Binder - Enabled")]
     public partial class ColliderEnabledMonoBinder : ComponentMonoBinder<Collider>, IBinder<bool>
     {
-        [Header("Converter")]
         [SerializeField] private bool _isInvert;
         
         [BinderLog]

--- a/Assets/Plugins/Aspid/MVVM/StarterKit/Unity/Runtime/Binders/Colliders/Mono/ColliderIsTriggerEnumGroupMonoBinder.cs
+++ b/Assets/Plugins/Aspid/MVVM/StarterKit/Unity/Runtime/Binders/Colliders/Mono/ColliderIsTriggerEnumGroupMonoBinder.cs
@@ -8,7 +8,7 @@ namespace Aspid.MVVM.StarterKit
     [AddComponentContextMenu(typeof(Collider),"Add Binder/Collider Binder - IsTrigger EnumGroup")]
     public sealed class ColliderIsTriggerEnumGroupMonoBinder : EnumGroupMonoBinder<Collider>
     {
-        [Header("Parameters")]
+        [Header("Values")]
         [SerializeField] private bool _defaultValue;
         [SerializeField] private bool _selectedValue;
         

--- a/Assets/Plugins/Aspid/MVVM/StarterKit/Unity/Runtime/Binders/Colliders/Mono/ColliderIsTriggerMonoBinder.cs
+++ b/Assets/Plugins/Aspid/MVVM/StarterKit/Unity/Runtime/Binders/Colliders/Mono/ColliderIsTriggerMonoBinder.cs
@@ -8,7 +8,6 @@ namespace Aspid.MVVM.StarterKit
     [AddComponentContextMenu(typeof(Collider),"Add Binder/Collider Binder - IsTrigger")]
     public partial class ColliderIsTriggerMonoBinder : ComponentMonoBinder<Collider>, IBinder<bool>
     {
-        [Header("Converter")]
         [SerializeField] private bool _isInvert;
         
         [BinderLog]

--- a/Assets/Plugins/Aspid/MVVM/StarterKit/Unity/Runtime/Binders/Colliders/Mono/ColliderMaterialEnumGroupMonoBinder.cs
+++ b/Assets/Plugins/Aspid/MVVM/StarterKit/Unity/Runtime/Binders/Colliders/Mono/ColliderMaterialEnumGroupMonoBinder.cs
@@ -15,7 +15,7 @@ namespace Aspid.MVVM.StarterKit
     [AddComponentContextMenu(typeof(Collider),"Add Binder/Collider Binder - Material EnumGroup")]
     public sealed class ColliderMaterialEnumGroupMonoBinder : EnumGroupMonoBinder<Collider>
     {
-        [Header("Parameters")]
+        [Header("Values")]
         [SerializeField] private PhysicsMaterial _defaultValue;
         [SerializeField] private PhysicsMaterial _selectedValue;
         

--- a/Assets/Plugins/Aspid/MVVM/StarterKit/Unity/Runtime/Binders/Colliders/Mono/ColliderMaterialEnumMonoBinder.cs
+++ b/Assets/Plugins/Aspid/MVVM/StarterKit/Unity/Runtime/Binders/Colliders/Mono/ColliderMaterialEnumMonoBinder.cs
@@ -15,7 +15,6 @@ namespace Aspid.MVVM.StarterKit
     [AddComponentContextMenu(typeof(Collider),"Add Binder/Collider Binder - Material Enum")]
     public sealed class ColliderMaterialEnumMonoBinder : EnumMonoBinder<Collider, PhysicsMaterial>
     {
-        [Header("Converter")]
         [SerializeReferenceDropdown]
         [SerializeReference] private Converter _converter;
         

--- a/Assets/Plugins/Aspid/MVVM/StarterKit/Unity/Runtime/Binders/Colliders/Mono/ColliderMaterialMonoBinder.cs
+++ b/Assets/Plugins/Aspid/MVVM/StarterKit/Unity/Runtime/Binders/Colliders/Mono/ColliderMaterialMonoBinder.cs
@@ -15,7 +15,6 @@ namespace Aspid.MVVM.StarterKit
     [AddComponentContextMenu(typeof(Collider),"Add Binder/Collider Binder - Material")]
     public partial class ColliderMaterialMonoBinder : ComponentMonoBinder<Collider>, IBinder<PhysicsMaterial>
     {
-        [Header("Converter")]
         [SerializeReferenceDropdown]
         [SerializeReference] private Converter _converter;
         

--- a/Assets/Plugins/Aspid/MVVM/StarterKit/Unity/Runtime/Binders/Colliders/Mono/ColliderMaterialSwitcherMonoBinder.cs
+++ b/Assets/Plugins/Aspid/MVVM/StarterKit/Unity/Runtime/Binders/Colliders/Mono/ColliderMaterialSwitcherMonoBinder.cs
@@ -15,7 +15,7 @@ namespace Aspid.MVVM.StarterKit
     [AddComponentContextMenu(typeof(Collider),"Add Binder/Collider Binder - Material Switcher")]
     public sealed class ColliderMaterialSwitcherMonoBinder : SwitcherMonoBinder<Collider, PhysicsMaterial>
     {
-        [Header("Converter")]
+        [Header("Converters")]
         [SerializeReferenceDropdown]
         [SerializeReference] private Converter _converter;
         

--- a/Assets/Plugins/Aspid/MVVM/StarterKit/Unity/Runtime/Binders/Colliders/Mono/ColliderProvidesContactsEnumGroupMonoBinder.cs
+++ b/Assets/Plugins/Aspid/MVVM/StarterKit/Unity/Runtime/Binders/Colliders/Mono/ColliderProvidesContactsEnumGroupMonoBinder.cs
@@ -8,7 +8,7 @@ namespace Aspid.MVVM.StarterKit
     [AddComponentContextMenu(typeof(Collider),"Add Binder/Collider Binder - ProvidesContacts EnumGroup")]
     public sealed class ColliderProvidesContactsEnumGroupMonoBinder : EnumGroupMonoBinder<Collider>
     {
-        [Header("Parameters")]
+        [Header("Values")]
         [SerializeField] private bool _defaultValue;
         [SerializeField] private bool _selectedValue;
         

--- a/Assets/Plugins/Aspid/MVVM/StarterKit/Unity/Runtime/Binders/Colliders/Mono/ColliderProvidesContactsMonoBinder.cs
+++ b/Assets/Plugins/Aspid/MVVM/StarterKit/Unity/Runtime/Binders/Colliders/Mono/ColliderProvidesContactsMonoBinder.cs
@@ -8,7 +8,6 @@ namespace Aspid.MVVM.StarterKit
     [AddComponentContextMenu(typeof(Collider),"Add Binder/Collider Binder - ProvidesContacts")]
     public partial class ColliderProvidesContactsMonoBinder : ComponentMonoBinder<Collider>, IBinder<bool>
     {
-        [Header("Converter")]
         [SerializeField] private bool _isInvert;
         
         [BinderLog]

--- a/Assets/Plugins/Aspid/MVVM/StarterKit/Unity/Runtime/Binders/Colliders/SphereColliders/Mono/SphereColliderCenterEnumGroupMonoBinder.cs
+++ b/Assets/Plugins/Aspid/MVVM/StarterKit/Unity/Runtime/Binders/Colliders/SphereColliders/Mono/SphereColliderCenterEnumGroupMonoBinder.cs
@@ -8,7 +8,7 @@ namespace Aspid.MVVM.StarterKit
     [AddComponentContextMenu(typeof(SphereCollider),"Add SphereCollider Binder/SphereCollider Binder - Center EnumGroup")]
     public sealed class SphereColliderCenterEnumGroupMonoBinder : EnumGroupMonoBinder<SphereCollider>
     {
-        [Header("Parameters")]
+        [Header("Values")]
         [SerializeField] private Vector3 _defaultValue;
         [SerializeField] private Vector3 _selectedValue;
         

--- a/Assets/Plugins/Aspid/MVVM/StarterKit/Unity/Runtime/Binders/Colliders/SphereColliders/Mono/SphereColliderCenterEnumMonoBinder.cs
+++ b/Assets/Plugins/Aspid/MVVM/StarterKit/Unity/Runtime/Binders/Colliders/SphereColliders/Mono/SphereColliderCenterEnumMonoBinder.cs
@@ -8,7 +8,6 @@ namespace Aspid.MVVM.StarterKit
     [AddComponentContextMenu(typeof(SphereCollider),"Add SphereCollider Binder/SphereCollider Binder - Center Enum")]
     public sealed class SphereColliderCenterEnumMonoBinder : EnumMonoBinder<SphereCollider, Vector3>
     {
-        [Header("Converter")]
         [SerializeField] private Vector3CombineConverter _converter = Vector3CombineConverter.Default;
         
         protected override void SetValue(Vector3 value) =>

--- a/Assets/Plugins/Aspid/MVVM/StarterKit/Unity/Runtime/Binders/Colliders/SphereColliders/Mono/SphereColliderCenterMonoBinder.cs
+++ b/Assets/Plugins/Aspid/MVVM/StarterKit/Unity/Runtime/Binders/Colliders/SphereColliders/Mono/SphereColliderCenterMonoBinder.cs
@@ -8,7 +8,6 @@ namespace Aspid.MVVM.StarterKit
     [AddComponentContextMenu(typeof(SphereCollider),"Add SphereCollider Binder/SphereCollider Binder - Center")]
     public partial class SphereColliderCenterMonoBinder : ComponentMonoBinder<SphereCollider>, IVectorBinder, INumberBinder
     {
-        [Header("Converter")]
         [SerializeField] private Vector3CombineConverter _converter = Vector3CombineConverter.Default;
         
         [BinderLog]

--- a/Assets/Plugins/Aspid/MVVM/StarterKit/Unity/Runtime/Binders/Colliders/SphereColliders/Mono/SphereColliderCenterSwitcherMonoBinder.cs
+++ b/Assets/Plugins/Aspid/MVVM/StarterKit/Unity/Runtime/Binders/Colliders/SphereColliders/Mono/SphereColliderCenterSwitcherMonoBinder.cs
@@ -8,7 +8,7 @@ namespace Aspid.MVVM.StarterKit
     [AddComponentContextMenu(typeof(SphereCollider),"Add SphereCollider Binder/SphereCollider Binder - Center Switcher")]
     public sealed class SphereColliderCenterSwitcherMonoBinder : SwitcherMonoBinder<SphereCollider, Vector3>
     {
-        [Header("Converter")]
+        [Header("Converters")]
         [SerializeField] private Vector3CombineConverter _converter = Vector3CombineConverter.Default;
         
         protected override void SetValue(Vector3 value) =>

--- a/Assets/Plugins/Aspid/MVVM/StarterKit/Unity/Runtime/Binders/Colliders/SphereColliders/Mono/SphereColliderRadiusEnumGroupMonoBinder.cs
+++ b/Assets/Plugins/Aspid/MVVM/StarterKit/Unity/Runtime/Binders/Colliders/SphereColliders/Mono/SphereColliderRadiusEnumGroupMonoBinder.cs
@@ -13,7 +13,7 @@ namespace Aspid.MVVM.StarterKit
     [AddComponentContextMenu(typeof(SphereCollider),"Add SphereCollider Binder/SphereCollider Binder - Radius EnumGroup")]
     public sealed class SphereColliderRadiusEnumGroupMonoBinder : EnumGroupMonoBinder<SphereCollider>
     {
-        [Header("Parameters")]
+        [Header("Values")]
         [SerializeField] [Min(0)] private float _defaultValue;
         [SerializeField] [Min(0)] private float _selectedValue;
         

--- a/Assets/Plugins/Aspid/MVVM/StarterKit/Unity/Runtime/Binders/Colliders/SphereColliders/Mono/SphereColliderRadiusEnumMonoBinder.cs
+++ b/Assets/Plugins/Aspid/MVVM/StarterKit/Unity/Runtime/Binders/Colliders/SphereColliders/Mono/SphereColliderRadiusEnumMonoBinder.cs
@@ -13,7 +13,6 @@ namespace Aspid.MVVM.StarterKit
     [AddComponentContextMenu(typeof(SphereCollider),"Add SphereCollider Binder/SphereCollider Binder - Radius Enum")]
     public sealed class SphereColliderRadiusEnumMonoBinder : EnumMonoBinder<SphereCollider, float>
     {
-        [Header("Converter")]
         [SerializeReferenceDropdown]
         [SerializeReference] private Converter _converter;
 

--- a/Assets/Plugins/Aspid/MVVM/StarterKit/Unity/Runtime/Binders/Colliders/SphereColliders/Mono/SphereColliderRadiusMonoBinder.cs
+++ b/Assets/Plugins/Aspid/MVVM/StarterKit/Unity/Runtime/Binders/Colliders/SphereColliders/Mono/SphereColliderRadiusMonoBinder.cs
@@ -13,7 +13,6 @@ namespace Aspid.MVVM.StarterKit
     [AddComponentContextMenu(typeof(SphereCollider),"Add SphereCollider Binder/SphereCollider Binder - Radius")]
     public partial class SphereColliderRadiusMonoBinder : ComponentMonoBinder<SphereCollider>, INumberBinder
     {
-        [Header("Converter")]
         [SerializeReferenceDropdown]
         [SerializeReference] private Converter _converter;
 

--- a/Assets/Plugins/Aspid/MVVM/StarterKit/Unity/Runtime/Binders/Colliders/SphereColliders/Mono/SphereColliderRadiusSwitcherMonoBinder.cs
+++ b/Assets/Plugins/Aspid/MVVM/StarterKit/Unity/Runtime/Binders/Colliders/SphereColliders/Mono/SphereColliderRadiusSwitcherMonoBinder.cs
@@ -13,7 +13,7 @@ namespace Aspid.MVVM.StarterKit
     [AddComponentContextMenu(typeof(SphereCollider),"Add SphereCollider Binder/SphereCollider Binder - Radius Switcher")]
     public sealed class SphereColliderRadiusSwitcherMonoBinder : SwitcherMonoBinder<SphereCollider, float>
     {
-        [Header("Converter")]
+        [Header("Converters")]
         [SerializeReferenceDropdown]
         [SerializeReference] private Converter _converter;
 

--- a/Assets/Plugins/Aspid/MVVM/StarterKit/Unity/Runtime/Binders/Colliders/SphereColliders/SphereColliderCenterBinder.cs
+++ b/Assets/Plugins/Aspid/MVVM/StarterKit/Unity/Runtime/Binders/Colliders/SphereColliders/SphereColliderCenterBinder.cs
@@ -9,7 +9,6 @@ namespace Aspid.MVVM.StarterKit
     public class SphereColliderCenterBinder : TargetBinder<SphereCollider>, IVectorBinder, INumberBinder
     {
         // ReSharper disable once MemberInitializerValueIgnored
-        [Header("Converter")]
         [SerializeField] private Vector3CombineConverter? _converter = Vector3CombineConverter.Default;
 
         public SphereColliderCenterBinder(SphereCollider target, BindMode mode)

--- a/Assets/Plugins/Aspid/MVVM/StarterKit/Unity/Runtime/Binders/Colliders/SphereColliders/SphereColliderCenterSwitcherBinder.cs
+++ b/Assets/Plugins/Aspid/MVVM/StarterKit/Unity/Runtime/Binders/Colliders/SphereColliders/SphereColliderCenterSwitcherBinder.cs
@@ -9,7 +9,7 @@ namespace Aspid.MVVM.StarterKit
     public sealed class SphereColliderCenterSwitcherBinder : SwitcherBinder<SphereCollider, Vector3>
     {
         // ReSharper disable once MemberInitializerValueIgnored
-        [Header("Converter")]
+        [Header("Converters")]
         [SerializeField] private Vector3CombineConverter? _converter = Vector3CombineConverter.Default;
         
         public SphereColliderCenterSwitcherBinder(

--- a/Assets/Plugins/Aspid/MVVM/StarterKit/Unity/Runtime/Binders/Colliders/SphereColliders/SphereColliderRadiusBinder.cs
+++ b/Assets/Plugins/Aspid/MVVM/StarterKit/Unity/Runtime/Binders/Colliders/SphereColliders/SphereColliderRadiusBinder.cs
@@ -13,7 +13,6 @@ namespace Aspid.MVVM.StarterKit
     [Serializable]
     public class SphereColliderRadiusBinder : TargetBinder<SphereCollider>, INumberBinder
     {
-        [Header("Converter")]
         [SerializeReferenceDropdown]
         [SerializeReference] private Converter? _converter;
         

--- a/Assets/Plugins/Aspid/MVVM/StarterKit/Unity/Runtime/Binders/Colliders/SphereColliders/SphereColliderRadiusSwitcherBinder.cs
+++ b/Assets/Plugins/Aspid/MVVM/StarterKit/Unity/Runtime/Binders/Colliders/SphereColliders/SphereColliderRadiusSwitcherBinder.cs
@@ -13,7 +13,7 @@ namespace Aspid.MVVM.StarterKit
     [Serializable]
     public sealed class SphereColliderRadiusSwitcherBinder : SwitcherBinder<CapsuleCollider, float>
     {
-        [Header("Converter")]
+        [Header("Converters")]
         [SerializeReferenceDropdown]
         [SerializeReference] private Converter? _converter;
         

--- a/Assets/Plugins/Aspid/MVVM/StarterKit/Unity/Runtime/Binders/Commands/ButtonCommandBinder.cs
+++ b/Assets/Plugins/Aspid/MVVM/StarterKit/Unity/Runtime/Binders/Commands/ButtonCommandBinder.cs
@@ -9,7 +9,6 @@ namespace Aspid.MVVM.StarterKit
     public sealed class ButtonCommandBinder : TargetBinder<Button>, IBinder<IRelayCommand>
     {
         // ReSharper disable once MemberInitializerValueIgnored
-        [Header("Parameter")]
         [SerializeField] private InteractableMode _interactableMode = InteractableMode.Interactable;
         
         [SerializeReferenceDropdown]
@@ -71,7 +70,6 @@ namespace Aspid.MVVM.StarterKit
     [Serializable]
     public class ButtonCommandBinder<T> : TargetBinder<Button>, IBinder<IRelayCommand<T>>
     {
-        [Header("Parameters")]
         [SerializeField] private T _param;
         
         // ReSharper disable once MemberInitializerValueIgnored
@@ -157,7 +155,6 @@ namespace Aspid.MVVM.StarterKit
     [Serializable]
     public class ButtonCommandBinder<T1, T2> : TargetBinder<Button>, IBinder<IRelayCommand<T1, T2>>
     {
-        [Header("Parameters")]
         [SerializeField] private T1 _param1;
         [SerializeField] private T2 _param2;
         
@@ -254,7 +251,6 @@ namespace Aspid.MVVM.StarterKit
     [Serializable]
     public class ButtonCommandBinder<T1, T2, T3> : TargetBinder<Button>, IBinder<IRelayCommand<T1, T2, T3>>
     {
-        [Header("Parameters")]
         [SerializeField] private T1 _param1;
         [SerializeField] private T2 _param2;
         [SerializeField] private T3 _param3;
@@ -350,7 +346,6 @@ namespace Aspid.MVVM.StarterKit
     [Serializable]
     public class ButtonCommandBinder<T1, T2, T3, T4> : TargetBinder<Button>, IBinder<IRelayCommand<T1, T2, T3, T4>>
     {
-        [Header("Parameters")]
         [SerializeField] private T1 _param1;
         [SerializeField] private T2 _param2;
         [SerializeField] private T3 _param3;

--- a/Assets/Plugins/Aspid/MVVM/StarterKit/Unity/Runtime/Binders/Commands/DropdownCommandBinder.cs
+++ b/Assets/Plugins/Aspid/MVVM/StarterKit/Unity/Runtime/Binders/Commands/DropdownCommandBinder.cs
@@ -12,7 +12,6 @@ namespace Aspid.MVVM.StarterKit
         IBinder<IRelayCommand<long>>
     {
         // ReSharper disable once MemberInitializerValueIgnored
-        [Header("Parameter")]
         [SerializeField] private InteractableMode _interactableMode = InteractableMode.Interactable;
         
         [SerializeReferenceDropdown]
@@ -100,7 +99,6 @@ namespace Aspid.MVVM.StarterKit
         IBinder<IRelayCommand<int, T>>,
         IBinder<IRelayCommand<long, T>>
     {
-        [Header("Parameters")]
         [SerializeField] private T _param;
         
         // ReSharper disable once MemberInitializerValueIgnored
@@ -206,7 +204,6 @@ namespace Aspid.MVVM.StarterKit
         IBinder<IRelayCommand<int, T1, T2>>,
         IBinder<IRelayCommand<long, T1, T2>>
     {
-        [Header("Parameters")]
         [SerializeField] private T1 _param1;
         [SerializeField] private T2 _param2;
         
@@ -323,7 +320,6 @@ namespace Aspid.MVVM.StarterKit
         IBinder<IRelayCommand<int, T1, T2, T3>>,
         IBinder<IRelayCommand<long, T1, T2, T3>>
     {
-        [Header("Parameters")]
         [SerializeField] private T1 _param1;
         [SerializeField] private T2 _param2;
         [SerializeField] private T3 _param3;

--- a/Assets/Plugins/Aspid/MVVM/StarterKit/Unity/Runtime/Binders/Commands/InputFieldCommandBinder.cs
+++ b/Assets/Plugins/Aspid/MVVM/StarterKit/Unity/Runtime/Binders/Commands/InputFieldCommandBinder.cs
@@ -11,7 +11,6 @@ namespace Aspid.MVVM.StarterKit
         IBinder<IRelayCommand>,
         IBinder<IRelayCommand<string>>
     {
-        [Header("Parameters")]
         // ReSharper disable once MemberInitializerValueIgnored
         [SerializeField] private UpdateInputFieldEvent _updateEvent = UpdateInputFieldEvent.OnValueChanged;
         
@@ -132,7 +131,6 @@ namespace Aspid.MVVM.StarterKit
     [Serializable]
     public class InputFieldCommandBinder<T>: TargetBinder<TMP_InputField>, IBinder<IRelayCommand<string, T>>
     {
-        [Header("Parameters")]
         [SerializeField] private T _param;
         
         [Space]
@@ -255,7 +253,6 @@ namespace Aspid.MVVM.StarterKit
     [Serializable]
     public class InputFieldCommandBinder<T1, T2>: TargetBinder<TMP_InputField>, IBinder<IRelayCommand<string, T1, T2>>
     {
-        [Header("Parameters")]
         [SerializeField] private T1 _param1;
         [SerializeField] private T2 _param2;
         
@@ -389,7 +386,6 @@ namespace Aspid.MVVM.StarterKit
     [Serializable]
     public class InputFieldCommandBinder<T1, T2, T3>: TargetBinder<TMP_InputField>, IBinder<IRelayCommand<string, T1, T2, T3>>
     {
-        [Header("Parameters")]
         [SerializeField] private T1 _param1;
         [SerializeField] private T2 _param2;
         [SerializeField] private T3 _param3;

--- a/Assets/Plugins/Aspid/MVVM/StarterKit/Unity/Runtime/Binders/Commands/Mono/ButtonCommandMonoBinder.cs
+++ b/Assets/Plugins/Aspid/MVVM/StarterKit/Unity/Runtime/Binders/Commands/Mono/ButtonCommandMonoBinder.cs
@@ -11,7 +11,6 @@ namespace Aspid.MVVM.StarterKit
         IBinder<IRelayCommand>,
         IBinder<IRelayCommand<bool>>
     {
-        [Header("Parameter")]
         [SerializeField] private InteractableMode _interactableMode = InteractableMode.Interactable;
 
         [SerializeReferenceDropdown]
@@ -79,7 +78,6 @@ namespace Aspid.MVVM.StarterKit
     public abstract partial class ButtonCommandMonoBinder<T> : ComponentMonoBinder<Button>, 
         IBinder<IRelayCommand<T>>
     {
-        [Header("Parameters")]
         [SerializeField] private T _param;
         
         [Space]
@@ -138,7 +136,6 @@ namespace Aspid.MVVM.StarterKit
     public abstract partial class ButtonCommandMonoBinder<T1, T2> : ComponentMonoBinder<Button>,
         IBinder<IRelayCommand<T1, T2>>
     {
-        [Header("Parameters")]
         [SerializeField] private T1 _param1;
         [SerializeField] private T2 _param2;
         
@@ -204,7 +201,6 @@ namespace Aspid.MVVM.StarterKit
     public abstract partial class ButtonCommandMonoBinder<T1, T2, T3> : ComponentMonoBinder<Button>, 
         IBinder<IRelayCommand<T1, T2, T3>>
     {
-        [Header("Parameters")]
         [SerializeField] private T1 _param1;
         [SerializeField] private T2 _param2;
         [SerializeField] private T3 _param3;
@@ -277,7 +273,6 @@ namespace Aspid.MVVM.StarterKit
     public abstract partial class ButtonCommandMonoBinder<T1, T2, T3, T4> : ComponentMonoBinder<Button>, 
         IBinder<IRelayCommand<T1, T2, T3, T4>>
     {
-        [Header("Parameters")]
         [SerializeField] private T1 _param1;
         [SerializeField] private T2 _param2;
         [SerializeField] private T3 _param3;

--- a/Assets/Plugins/Aspid/MVVM/StarterKit/Unity/Runtime/Binders/Commands/Mono/DropdownCommandMonoBinder.cs
+++ b/Assets/Plugins/Aspid/MVVM/StarterKit/Unity/Runtime/Binders/Commands/Mono/DropdownCommandMonoBinder.cs
@@ -12,7 +12,6 @@ namespace Aspid.MVVM.StarterKit
         IBinder<IRelayCommand<int>>,
         IBinder<IRelayCommand<long>>
     {
-        [Header("Parameter")]
         [SerializeField] private InteractableMode _interactableMode = InteractableMode.Interactable;
         
         [SerializeReferenceDropdown]
@@ -81,7 +80,6 @@ namespace Aspid.MVVM.StarterKit
         IBinder<IRelayCommand<int, T>>,
         IBinder<IRelayCommand<long, T>>
     {
-        [Header("Parameters")]
         [SerializeField] private T _param;
         
         [Space]
@@ -159,7 +157,6 @@ namespace Aspid.MVVM.StarterKit
         IBinder<IRelayCommand<int, T1, T2>>,
         IBinder<IRelayCommand<long, T1, T2>>
     {
-        [Header("Parameters")]
         [SerializeField] private T1 _param1;
         [SerializeField] private T2 _param2;
         
@@ -244,7 +241,6 @@ namespace Aspid.MVVM.StarterKit
         IBinder<IRelayCommand<int, T1, T2, T3>>,
         IBinder<IRelayCommand<long, T1, T2, T3>>
     {
-        [Header("Parameters")]
         [SerializeField] private T1 _param1;
         [SerializeField] private T2 _param2;
         [SerializeField] private T3 _param3;

--- a/Assets/Plugins/Aspid/MVVM/StarterKit/Unity/Runtime/Binders/Commands/Mono/InputFieldCommandMonoBinder.cs
+++ b/Assets/Plugins/Aspid/MVVM/StarterKit/Unity/Runtime/Binders/Commands/Mono/InputFieldCommandMonoBinder.cs
@@ -13,7 +13,6 @@ namespace Aspid.MVVM.StarterKit
         IBinder<IRelayCommand>,
         IBinder<IRelayCommand<string>>
     {
-        [Header("Parameters")]
         [SerializeField] private UpdateInputFieldEvent _updateEvent = UpdateInputFieldEvent.OnValueChanged;
         [SerializeField] private InteractableMode _interactableMode = InteractableMode.Interactable;
         
@@ -117,7 +116,6 @@ namespace Aspid.MVVM.StarterKit
     public abstract partial class InputFieldCommandMonoBinder<T> : ComponentMonoBinder<TMP_InputField>,
         IBinder<IRelayCommand<string, T>>
     {
-        [Header("Parameters")]
         [SerializeField] private T _param;
         
         [Space]
@@ -212,7 +210,6 @@ namespace Aspid.MVVM.StarterKit
     public abstract partial class InputFieldCommandMonoBinder<T1, T2> : ComponentMonoBinder<TMP_InputField>,
         IBinder<IRelayCommand<string, T1, T2>>
     {
-        [Header("Parameters")]
         [SerializeField] private T1 _param1;
         [SerializeField] private T2 _param2;
         
@@ -314,7 +311,6 @@ namespace Aspid.MVVM.StarterKit
     public abstract partial class InputFieldCommandMonoBinder<T1, T2, T3> : ComponentMonoBinder<TMP_InputField>, 
         IBinder<IRelayCommand<string, T1, T2, T3>>
     {
-        [Header("Parameters")]
         [SerializeField] private T1 _param1;
         [SerializeField] private T2 _param2;
         [SerializeField] private T3 _param3;

--- a/Assets/Plugins/Aspid/MVVM/StarterKit/Unity/Runtime/Binders/Commands/Mono/ScrollBarCommandMonoBinder.cs
+++ b/Assets/Plugins/Aspid/MVVM/StarterKit/Unity/Runtime/Binders/Commands/Mono/ScrollBarCommandMonoBinder.cs
@@ -13,7 +13,6 @@ namespace Aspid.MVVM.StarterKit
         IBinder<IRelayCommand<float>>, 
         IBinder<IRelayCommand<double>>
     {
-        [Header("Parameter")]
         [SerializeField] private InteractableMode _interactableMode = InteractableMode.Interactable;
 
         [SerializeReferenceDropdown]
@@ -100,7 +99,6 @@ namespace Aspid.MVVM.StarterKit
         IBinder<IRelayCommand<float, T>>, 
         IBinder<IRelayCommand<double, T>>
     {
-        [Header("Parameters")]
         [SerializeField] private T _param;
         
         [Space]
@@ -196,7 +194,6 @@ namespace Aspid.MVVM.StarterKit
         IBinder<IRelayCommand<float, T1, T2>>, 
         IBinder<IRelayCommand<double, T1, T2>>
     {
-        [Header("Parameters")]
         [SerializeField] private T1 _param1;
         [SerializeField] private T2 _param2;
         
@@ -300,7 +297,6 @@ namespace Aspid.MVVM.StarterKit
         IBinder<IRelayCommand<float, T1, T2, T3>>, 
         IBinder<IRelayCommand<double, T1, T2, T3>>
     {
-        [Header("Parameters")]
         [SerializeField] private T1 _param1;
         [SerializeField] private T2 _param2;
         [SerializeField] private T3 _param3;

--- a/Assets/Plugins/Aspid/MVVM/StarterKit/Unity/Runtime/Binders/Commands/Mono/ScrollRectCommandMonoBinder.cs
+++ b/Assets/Plugins/Aspid/MVVM/StarterKit/Unity/Runtime/Binders/Commands/Mono/ScrollRectCommandMonoBinder.cs
@@ -11,7 +11,6 @@ namespace Aspid.MVVM.StarterKit
         IBinder<IRelayCommand<Vector2>>, 
         IBinder<IRelayCommand<Vector3>>
     {
-        [Header("Parameter")]
         [SerializeReferenceDropdown]
         [SerializeReference] private ICanExecuteView _interactable;
         
@@ -54,7 +53,6 @@ namespace Aspid.MVVM.StarterKit
         IBinder<IRelayCommand<Vector2, T>>, 
         IBinder<IRelayCommand<Vector3, T>>
     {
-        [Header("Parameters")]
         [SerializeField] private T _param;
         
         [Space]
@@ -106,7 +104,6 @@ namespace Aspid.MVVM.StarterKit
         IBinder<IRelayCommand<Vector2, T1, T2>>, 
         IBinder<IRelayCommand<Vector3, T1, T2>>
     {
-        [Header("Parameters")]
         [SerializeField] private T1 _param1;
         [SerializeField] private T2 _param2;
         
@@ -165,7 +162,6 @@ namespace Aspid.MVVM.StarterKit
         IBinder<IRelayCommand<Vector2, T1, T2, T3>>, 
         IBinder<IRelayCommand<Vector3, T1, T2, T3>>
     {
-        [Header("Parameters")]
         [SerializeField] private T1 _param1;
         [SerializeField] private T2 _param2;
         [SerializeField] private T3 _param3;

--- a/Assets/Plugins/Aspid/MVVM/StarterKit/Unity/Runtime/Binders/Commands/Mono/SliderCommandMonoBinder.cs
+++ b/Assets/Plugins/Aspid/MVVM/StarterKit/Unity/Runtime/Binders/Commands/Mono/SliderCommandMonoBinder.cs
@@ -13,7 +13,6 @@ namespace Aspid.MVVM.StarterKit
         IBinder<IRelayCommand<float>>,
         IBinder<IRelayCommand<double>>
     {
-        [Header("Parameter")]
         [SerializeField] private InteractableMode _interactableMode = InteractableMode.Interactable;
 
         [SerializeReferenceDropdown]
@@ -100,7 +99,6 @@ namespace Aspid.MVVM.StarterKit
         IBinder<IRelayCommand<float, T>>, 
         IBinder<IRelayCommand<double, T>>
     {
-        [Header("Parameters")]
         [SerializeField] private T _param;
         
         [Space]
@@ -196,7 +194,6 @@ namespace Aspid.MVVM.StarterKit
         IBinder<IRelayCommand<float, T1, T2>>, 
         IBinder<IRelayCommand<double, T1, T2>>
     {
-        [Header("Parameters")]
         [SerializeField] private T1 _param1;
         [SerializeField] private T2 _param2;
         
@@ -299,7 +296,6 @@ namespace Aspid.MVVM.StarterKit
         IBinder<IRelayCommand<float, T1, T2, T3>>, 
         IBinder<IRelayCommand<double, T1, T2, T3>>
     {
-        [Header("Parameters")]
         [SerializeField] private T1 _param1;
         [SerializeField] private T2 _param2;
         [SerializeField] private T3 _param3;

--- a/Assets/Plugins/Aspid/MVVM/StarterKit/Unity/Runtime/Binders/Commands/Mono/ToggleCommandMonoBinder.cs
+++ b/Assets/Plugins/Aspid/MVVM/StarterKit/Unity/Runtime/Binders/Commands/Mono/ToggleCommandMonoBinder.cs
@@ -9,7 +9,6 @@ namespace Aspid.MVVM.StarterKit
     [AddComponentContextMenu(typeof(Toggle),"Add Toggle Binder/Toggle Binder - Command")]
     public partial class ToggleCommandMonoBinder : ComponentMonoBinder<Toggle>, IBinder<IRelayCommand>, IBinder<IRelayCommand<bool>>
     {
-        [Header("Parameter")]
         [SerializeField] private InteractableMode _interactableMode = InteractableMode.Interactable;
         
         [SerializeReferenceDropdown]
@@ -76,7 +75,6 @@ namespace Aspid.MVVM.StarterKit
     
     public abstract partial class ToggleCommandMonoBinder<T> : ComponentMonoBinder<Toggle>, IBinder<IRelayCommand<bool, T>>
     {
-        [Header("Parameters")]
         [SerializeField] private T _param;
         
         [Space]
@@ -134,7 +132,6 @@ namespace Aspid.MVVM.StarterKit
     
     public abstract partial class ToggleCommandMonoBinder<T1, T2> : ComponentMonoBinder<Toggle>, IBinder<IRelayCommand<bool, T1, T2>>
     {
-        [Header("Parameters")]
         [SerializeField] private T1 _param1;
         [SerializeField] private T2 _param2;
         
@@ -199,7 +196,6 @@ namespace Aspid.MVVM.StarterKit
     
     public abstract partial class ToggleCommandMonoBinder<T1, T2, T3> : ComponentMonoBinder<Toggle>, IBinder<IRelayCommand<bool, T1, T2, T3>>
     {
-        [Header("Parameters")]
         [SerializeField] private T1 _param1;
         [SerializeField] private T2 _param2;
         [SerializeField] private T3 _param3;

--- a/Assets/Plugins/Aspid/MVVM/StarterKit/Unity/Runtime/Binders/Commands/ScrollRectCommandBinder.cs
+++ b/Assets/Plugins/Aspid/MVVM/StarterKit/Unity/Runtime/Binders/Commands/ScrollRectCommandBinder.cs
@@ -10,7 +10,6 @@ namespace Aspid.MVVM.StarterKit
         IBinder<IRelayCommand<Vector2>>, 
         IBinder<IRelayCommand<Vector3>>
     {
-        [Header("Parameter")]
         [SerializeReferenceDropdown]
         [SerializeReference] private ICanExecuteView _interactable;
         
@@ -62,11 +61,10 @@ namespace Aspid.MVVM.StarterKit
     }
 
     [Serializable]
-    public class ScrollRectCommandBinder<T> :  TargetBinder<ScrollRect>, 
+    public class ScrollRectCommandBinder<T> : TargetBinder<ScrollRect>, 
         IBinder<IRelayCommand<Vector2, T>>, 
         IBinder<IRelayCommand<Vector3, T>>
     {
-        [Header("Parameter")]
         [SerializeField] private T _param;
         
         [Space]
@@ -136,7 +134,6 @@ namespace Aspid.MVVM.StarterKit
         IBinder<IRelayCommand<Vector2, T1, T2>>, 
         IBinder<IRelayCommand<Vector3, T1, T2>>
     {
-        [Header("Parameters")]
         [SerializeField] private T1 _param1;
         [SerializeField] private T2 _param2;
         
@@ -216,7 +213,6 @@ namespace Aspid.MVVM.StarterKit
         IBinder<IRelayCommand<Vector2, T1, T2, T3>>, 
         IBinder<IRelayCommand<Vector3, T1, T2, T3>>
     {
-        [Header("Parameters")]
         [SerializeField] private T1 _param1;
         [SerializeField] private T2 _param2;
         [SerializeField] private T3 _param3;

--- a/Assets/Plugins/Aspid/MVVM/StarterKit/Unity/Runtime/Binders/Commands/ScrollbarCommandBinder.cs
+++ b/Assets/Plugins/Aspid/MVVM/StarterKit/Unity/Runtime/Binders/Commands/ScrollbarCommandBinder.cs
@@ -13,7 +13,6 @@ namespace Aspid.MVVM.StarterKit
         IBinder<IRelayCommand<double>>
     {
         // ReSharper disable once MemberInitializerValueIgnored
-        [Header("Parameter")]
         [SerializeField] private InteractableMode _interactableMode = InteractableMode.Interactable;
         
         [SerializeReferenceDropdown]
@@ -113,7 +112,6 @@ namespace Aspid.MVVM.StarterKit
         IBinder<IRelayCommand<float, T>>, 
         IBinder<IRelayCommand<double, T>>
     {
-        [Header("Parameters")]
         [SerializeField] private T _param;
         
         // ReSharper disable once MemberInitializerValueIgnored
@@ -233,7 +231,6 @@ namespace Aspid.MVVM.StarterKit
         IBinder<IRelayCommand<float, T1, T2>>, 
         IBinder<IRelayCommand<double, T1, T2>>
     {
-        [Header("Parameters")]
         [SerializeField] private T1 _param1;
         [SerializeField] private T2 _param2;
         
@@ -364,7 +361,6 @@ namespace Aspid.MVVM.StarterKit
         IBinder<IRelayCommand<float, T1, T2, T3>>, 
         IBinder<IRelayCommand<double, T1, T2, T3>>
     {
-        [Header("Parameters")]
         [SerializeField] private T1 _param1;
         [SerializeField] private T2 _param2;
         [SerializeField] private T3 _param3;

--- a/Assets/Plugins/Aspid/MVVM/StarterKit/Unity/Runtime/Binders/Commands/SliderCommandBinder.cs
+++ b/Assets/Plugins/Aspid/MVVM/StarterKit/Unity/Runtime/Binders/Commands/SliderCommandBinder.cs
@@ -9,7 +9,6 @@ namespace Aspid.MVVM.StarterKit
     public sealed class SliderCommandBinder : TargetBinder<Slider>, IBinder<IRelayCommand<float>>
     {
         // ReSharper disable once MemberInitializerValueIgnored
-        [Header("Parameter")]
         [SerializeField] private InteractableMode _interactableMode = InteractableMode.Interactable;
         
         [SerializeReferenceDropdown]
@@ -101,7 +100,6 @@ namespace Aspid.MVVM.StarterKit
     [Serializable]
     public class SliderCommandBinder<T> : TargetBinder<Slider>, IBinder<IRelayCommand<float, T>>
     {
-        [Header("Parameters")]
         [SerializeField] private T _param;
         
         // ReSharper disable once MemberInitializerValueIgnored
@@ -209,7 +207,6 @@ namespace Aspid.MVVM.StarterKit
     [Serializable]
     public class SliderCommandBinder<T1, T2> : TargetBinder<Slider>, IBinder<IRelayCommand<float, T1, T2>>
     {
-        [Header("Parameters")]
         [SerializeField] private T1 _param1;
         [SerializeField] private T2 _param2;
         
@@ -326,7 +323,6 @@ namespace Aspid.MVVM.StarterKit
     [Serializable]
     public class SliderCommandBinder<T1, T2, T3> : TargetBinder<Slider>, IBinder<IRelayCommand<float, T1, T2, T3>>
     {
-        [Header("Parameters")]
         [SerializeField] private T1 _param1;
         [SerializeField] private T2 _param2;
         [SerializeField] private T3 _param3;

--- a/Assets/Plugins/Aspid/MVVM/StarterKit/Unity/Runtime/Binders/Commands/ToggleCommandBinder.cs
+++ b/Assets/Plugins/Aspid/MVVM/StarterKit/Unity/Runtime/Binders/Commands/ToggleCommandBinder.cs
@@ -9,7 +9,6 @@ namespace Aspid.MVVM.StarterKit
     public sealed class ToggleCommandBinder : TargetBinder<Toggle>, IBinder<IRelayCommand>, IBinder<IRelayCommand<bool>>
     {
         // ReSharper disable once MemberInitializerValueIgnored
-        [Header("Parameter")]
         [SerializeField] private InteractableMode _interactableMode = InteractableMode.Interactable;
         
         [SerializeReferenceDropdown]
@@ -89,7 +88,6 @@ namespace Aspid.MVVM.StarterKit
     [Serializable]
     public class ToggleCommandBinder<T> : TargetBinder<Toggle>, IBinder<IRelayCommand<bool, T>>
     {
-        [Header("Parameters")]
         [SerializeField] private T _param;
         
         // ReSharper disable once MemberInitializerValueIgnored
@@ -171,7 +169,6 @@ namespace Aspid.MVVM.StarterKit
     [Serializable]
     public class ToggleCommandBinder<T1, T2> : TargetBinder<Toggle>, IBinder<IRelayCommand<bool, T1, T2>>
     {
-        [Header("Parameters")]
         [SerializeField] private T1 _param1;
         [SerializeField] private T2 _param2;
         
@@ -266,7 +263,6 @@ namespace Aspid.MVVM.StarterKit
     [Serializable]
     public class ToggleCommandBinder<T1, T2, T3> : TargetBinder<Toggle>, IBinder<IRelayCommand<bool, T1, T2, T3>>
     {
-        [Header("Parameters")]
         [SerializeField] private T1 _param1;
         [SerializeField] private T2 _param2;
         [SerializeField] private T3 _param3;

--- a/Assets/Plugins/Aspid/MVVM/StarterKit/Unity/Runtime/Binders/GameObjects/GameObjectTagBinder.cs
+++ b/Assets/Plugins/Aspid/MVVM/StarterKit/Unity/Runtime/Binders/GameObjects/GameObjectTagBinder.cs
@@ -13,7 +13,6 @@ namespace Aspid.MVVM.StarterKit
     [Serializable]
     public class GameObjectTagBinder : TargetBinder<GameObject>, IBinder<string>
     {
-        [Header("Converter")]
         [SerializeReferenceDropdown]
         [SerializeReference] private Converter? _converter;
         

--- a/Assets/Plugins/Aspid/MVVM/StarterKit/Unity/Runtime/Binders/GameObjects/GameObjectVisibleBinder.cs
+++ b/Assets/Plugins/Aspid/MVVM/StarterKit/Unity/Runtime/Binders/GameObjects/GameObjectVisibleBinder.cs
@@ -8,7 +8,6 @@ namespace Aspid.MVVM.StarterKit
     [Serializable]
     public class GameObjectVisibleBinder : TargetBinder<GameObject>, IBinder<bool>
     {
-        [Header("Converter")]
         [SerializeField] private bool _isInvert;
         
         public GameObjectVisibleBinder(GameObject target, BindMode mode)

--- a/Assets/Plugins/Aspid/MVVM/StarterKit/Unity/Runtime/Binders/GameObjects/Mono/GameObjectTagEnumGroupMonoBinder.cs
+++ b/Assets/Plugins/Aspid/MVVM/StarterKit/Unity/Runtime/Binders/GameObjects/Mono/GameObjectTagEnumGroupMonoBinder.cs
@@ -7,7 +7,7 @@ namespace Aspid.MVVM.StarterKit
     [AddComponentContextMenu(typeof(Component),"Add General Binder/GameObject/GameObject Binder - Tag EnumGroup")]
     public sealed class GameObjectTagEnumGroupMonoBinder : EnumGroupMonoBinder<GameObject>
     {
-        [Header("Parameters")]
+        [Header("Values")]
         [SerializeField] private string _defaultValue;
         [SerializeField] private string _selectedValue;
         

--- a/Assets/Plugins/Aspid/MVVM/StarterKit/Unity/Runtime/Binders/GameObjects/Mono/GameObjectTagMonoBinder.cs
+++ b/Assets/Plugins/Aspid/MVVM/StarterKit/Unity/Runtime/Binders/GameObjects/Mono/GameObjectTagMonoBinder.cs
@@ -12,7 +12,6 @@ namespace Aspid.MVVM.StarterKit
     [AddComponentContextMenu(typeof(Component),"Add General Binder/GameObject/GameObject Binder - Tag")]
     public partial class GameObjectTagMonoBinder : MonoBinder, IBinder<string>
     {
-        [Header("Converter")]
         [SerializeReferenceDropdown]
         [SerializeReference] private Converter _converter;
         

--- a/Assets/Plugins/Aspid/MVVM/StarterKit/Unity/Runtime/Binders/GameObjects/Mono/GameObjectVisibleEnumGroupMonoBinder.cs
+++ b/Assets/Plugins/Aspid/MVVM/StarterKit/Unity/Runtime/Binders/GameObjects/Mono/GameObjectVisibleEnumGroupMonoBinder.cs
@@ -7,7 +7,7 @@ namespace Aspid.MVVM.StarterKit
     [AddComponentContextMenu(typeof(Component),"Add General Binder/GameObject/GameObject Binder - Visible EnumGroup")]
     public sealed class GameObjectVisibleEnumGroupMonoBinder : EnumGroupMonoBinder<GameObject>
     {
-        [Header("Parameters")]
+        [Header("Values")]
         [SerializeField] private bool _defaultValue;
         [SerializeField] private bool _selectedValue;
         

--- a/Assets/Plugins/Aspid/MVVM/StarterKit/Unity/Runtime/Binders/Graphics/GraphicColorBinder.cs
+++ b/Assets/Plugins/Aspid/MVVM/StarterKit/Unity/Runtime/Binders/Graphics/GraphicColorBinder.cs
@@ -14,7 +14,6 @@ namespace Aspid.MVVM.StarterKit
     [Serializable]
     public class GraphicColorBinder : TargetBinder<Graphic>, IColorBinder
     {
-        [Header("Converter")]
         [SerializeReferenceDropdown]
         [SerializeReference] private Converter? _converter;
         

--- a/Assets/Plugins/Aspid/MVVM/StarterKit/Unity/Runtime/Binders/Graphics/GraphicColorSwitcherBinder.cs
+++ b/Assets/Plugins/Aspid/MVVM/StarterKit/Unity/Runtime/Binders/Graphics/GraphicColorSwitcherBinder.cs
@@ -14,7 +14,7 @@ namespace Aspid.MVVM.StarterKit
     [Serializable]
     public sealed class GraphicColorSwitcherBinder : SwitcherBinder<Graphic, Color>
     {
-        [Header("Converter")]
+        [Header("Converters")]
         [SerializeReferenceDropdown]
         [SerializeReference] private Converter? _converter;
         

--- a/Assets/Plugins/Aspid/MVVM/StarterKit/Unity/Runtime/Binders/Graphics/Mono/GraphicColorEnumGroupMonoBinder.cs
+++ b/Assets/Plugins/Aspid/MVVM/StarterKit/Unity/Runtime/Binders/Graphics/Mono/GraphicColorEnumGroupMonoBinder.cs
@@ -14,7 +14,7 @@ namespace Aspid.MVVM.StarterKit
     [AddComponentContextMenu(typeof(Graphic),"Add Graphic Binder/Graphic Binder - Color EnumGroup")]
     public sealed class GraphicColorEnumGroupMonoBinder : EnumGroupMonoBinder<Graphic>
     {
-        [Header("Parameters")]
+        [Header("Values")]
         [SerializeField] private Color _defaultValue;
         [SerializeField] private Color _selectedValue;
         

--- a/Assets/Plugins/Aspid/MVVM/StarterKit/Unity/Runtime/Binders/Graphics/Mono/GraphicColorEnumMonoBinder.cs
+++ b/Assets/Plugins/Aspid/MVVM/StarterKit/Unity/Runtime/Binders/Graphics/Mono/GraphicColorEnumMonoBinder.cs
@@ -14,7 +14,6 @@ namespace Aspid.MVVM.StarterKit
     [AddComponentContextMenu(typeof(Graphic),"Add Graphic Binder/Graphic Binder - Color Enum")]
     public sealed class GraphicColorEnumMonoBinder : EnumMonoBinder<Graphic, Color>
     {
-        [Header("Converter")]
         [SerializeReferenceDropdown]
         [SerializeReference] private Converter _converter;
         

--- a/Assets/Plugins/Aspid/MVVM/StarterKit/Unity/Runtime/Binders/Graphics/Mono/GraphicColorMonoBinder.cs
+++ b/Assets/Plugins/Aspid/MVVM/StarterKit/Unity/Runtime/Binders/Graphics/Mono/GraphicColorMonoBinder.cs
@@ -15,7 +15,6 @@ namespace Aspid.MVVM.StarterKit
     [AddComponentContextMenu(typeof(Graphic),"Add Graphic Binder/Graphic Binder - Color")]
     public partial class GraphicColorMonoBinder : ComponentMonoBinder<Graphic>, IColorBinder
     {
-        [Header("Converter")]
         [SerializeReferenceDropdown]
         [SerializeReference] private Converter _converter;
         

--- a/Assets/Plugins/Aspid/MVVM/StarterKit/Unity/Runtime/Binders/Graphics/Mono/GraphicColorSwitcherMonoBinder.cs
+++ b/Assets/Plugins/Aspid/MVVM/StarterKit/Unity/Runtime/Binders/Graphics/Mono/GraphicColorSwitcherMonoBinder.cs
@@ -14,7 +14,7 @@ namespace Aspid.MVVM.StarterKit
     [AddComponentContextMenu(typeof(Graphic),"Add Graphic Binder/Graphic Binder - Color Switcher")]
     public sealed class GraphicColorSwitcherMonoBinder : SwitcherMonoBinder<Graphic, Color>
     {
-        [Header("Converter")]
+        [Header("Converters")]
         [SerializeReferenceDropdown]
         [SerializeReference] private Converter _converter;
         

--- a/Assets/Plugins/Aspid/MVVM/StarterKit/Unity/Runtime/Binders/Images/ImageFillBinder.cs
+++ b/Assets/Plugins/Aspid/MVVM/StarterKit/Unity/Runtime/Binders/Images/ImageFillBinder.cs
@@ -14,7 +14,6 @@ namespace Aspid.MVVM.StarterKit
     [Serializable]
     public class ImageFillBinder : TargetBinder<Image>, INumberBinder
     {
-        [Header("Converter")]
         [SerializeReferenceDropdown]
         [SerializeReference] private Converter? _converter;
         

--- a/Assets/Plugins/Aspid/MVVM/StarterKit/Unity/Runtime/Binders/Images/ImageFillSwitcherBinder.cs
+++ b/Assets/Plugins/Aspid/MVVM/StarterKit/Unity/Runtime/Binders/Images/ImageFillSwitcherBinder.cs
@@ -14,7 +14,7 @@ namespace Aspid.MVVM.StarterKit
     [Serializable]
     public sealed class ImageFillSwitcherBinder : SwitcherBinder<Image, float>
     {
-        [Header("Converter")]
+        [Header("Converters")]
         [SerializeReferenceDropdown]
         [SerializeReference] private Converter? _converter;
         

--- a/Assets/Plugins/Aspid/MVVM/StarterKit/Unity/Runtime/Binders/Images/ImageSpriteBinder.cs
+++ b/Assets/Plugins/Aspid/MVVM/StarterKit/Unity/Runtime/Binders/Images/ImageSpriteBinder.cs
@@ -9,7 +9,6 @@ namespace Aspid.MVVM.StarterKit
     [Serializable]
     public class ImageSpriteBinder : TargetBinder<Image>, IBinder<Sprite?>, IBinder<Texture2D?>
     {
-        [Header("Parameters")]
         [SerializeField] private bool _disabledWhenNull;
         
         public ImageSpriteBinder(Image target, BindMode mode)

--- a/Assets/Plugins/Aspid/MVVM/StarterKit/Unity/Runtime/Binders/Images/ImageSpriteSwitcherBinder.cs
+++ b/Assets/Plugins/Aspid/MVVM/StarterKit/Unity/Runtime/Binders/Images/ImageSpriteSwitcherBinder.cs
@@ -9,7 +9,6 @@ namespace Aspid.MVVM.StarterKit
     [Serializable]
     public sealed class ImageSpriteSwitcherBinder : SwitcherBinder<Image, Sprite?>
     {
-        [Header("Parameter")]
         [SerializeField] private bool _disabledWhenNull;
 
         public ImageSpriteSwitcherBinder(

--- a/Assets/Plugins/Aspid/MVVM/StarterKit/Unity/Runtime/Binders/Images/Mono/ImageFillEnumGroupMonoBinder.cs
+++ b/Assets/Plugins/Aspid/MVVM/StarterKit/Unity/Runtime/Binders/Images/Mono/ImageFillEnumGroupMonoBinder.cs
@@ -15,7 +15,7 @@ namespace Aspid.MVVM.StarterKit
     [AddComponentContextMenu(typeof(Image),"Add Image Binder/Image Binder - Fill EnumGroup")]
     public sealed class ImageFillEnumGroupMonoBinder : EnumGroupMonoBinder<Image>
     {
-        [Header("Parameters")]
+        [Header("Values")]
         [SerializeField] [Range(0, 1)] private float _defaultValue;
         [SerializeField] [Range(0, 1)] private float _selectedValue;
         

--- a/Assets/Plugins/Aspid/MVVM/StarterKit/Unity/Runtime/Binders/Images/Mono/ImageFillEnumMonoBinder.cs
+++ b/Assets/Plugins/Aspid/MVVM/StarterKit/Unity/Runtime/Binders/Images/Mono/ImageFillEnumMonoBinder.cs
@@ -14,7 +14,6 @@ namespace Aspid.MVVM.StarterKit
     [AddComponentContextMenu(typeof(Image),"Add Image Binder/Image Binder - Fill Enum")]
     public sealed class ImageFillEnumMonoBinder : EnumMonoBinder<Image, float>
     {
-        [Header("Converter")]
         [SerializeReferenceDropdown] 
         [SerializeReference] private Converter _converter;
 

--- a/Assets/Plugins/Aspid/MVVM/StarterKit/Unity/Runtime/Binders/Images/Mono/ImageFillMonoBinder.cs
+++ b/Assets/Plugins/Aspid/MVVM/StarterKit/Unity/Runtime/Binders/Images/Mono/ImageFillMonoBinder.cs
@@ -14,7 +14,6 @@ namespace Aspid.MVVM.StarterKit
     [AddComponentContextMenu(typeof(Image),"Add Image Binder/Image Binder - Fill")]
     public partial class ImageFillMonoBinder : ComponentMonoBinder<Image>, INumberBinder
     {
-        [Header("Converter")]
         [SerializeReferenceDropdown]
         [SerializeReference] private Converter _converter;
         

--- a/Assets/Plugins/Aspid/MVVM/StarterKit/Unity/Runtime/Binders/Images/Mono/ImageFillSwitcherMonoBinder.cs
+++ b/Assets/Plugins/Aspid/MVVM/StarterKit/Unity/Runtime/Binders/Images/Mono/ImageFillSwitcherMonoBinder.cs
@@ -14,7 +14,7 @@ namespace Aspid.MVVM.StarterKit
     [AddComponentContextMenu(typeof(Image),"Add Image Binder/Image Binder - Fill Switcher")]
     public sealed class ImageFillSwitcherMonoBinder : SwitcherMonoBinder<Image, float>
     {
-        [Header("Converter")]
+        [Header("Converters")]
         [SerializeReferenceDropdown]
         [SerializeReference] private Converter _converter;
         

--- a/Assets/Plugins/Aspid/MVVM/StarterKit/Unity/Runtime/Binders/Images/Mono/ImageSpriteAddressableMonoBinder.cs
+++ b/Assets/Plugins/Aspid/MVVM/StarterKit/Unity/Runtime/Binders/Images/Mono/ImageSpriteAddressableMonoBinder.cs
@@ -10,7 +10,6 @@ namespace Aspid.MVVM.StarterKit
     [AddComponentContextMenu(typeof(Image), "Add Image Binder/Image Binder - Sprite Addressable")]
     public sealed class ImageSpriteAddressableMonoBinder : AddressableMonoBinder<Sprite, Image>
     {
-        [Header("Parameters")]
         [SerializeField] private Sprite _defaultSprite;
         [SerializeField] private bool _disabledWhenNull = true;
 

--- a/Assets/Plugins/Aspid/MVVM/StarterKit/Unity/Runtime/Binders/Images/Mono/ImageSpriteEnumGroupMonoBinder.cs
+++ b/Assets/Plugins/Aspid/MVVM/StarterKit/Unity/Runtime/Binders/Images/Mono/ImageSpriteEnumGroupMonoBinder.cs
@@ -9,7 +9,7 @@ namespace Aspid.MVVM.StarterKit
     [AddComponentContextMenu(typeof(Image),"Add Image Binder/Image Binder - Sprite EnumGroup")]
     public sealed class ImageSpriteEnumGroupMonoBinder : EnumGroupMonoBinder<Image>
     {
-        [Header("Parameters")]
+        [Header("Values")]
         [SerializeField] private Sprite _defaultValue;
         [SerializeField] private Sprite _selectedValue;
         

--- a/Assets/Plugins/Aspid/MVVM/StarterKit/Unity/Runtime/Binders/Images/Mono/ImageSpriteEnumMonoBinder.cs
+++ b/Assets/Plugins/Aspid/MVVM/StarterKit/Unity/Runtime/Binders/Images/Mono/ImageSpriteEnumMonoBinder.cs
@@ -9,7 +9,6 @@ namespace Aspid.MVVM.StarterKit
     [AddComponentContextMenu(typeof(Image),"Add Image Binder/Image Binder - Sprite Enum")]
     public sealed class ImageSpriteEnumMonoBinder : EnumMonoBinder<Image, Sprite>
     {
-        [Header("Parameter")]
         [SerializeField] private bool _disabledWhenNull = true;
         
         protected override void SetValue(Sprite value) 

--- a/Assets/Plugins/Aspid/MVVM/StarterKit/Unity/Runtime/Binders/Images/Mono/ImageSpriteMonoBinder.cs
+++ b/Assets/Plugins/Aspid/MVVM/StarterKit/Unity/Runtime/Binders/Images/Mono/ImageSpriteMonoBinder.cs
@@ -9,7 +9,6 @@ namespace Aspid.MVVM.StarterKit
     [AddComponentContextMenu(typeof(Image),"Add Image Binder/Image Binder - Sprite")]
     public partial class ImageSpriteMonoBinder : ComponentMonoBinder<Image>, IBinder<Sprite>, IBinder<Texture2D>
     {
-        [Header("Parameters")]
         [SerializeField] private bool _disabledWhenNull = true;
 
         [BinderLog]

--- a/Assets/Plugins/Aspid/MVVM/StarterKit/Unity/Runtime/Binders/InputFields/InputFieldBinder.cs
+++ b/Assets/Plugins/Aspid/MVVM/StarterKit/Unity/Runtime/Binders/InputFields/InputFieldBinder.cs
@@ -23,10 +23,8 @@ namespace Aspid.MVVM.StarterKit
         public event Action<float>? FloatValueChanged;
         public event Action<double>? DoubleValueChanged;
         
-        [Header("Parameter")]
         [SerializeField] private UpdateInputFieldEvent _updateEvent = UpdateInputFieldEvent.OnValueChanged;
         
-        [Header("Converter")]
         [SerializeReferenceDropdown]
         [SerializeReference] private Converter? _converter;
         

--- a/Assets/Plugins/Aspid/MVVM/StarterKit/Unity/Runtime/Binders/InputFields/Mono/InputFieldMonoBinder.cs
+++ b/Assets/Plugins/Aspid/MVVM/StarterKit/Unity/Runtime/Binders/InputFields/Mono/InputFieldMonoBinder.cs
@@ -15,7 +15,7 @@ using Converter = Aspid.MVVM.StarterKit.IConverterString;
 namespace Aspid.MVVM.StarterKit
 {
     [BindModeOverride(IsAll = true)]
-    [AddComponentMenu("Aspid/MVVM/Binders/UI/Text/InputField Binder - Text")]
+    [AddComponentMenu("Aspid/MVVM/Binders/UI/InputField/InputField Binder - Text")]
     [AddPropertyContextMenu(typeof(TMP_InputField), "m_Text")]
     [AddComponentContextMenu(typeof(TMP_InputField),"Add InputField Binder/InputField Binder - Text")]
     public partial class InputFieldMonoBinder : ComponentMonoBinder<TMP_InputField>, 
@@ -26,11 +26,9 @@ namespace Aspid.MVVM.StarterKit
         public event Action<long> LongValueChanged;
         public event Action<float> FloatValueChanged;
         public event Action<double> DoubleValueChanged;
-
-        [Header("Parameter")]
-        [SerializeField] private UpdateInputFieldEvent _updateEvent = UpdateInputFieldEvent.OnValueChanged;
         
-        [Header("Converter")]
+        [SerializeField] private UpdateInputFieldEvent _updateEvent = UpdateInputFieldEvent.OnValueChanged;
+
         [SerializeReferenceDropdown]
         [SerializeReference] private Converter _converter;
         

--- a/Assets/Plugins/Aspid/MVVM/StarterKit/Unity/Runtime/Binders/LineRenderers/LineRendererColorBinder.cs
+++ b/Assets/Plugins/Aspid/MVVM/StarterKit/Unity/Runtime/Binders/LineRenderers/LineRendererColorBinder.cs
@@ -13,10 +13,8 @@ namespace Aspid.MVVM.StarterKit
     [Serializable]
     public class LineRendererColorBinder : TargetBinder<LineRenderer>, IColorBinder
     {
-        [Header("Parameter")]
         [SerializeField] private LineRendererColorMode _colorMode;
         
-        [Header("Converter")]
         [SerializeReferenceDropdown]
         [SerializeReference] private Converter? _converter;
         

--- a/Assets/Plugins/Aspid/MVVM/StarterKit/Unity/Runtime/Binders/LineRenderers/LineRendererColorSwitcherBinder.cs
+++ b/Assets/Plugins/Aspid/MVVM/StarterKit/Unity/Runtime/Binders/LineRenderers/LineRendererColorSwitcherBinder.cs
@@ -15,7 +15,7 @@ namespace Aspid.MVVM.StarterKit
     {
         [SerializeField] private LineRendererColorMode _colorMode;
         
-        [Header("Converter")]
+        [Header("Converters")]
         [SerializeReferenceDropdown]
         [SerializeReference] private Converter? _converter;
 

--- a/Assets/Plugins/Aspid/MVVM/StarterKit/Unity/Runtime/Binders/LineRenderers/Mono/LineRendererColorEnumGroupMonoBinder.cs
+++ b/Assets/Plugins/Aspid/MVVM/StarterKit/Unity/Runtime/Binders/LineRenderers/Mono/LineRendererColorEnumGroupMonoBinder.cs
@@ -13,7 +13,7 @@ namespace Aspid.MVVM.StarterKit
     [AddComponentContextMenu(typeof(LineRenderer),"Add LineRenderer Binder/LineRenderer Binder - Color EnumGroup")]
     public sealed class LineRendererColorEnumGroupMonoBinder : EnumGroupMonoBinder<LineRenderer>
     {
-        [Header("Parameters")]
+        [Header("Values")]
         [SerializeField] private Color _defaultValue;
         [SerializeField] private Color _selectedValue;
         [SerializeField] private LineRendererColorMode _colorMode = LineRendererColorMode.StartAndEnd;

--- a/Assets/Plugins/Aspid/MVVM/StarterKit/Unity/Runtime/Binders/LineRenderers/Mono/LineRendererColorEnumMonoBinder.cs
+++ b/Assets/Plugins/Aspid/MVVM/StarterKit/Unity/Runtime/Binders/LineRenderers/Mono/LineRendererColorEnumMonoBinder.cs
@@ -13,10 +13,8 @@ namespace Aspid.MVVM.StarterKit
     [AddComponentContextMenu(typeof(LineRenderer),"Add LineRenderer Binder/LineRenderer Binder - Color Enum")]
     public sealed class LineRendererColorEnumMonoBinder : EnumMonoBinder<LineRenderer, Color>
     {
-        [Header("Parameter")]
         [SerializeField] private LineRendererColorMode _colorMode = LineRendererColorMode.StartAndEnd;
-     
-        [Header("Converter")]
+        
         [SerializeReferenceDropdown]
         [SerializeReference] private Converter _converter;
         

--- a/Assets/Plugins/Aspid/MVVM/StarterKit/Unity/Runtime/Binders/LineRenderers/Mono/LineRendererColorMonoBinder.cs
+++ b/Assets/Plugins/Aspid/MVVM/StarterKit/Unity/Runtime/Binders/LineRenderers/Mono/LineRendererColorMonoBinder.cs
@@ -13,10 +13,8 @@ namespace Aspid.MVVM.StarterKit
     [AddComponentContextMenu(typeof(LineRenderer),"Add LineRenderer Binder/LineRenderer Binder - Color")]
     public partial class LineRendererColorMonoBinder : ComponentMonoBinder<LineRenderer>, IColorBinder
     {
-        [Header("Parameter")]
         [SerializeField] private LineRendererColorMode _colorMode = LineRendererColorMode.StartAndEnd;
         
-        [Header("Converter")]
         [SerializeReferenceDropdown]
         [SerializeReference] private Converter _converter;
         

--- a/Assets/Plugins/Aspid/MVVM/StarterKit/Unity/Runtime/Binders/LineRenderers/Mono/LineRendererColorSwitcherMonoBinder.cs
+++ b/Assets/Plugins/Aspid/MVVM/StarterKit/Unity/Runtime/Binders/LineRenderers/Mono/LineRendererColorSwitcherMonoBinder.cs
@@ -15,7 +15,7 @@ namespace Aspid.MVVM.StarterKit
     {
         [SerializeField] private LineRendererColorMode _colorMode = LineRendererColorMode.StartAndEnd;
         
-        [Header("Converter")]
+        [Header("Converters")]
         [SerializeReferenceDropdown]
         [SerializeReference] private Converter _converter;
         

--- a/Assets/Plugins/Aspid/MVVM/StarterKit/Unity/Runtime/Binders/LocalizeStringEvents/LocalizeStringEventEntryBinder.cs
+++ b/Assets/Plugins/Aspid/MVVM/StarterKit/Unity/Runtime/Binders/LocalizeStringEvents/LocalizeStringEventEntryBinder.cs
@@ -15,7 +15,6 @@ namespace Aspid.MVVM.StarterKit
     [Serializable]
     public class LocalizeStringEventEntryBinder : TargetBinder<LocalizeStringEvent>, IBinder<string>
     {
-        [Header("Converter")]
         [SerializeReferenceDropdown]
         [SerializeReference] private Converter? _converter;
         

--- a/Assets/Plugins/Aspid/MVVM/StarterKit/Unity/Runtime/Binders/LocalizeStringEvents/LocalizeStringEventEntrySwitcherBinder.cs
+++ b/Assets/Plugins/Aspid/MVVM/StarterKit/Unity/Runtime/Binders/LocalizeStringEvents/LocalizeStringEventEntrySwitcherBinder.cs
@@ -15,7 +15,7 @@ namespace Aspid.MVVM.StarterKit
     [Serializable]
     public sealed class LocalizeStringEventEntrySwitcherBinder : SwitcherBinder<LocalizeStringEvent, string>
     { 
-        [Header("Converter")]
+        [Header("Converters")]
         [SerializeReferenceDropdown]
         [SerializeReference] private Converter? _converter;
         

--- a/Assets/Plugins/Aspid/MVVM/StarterKit/Unity/Runtime/Binders/LocalizeStringEvents/Mono/LocalizeStringEventEntryEnumGroupMonoBinder.cs
+++ b/Assets/Plugins/Aspid/MVVM/StarterKit/Unity/Runtime/Binders/LocalizeStringEvents/Mono/LocalizeStringEventEntryEnumGroupMonoBinder.cs
@@ -15,7 +15,7 @@ namespace Aspid.MVVM.StarterKit
     [AddComponentContextMenu(typeof(LocalizeStringEvent),"Add LocalizeStringEvent Binder/LocalizeStringEvent Binder - Entry EnumGroup")]
     public sealed class LocalizeStringEventEntryEnumGroupMonoBinder : EnumGroupMonoBinder<LocalizeStringEvent>
     {
-        [Header("Parameters")]
+        [Header("Values")]
         [SerializeField] private string _defaultValue;
         [SerializeField] private string _selectedValue;
         

--- a/Assets/Plugins/Aspid/MVVM/StarterKit/Unity/Runtime/Binders/LocalizeStringEvents/Mono/LocalizeStringEventEntryEnumMonoBinder.cs
+++ b/Assets/Plugins/Aspid/MVVM/StarterKit/Unity/Runtime/Binders/LocalizeStringEvents/Mono/LocalizeStringEventEntryEnumMonoBinder.cs
@@ -15,7 +15,6 @@ namespace Aspid.MVVM.StarterKit
     [AddComponentContextMenu(typeof(LocalizeStringEvent),"Add LocalizeStringEvent Binder/LocalizeStringEvent Binder - Entry Enum")]
     public sealed class LocalizeStringEventEntryEnumMonoBinder : EnumMonoBinder<LocalizeStringEvent, string>
     {
-        [Header("Converter")]
         [SerializeReferenceDropdown]
         [SerializeReference] private Converter _converter;
         

--- a/Assets/Plugins/Aspid/MVVM/StarterKit/Unity/Runtime/Binders/LocalizeStringEvents/Mono/LocalizeStringEventEntryMonoBinder.cs
+++ b/Assets/Plugins/Aspid/MVVM/StarterKit/Unity/Runtime/Binders/LocalizeStringEvents/Mono/LocalizeStringEventEntryMonoBinder.cs
@@ -15,7 +15,6 @@ namespace Aspid.MVVM.StarterKit
     [AddComponentContextMenu(typeof(LocalizeStringEvent),"Add LocalizeStringEvent Binder/LocalizeStringEvent Binder - Entry")]
     public partial class LocalizeStringEventEntryMonoBinder : ComponentMonoBinder<LocalizeStringEvent>, IBinder<string>
     {
-        [Header("Converter")]
         [SerializeReferenceDropdown]
         [SerializeReference] private Converter _converter;
         

--- a/Assets/Plugins/Aspid/MVVM/StarterKit/Unity/Runtime/Binders/LocalizeStringEvents/Mono/LocalizeStringEventEntrySwitcherMonoBinder.cs
+++ b/Assets/Plugins/Aspid/MVVM/StarterKit/Unity/Runtime/Binders/LocalizeStringEvents/Mono/LocalizeStringEventEntrySwitcherMonoBinder.cs
@@ -15,7 +15,7 @@ namespace Aspid.MVVM.StarterKit
     [AddComponentContextMenu(typeof(LocalizeStringEvent),"Add LocalizeStringEvent Binder/LocalizeStringEvent Binder - Entry Switcher")]
     public sealed class LocalizeStringEventEntrySwitcherMonoBinder : SwitcherMonoBinder<LocalizeStringEvent, string>
     {
-        [Header("Converter")]
+        [Header("Converters")]
         [SerializeReferenceDropdown]
         [SerializeReference] private Converter _converter;
         

--- a/Assets/Plugins/Aspid/MVVM/StarterKit/Unity/Runtime/Binders/Mono/ComponentMonoBinder.cs
+++ b/Assets/Plugins/Aspid/MVVM/StarterKit/Unity/Runtime/Binders/Mono/ComponentMonoBinder.cs
@@ -6,7 +6,6 @@ namespace Aspid.MVVM.StarterKit
     public abstract class ComponentMonoBinder<TComponent> : MonoBinder
         where TComponent : Component
     {
-        [Header("Component")]
         [SerializeField] private TComponent _component;
         
         private bool _isCached;

--- a/Assets/Plugins/Aspid/MVVM/StarterKit/Unity/Runtime/Binders/Mono/EnumGroupMonoBinder.cs
+++ b/Assets/Plugins/Aspid/MVVM/StarterKit/Unity/Runtime/Binders/Mono/EnumGroupMonoBinder.cs
@@ -6,7 +6,6 @@ namespace Aspid.MVVM.StarterKit
 {
     public abstract partial class EnumGroupMonoBinder<TElement> : MonoBinder, IBinder<Enum>
     {
-        [Header("Enum")]
         [SerializeField] private EnumValues<TElement> _enumValues;
         
         private bool _initialized;

--- a/Assets/Plugins/Aspid/MVVM/StarterKit/Unity/Runtime/Binders/Mono/EnumMonoBinder.cs
+++ b/Assets/Plugins/Aspid/MVVM/StarterKit/Unity/Runtime/Binders/Mono/EnumMonoBinder.cs
@@ -6,7 +6,6 @@ namespace Aspid.MVVM.StarterKit
 {
     public abstract partial class EnumMonoBinder<T> : MonoBinder, IBinder<Enum>
     {
-        [Header("Enum")]
         [SerializeField] private EnumValues<T> _enumValues;
         
         [BinderLog]
@@ -22,7 +21,6 @@ namespace Aspid.MVVM.StarterKit
     public abstract partial class EnumMonoBinder<TComponent, T> : ComponentMonoBinder<TComponent>, IBinder<Enum>
         where TComponent : Component
     {
-        [Header("Enum")]
         [SerializeField] private EnumValues<T> _enumValues;
         
         [BinderLog]

--- a/Assets/Plugins/Aspid/MVVM/StarterKit/Unity/Runtime/Binders/Mono/SwitcherMonoBinder.cs
+++ b/Assets/Plugins/Aspid/MVVM/StarterKit/Unity/Runtime/Binders/Mono/SwitcherMonoBinder.cs
@@ -5,7 +5,7 @@ namespace Aspid.MVVM.StarterKit
 {
     public abstract partial class SwitcherMonoBinder<T> : MonoBinder, IBinder<bool> 
     {
-        [Header("Parameters")]
+        [Header("Values")]
         [SerializeField] private T _trueValue;
         [SerializeField] private T _falseValue;
 
@@ -19,7 +19,7 @@ namespace Aspid.MVVM.StarterKit
     public abstract partial class SwitcherMonoBinder<TComponent, T> : ComponentMonoBinder<TComponent>, IBinder<bool> 
         where TComponent : Component
     {
-        [Header("Parameters")]
+        [Header("Values")]
         [SerializeField] private T _trueValue;
         [SerializeField] private T _falseValue;
 

--- a/Assets/Plugins/Aspid/MVVM/StarterKit/Unity/Runtime/Binders/RawImages/Mono/RawImageMaterialEnumGroupMonoBinder.cs
+++ b/Assets/Plugins/Aspid/MVVM/StarterKit/Unity/Runtime/Binders/RawImages/Mono/RawImageMaterialEnumGroupMonoBinder.cs
@@ -14,7 +14,7 @@ namespace Aspid.MVVM.StarterKit
     [AddComponentContextMenu(typeof(LineRenderer),"Add RawImage Binder/RawImage Binder - Material EnumGroup")]
     public sealed class RawImageMaterialEnumGroupMonoBinder : EnumGroupMonoBinder<RawImage>
     {
-        [Header("Parameters")]
+        [Header("Values")]
         [SerializeField] private Material _defaultValue;
         [SerializeField] private Material _selectedValue;
         

--- a/Assets/Plugins/Aspid/MVVM/StarterKit/Unity/Runtime/Binders/RawImages/Mono/RawImageMaterialEnumMonoBinder.cs
+++ b/Assets/Plugins/Aspid/MVVM/StarterKit/Unity/Runtime/Binders/RawImages/Mono/RawImageMaterialEnumMonoBinder.cs
@@ -14,7 +14,6 @@ namespace Aspid.MVVM.StarterKit
     [AddComponentContextMenu(typeof(LineRenderer),"Add RawImage Binder/RawImage Binder - Material Enum")]
     public sealed class RawImageMaterialEnumMonoBinder : EnumMonoBinder<RawImage, Material>
     {
-        [Header("Converter")]
         [SerializeReferenceDropdown]
         [SerializeReference] private Converter _converter;
         

--- a/Assets/Plugins/Aspid/MVVM/StarterKit/Unity/Runtime/Binders/RawImages/Mono/RawImageMaterialMonoBinder.cs
+++ b/Assets/Plugins/Aspid/MVVM/StarterKit/Unity/Runtime/Binders/RawImages/Mono/RawImageMaterialMonoBinder.cs
@@ -14,7 +14,6 @@ namespace Aspid.MVVM.StarterKit
     [AddComponentContextMenu(typeof(LineRenderer),"Add RawImage Binder/RawImage Binder - Material")]
     public partial class RawImageMaterialMonoBinder : ComponentMonoBinder<RawImage>, IBinder<Material>
     {
-        [Header("Converter")]
         [SerializeReferenceDropdown]
         [SerializeReference] private Converter _converter;
         

--- a/Assets/Plugins/Aspid/MVVM/StarterKit/Unity/Runtime/Binders/RawImages/Mono/RawImageMaterialSwitcherMonoBinder.cs
+++ b/Assets/Plugins/Aspid/MVVM/StarterKit/Unity/Runtime/Binders/RawImages/Mono/RawImageMaterialSwitcherMonoBinder.cs
@@ -14,7 +14,7 @@ namespace Aspid.MVVM.StarterKit
     [AddComponentContextMenu(typeof(LineRenderer),"Add RawImage Binder/RawImage Binder - Material Switcher")]
     public sealed class RawImageMaterialSwitcherMonoBinder : SwitcherMonoBinder<RawImage, Material>
     {
-        [Header("Converter")]
+        [Header("Converters")]
         [SerializeReferenceDropdown]
         [SerializeReference] private Converter _converter;
         

--- a/Assets/Plugins/Aspid/MVVM/StarterKit/Unity/Runtime/Binders/RawImages/Mono/RawImageTextureAddressableMonoBinder.cs
+++ b/Assets/Plugins/Aspid/MVVM/StarterKit/Unity/Runtime/Binders/RawImages/Mono/RawImageTextureAddressableMonoBinder.cs
@@ -10,7 +10,6 @@ namespace Aspid.MVVM.StarterKit
     [AddComponentContextMenu(typeof(RawImage), "Add RawImage Binder/RawImage Binder - Texture Addressable")]
     public sealed class RawImageTextureAddressableMonoBinder : AddressableMonoBinder<Texture2D, RawImage>
     {
-        [Header("Parameters")]
         [SerializeField] private Texture2D _defaultTexture;
         [SerializeField] private bool _disabledWhenNull = true;
         

--- a/Assets/Plugins/Aspid/MVVM/StarterKit/Unity/Runtime/Binders/RawImages/Mono/RawImageTextureEnumGroupMonoBinder.cs
+++ b/Assets/Plugins/Aspid/MVVM/StarterKit/Unity/Runtime/Binders/RawImages/Mono/RawImageTextureEnumGroupMonoBinder.cs
@@ -9,7 +9,7 @@ namespace Aspid.MVVM.StarterKit
     [AddComponentContextMenu(typeof(LineRenderer),"Add RawImage Binder/RawImage Binder - Texture EnumGroup")]
     public sealed class RawImageTextureEnumGroupMonoBinder : EnumGroupMonoBinder<RawImage>
     {
-        [Header("Parameters")]
+        [Header("Values")]
         [SerializeField] private Texture2D _defaultValue;
         [SerializeField] private Texture2D _selectedValue;
         

--- a/Assets/Plugins/Aspid/MVVM/StarterKit/Unity/Runtime/Binders/RawImages/Mono/RawImageTextureEnumMonoBinder.cs
+++ b/Assets/Plugins/Aspid/MVVM/StarterKit/Unity/Runtime/Binders/RawImages/Mono/RawImageTextureEnumMonoBinder.cs
@@ -9,7 +9,6 @@ namespace Aspid.MVVM.StarterKit
     [AddComponentContextMenu(typeof(LineRenderer),"Add RawImage Binder/RawImage Binder - Texture Enum")]
     public sealed class RawImageTextureEnumMonoBinder : EnumMonoBinder<RawImage, Texture2D>
     {
-        [Header("Parameter")]
         [SerializeField] private bool _disabledWhenNull = true;
         
         protected override void SetValue(Texture2D value)

--- a/Assets/Plugins/Aspid/MVVM/StarterKit/Unity/Runtime/Binders/RawImages/Mono/RawImageTextureMonoBinder.cs
+++ b/Assets/Plugins/Aspid/MVVM/StarterKit/Unity/Runtime/Binders/RawImages/Mono/RawImageTextureMonoBinder.cs
@@ -9,7 +9,6 @@ namespace Aspid.MVVM.StarterKit
     [AddComponentContextMenu(typeof(RawImage),"Add RawImage Binder/RawImage Binder - Texture")]
     public partial class RawImageTextureMonoBinder : ComponentMonoBinder<RawImage>, IBinder<Texture2D>, IBinder<Sprite>
     {
-        [Header("Parameter")]
         [SerializeField] private bool _disabledWhenNull = true;
         
         [BinderLog]

--- a/Assets/Plugins/Aspid/MVVM/StarterKit/Unity/Runtime/Binders/RawImages/RawImageMaterialBinder.cs
+++ b/Assets/Plugins/Aspid/MVVM/StarterKit/Unity/Runtime/Binders/RawImages/RawImageMaterialBinder.cs
@@ -14,7 +14,6 @@ namespace Aspid.MVVM.StarterKit
     [Serializable]
     public class RawImageMaterialBinder : TargetBinder<RawImage>, IBinder<Material?>
     {
-        [Header("Converter")]
         [SerializeReferenceDropdown]
         [SerializeReference] private Converter? _converter;
         

--- a/Assets/Plugins/Aspid/MVVM/StarterKit/Unity/Runtime/Binders/RawImages/RawImageMaterialSwitcherBinder.cs
+++ b/Assets/Plugins/Aspid/MVVM/StarterKit/Unity/Runtime/Binders/RawImages/RawImageMaterialSwitcherBinder.cs
@@ -14,7 +14,7 @@ namespace Aspid.MVVM.StarterKit
     [Serializable]
     public sealed class RawImageMaterialSwitcherBinder : SwitcherBinder<RawImage, Material>
     {
-        [Header("Converter")]
+        [Header("Converters")]
         [SerializeReferenceDropdown]
         [SerializeReference] private Converter? _converter;
         

--- a/Assets/Plugins/Aspid/MVVM/StarterKit/Unity/Runtime/Binders/RawImages/RawImageTextureBinder.cs
+++ b/Assets/Plugins/Aspid/MVVM/StarterKit/Unity/Runtime/Binders/RawImages/RawImageTextureBinder.cs
@@ -9,7 +9,6 @@ namespace Aspid.MVVM.StarterKit
     [Serializable]
     public class RawImageTextureBinder : TargetBinder<RawImage>, IBinder<Texture2D?>, IBinder<Sprite?>
     {
-        [Header("Parameter")]
         [SerializeField] private bool _disabledWhenNull;
 
         public RawImageTextureBinder(RawImage target, BindMode mode)

--- a/Assets/Plugins/Aspid/MVVM/StarterKit/Unity/Runtime/Binders/RawImages/RawImageTextureSwitcherBinder.cs
+++ b/Assets/Plugins/Aspid/MVVM/StarterKit/Unity/Runtime/Binders/RawImages/RawImageTextureSwitcherBinder.cs
@@ -10,7 +10,6 @@ namespace Aspid.MVVM.StarterKit
     public sealed class RawImageTextureSwitcherBinder : SwitcherBinder<RawImage, Texture2D?>
     {
         // ReSharper disable once MemberInitializerValueIgnored
-        [Header("Parameter")]
         [SerializeField] private bool _disabledWhenNull = true;
 
         public RawImageTextureSwitcherBinder(

--- a/Assets/Plugins/Aspid/MVVM/StarterKit/Unity/Runtime/Binders/Renderers/Mono/RendererMaterialsColorEnumGroupMonoBinder.cs
+++ b/Assets/Plugins/Aspid/MVVM/StarterKit/Unity/Runtime/Binders/Renderers/Mono/RendererMaterialsColorEnumGroupMonoBinder.cs
@@ -13,7 +13,7 @@ namespace Aspid.MVVM.StarterKit
     [AddComponentContextMenu(typeof(Renderer),"Add Renderer Binder/Renderer Binder - MaterialsColor EnumGroup")]
     public sealed class RendererMaterialsColorEnumGroupMonoBinder : EnumGroupMonoBinder<Renderer>
     {
-        [Header("Parameters")]
+        [Header("Values")]
         [SerializeField] private Color _defaultValue;
         [SerializeField] private Color _selectedValues;
         [SerializeField] private string _colorPropertyName = "_BaseColor";

--- a/Assets/Plugins/Aspid/MVVM/StarterKit/Unity/Runtime/Binders/Renderers/Mono/RendererMaterialsColorEnumMonoBinder.cs
+++ b/Assets/Plugins/Aspid/MVVM/StarterKit/Unity/Runtime/Binders/Renderers/Mono/RendererMaterialsColorEnumMonoBinder.cs
@@ -13,10 +13,8 @@ namespace Aspid.MVVM.StarterKit
     [AddComponentContextMenu(typeof(Renderer),"Add Renderer Binder/Renderer Binder - MaterialsColor Enum")]
     public sealed class RendererMaterialsColorEnumMonoBinder : EnumMonoBinder<Renderer, Color>
     {
-        [Header("Parameter")]
         [SerializeField] private string _colorPropertyName = "_BaseColor";
-
-        [Header("Converter")]
+        
         [SerializeReferenceDropdown]
         [SerializeReference] private Converter _converter;
         

--- a/Assets/Plugins/Aspid/MVVM/StarterKit/Unity/Runtime/Binders/Renderers/Mono/RendererMaterialsColorMonoBinder.cs
+++ b/Assets/Plugins/Aspid/MVVM/StarterKit/Unity/Runtime/Binders/Renderers/Mono/RendererMaterialsColorMonoBinder.cs
@@ -13,10 +13,8 @@ namespace Aspid.MVVM.StarterKit
     [AddComponentContextMenu(typeof(Renderer),"Add Renderer Binder/Renderer Binder - MaterialsColor")]
     public partial class RendererMaterialsColorMonoBinder : ComponentMonoBinder<Renderer>, IColorBinder
     {
-        [Header("Parameter")]
         [SerializeField] private string _colorPropertyName = "_BaseColor";
         
-        [Header("Converter")]
         [SerializeReferenceDropdown]
         [SerializeReference] private Converter _converter;
 

--- a/Assets/Plugins/Aspid/MVVM/StarterKit/Unity/Runtime/Binders/Renderers/Mono/RendererMaterialsColorSwitcherMonoBinder.cs
+++ b/Assets/Plugins/Aspid/MVVM/StarterKit/Unity/Runtime/Binders/Renderers/Mono/RendererMaterialsColorSwitcherMonoBinder.cs
@@ -15,7 +15,7 @@ namespace Aspid.MVVM.StarterKit
     {
         [SerializeField] private string _colorPropertyName = "_BaseColor";
         
-        [Header("Converter")]
+        [Header("Converters")]
         [SerializeReferenceDropdown]
         [SerializeReference] private Converter _converter;
 

--- a/Assets/Plugins/Aspid/MVVM/StarterKit/Unity/Runtime/Binders/Renderers/Mono/RendererMaterialsEnumGroupMonoBinder.cs
+++ b/Assets/Plugins/Aspid/MVVM/StarterKit/Unity/Runtime/Binders/Renderers/Mono/RendererMaterialsEnumGroupMonoBinder.cs
@@ -13,7 +13,7 @@ namespace Aspid.MVVM.StarterKit
     [AddComponentContextMenu(typeof(Renderer),"Add Renderer Binder/Renderer Binder - Materials EnumGroup")]
     public sealed class RendererMaterialsEnumGroupMonoBinder : EnumGroupMonoBinder<Renderer>
     {
-        [Header("Parameters")]
+        [Header("Values")]
         [SerializeField] private Material[] _defaultValue;
         [SerializeField] private Material[] _selectedValue;
         

--- a/Assets/Plugins/Aspid/MVVM/StarterKit/Unity/Runtime/Binders/Renderers/Mono/RendererMaterialsEnumMonoBinder.cs
+++ b/Assets/Plugins/Aspid/MVVM/StarterKit/Unity/Runtime/Binders/Renderers/Mono/RendererMaterialsEnumMonoBinder.cs
@@ -13,7 +13,6 @@ namespace Aspid.MVVM.StarterKit
     [AddComponentContextMenu(typeof(Renderer),"Add Renderer Binder/Renderer Binder - Materials Enum")]
     public sealed class RendererMaterialsEnumMonoBinder : EnumMonoBinder<Renderer, Material[]>
     {
-        [Header("Converter")]
         [SerializeReferenceDropdown]
         [SerializeReference] private Converter _converter;
         

--- a/Assets/Plugins/Aspid/MVVM/StarterKit/Unity/Runtime/Binders/Renderers/Mono/RendererMaterialsMonoBinder.cs
+++ b/Assets/Plugins/Aspid/MVVM/StarterKit/Unity/Runtime/Binders/Renderers/Mono/RendererMaterialsMonoBinder.cs
@@ -14,7 +14,6 @@ namespace Aspid.MVVM.StarterKit
     [AddComponentContextMenu(typeof(Renderer),"Add Renderer Binder/Renderer Binder - Materials")]
     public partial class RendererMaterialsMonoBinder : ComponentMonoBinder<Renderer>, IBinder<Material>, IBinder<Material[]>, IBinder<IReadOnlyCollection<Material>>
     {
-        [Header("Converter")]
         [SerializeReferenceDropdown]
         [SerializeReference] private Converter _converter;
         

--- a/Assets/Plugins/Aspid/MVVM/StarterKit/Unity/Runtime/Binders/Renderers/Mono/RendererMaterialsSwitcherMonoBinder.cs
+++ b/Assets/Plugins/Aspid/MVVM/StarterKit/Unity/Runtime/Binders/Renderers/Mono/RendererMaterialsSwitcherMonoBinder.cs
@@ -13,7 +13,7 @@ namespace Aspid.MVVM.StarterKit
     [AddComponentContextMenu(typeof(Renderer),"Add Renderer Binder/Renderer Binder - Materials Switcher")]
     public sealed class RendererMaterialsSwitcherMonoBinder : SwitcherMonoBinder<Renderer, Material[]>
     {
-        [Header("Converter")]
+        [Header("Converters")]
         [SerializeReferenceDropdown]
         [SerializeReference] private Converter _converter;
 

--- a/Assets/Plugins/Aspid/MVVM/StarterKit/Unity/Runtime/Binders/Renderers/RendererMaterialColorBinder.cs
+++ b/Assets/Plugins/Aspid/MVVM/StarterKit/Unity/Runtime/Binders/Renderers/RendererMaterialColorBinder.cs
@@ -14,10 +14,8 @@ namespace Aspid.MVVM.StarterKit
     public class RendererMaterialColorBinder : TargetBinder<Renderer>, IColorBinder
     {
         // ReSharper disable once MemberInitializerValueIgnored
-        [Header("Parameter")]
         [SerializeField] private string _colorPropertyName = "_BaseColor";
         
-        [Header("Converter")]
         [SerializeReferenceDropdown]
         [SerializeReference] private Converter? _converter;
 

--- a/Assets/Plugins/Aspid/MVVM/StarterKit/Unity/Runtime/Binders/Renderers/RendererMaterialColorSwitcherBinder.cs
+++ b/Assets/Plugins/Aspid/MVVM/StarterKit/Unity/Runtime/Binders/Renderers/RendererMaterialColorSwitcherBinder.cs
@@ -16,7 +16,7 @@ namespace Aspid.MVVM.StarterKit
         // ReSharper disable once MemberInitializerValueIgnored
         [SerializeField] private string _colorPropertyName = "_BaseColor";
         
-        [Header("Converter")]
+        [Header("Converters")]
         [SerializeReferenceDropdown]
         [SerializeReference] private Converter? _converter;
 

--- a/Assets/Plugins/Aspid/MVVM/StarterKit/Unity/Runtime/Binders/Renderers/RendererMaterialsBinder.cs
+++ b/Assets/Plugins/Aspid/MVVM/StarterKit/Unity/Runtime/Binders/Renderers/RendererMaterialsBinder.cs
@@ -14,7 +14,6 @@ namespace Aspid.MVVM.StarterKit
     [Serializable]
     public class RendererMaterialsBinder : TargetBinder<Renderer>, IBinder<Material>, IBinder<Material[]>, IBinder<IReadOnlyCollection<Material>>
     {
-        [Header("Converter")]
         [SerializeReferenceDropdown]
         [SerializeReference] private Converter? _converter;
         

--- a/Assets/Plugins/Aspid/MVVM/StarterKit/Unity/Runtime/Binders/Renderers/RendererMaterialsSwitcherBinder.cs
+++ b/Assets/Plugins/Aspid/MVVM/StarterKit/Unity/Runtime/Binders/Renderers/RendererMaterialsSwitcherBinder.cs
@@ -13,7 +13,7 @@ namespace Aspid.MVVM.StarterKit
     [Serializable]
     public sealed class RendererMaterialsSwitcherBinder : SwitcherBinder<Renderer, Material[]?>
     {
-        [Header("Converter")]
+        [Header("Converters")]
         [SerializeReferenceDropdown]
         [SerializeReference] private Converter? _converter;
         

--- a/Assets/Plugins/Aspid/MVVM/StarterKit/Unity/Runtime/Binders/Sliders/Mono/SliderMinMaxEnumGroupMonoBinder.cs
+++ b/Assets/Plugins/Aspid/MVVM/StarterKit/Unity/Runtime/Binders/Sliders/Mono/SliderMinMaxEnumGroupMonoBinder.cs
@@ -15,7 +15,7 @@ namespace Aspid.MVVM.StarterKit
     [AddComponentContextMenu(typeof(Slider),"Add Slider Binder/Slider Binder - MinMax EnumGroup")]
     public sealed class SliderMinMaxEnumGroupMonoBinder : EnumGroupMonoBinder<Slider>
     {
-        [Header("Parameters")]
+        [Header("Values")]
         [SerializeField] private Vector2 _defaultValue;
         [SerializeField] private Vector2 _selectedValue;
         [SerializeField] private SliderValueMode _valueMode = SliderValueMode.Range;

--- a/Assets/Plugins/Aspid/MVVM/StarterKit/Unity/Runtime/Binders/Sliders/Mono/SliderMinMaxEnumMonoBinder.cs
+++ b/Assets/Plugins/Aspid/MVVM/StarterKit/Unity/Runtime/Binders/Sliders/Mono/SliderMinMaxEnumMonoBinder.cs
@@ -15,10 +15,8 @@ namespace Aspid.MVVM.StarterKit
     [AddComponentContextMenu(typeof(Slider),"Add Slider Binder/Slider Binder - MinMax Enum")]
     public sealed class SliderMinMaxEnumMonoBinder : EnumMonoBinder<Slider, Vector2>
     {
-        [Header("Parameter")]
         [SerializeField] private SliderValueMode _valueMode = SliderValueMode.Range;
         
-        [Header("Converter")]
         [SerializeReferenceDropdown]
         [SerializeReference] private Converter _converter;
         

--- a/Assets/Plugins/Aspid/MVVM/StarterKit/Unity/Runtime/Binders/Sliders/Mono/SliderMinMaxMonoBinder.cs
+++ b/Assets/Plugins/Aspid/MVVM/StarterKit/Unity/Runtime/Binders/Sliders/Mono/SliderMinMaxMonoBinder.cs
@@ -15,10 +15,8 @@ namespace Aspid.MVVM.StarterKit
     [AddComponentContextMenu(typeof(Slider),"Add Slider Binder/Slider Binder - MinMax")]
     public partial class SliderMinMaxMonoBinder : ComponentMonoBinder<Slider>, IBinder<Vector2>, INumberBinder
     {
-        [Header("Parameter")]
         [SerializeField] private SliderValueMode _valueMode = SliderValueMode.Range;
         
-        [Header("Converter")]
         [SerializeReferenceDropdown]
         [SerializeReference] private Converter _converter;
         

--- a/Assets/Plugins/Aspid/MVVM/StarterKit/Unity/Runtime/Binders/Sliders/Mono/SliderMinMaxSwitcherMonoBinder.cs
+++ b/Assets/Plugins/Aspid/MVVM/StarterKit/Unity/Runtime/Binders/Sliders/Mono/SliderMinMaxSwitcherMonoBinder.cs
@@ -17,7 +17,7 @@ namespace Aspid.MVVM.StarterKit
     {
         [SerializeField] private SliderValueMode _valueMode = SliderValueMode.Range;
         
-        [Header("Converter")]
+        [Header("Converters")]
         [SerializeReferenceDropdown]
         [SerializeReference] private Converter _converter;
 

--- a/Assets/Plugins/Aspid/MVVM/StarterKit/Unity/Runtime/Binders/Sliders/Mono/SliderValueEnumGroupMonoBinder.cs
+++ b/Assets/Plugins/Aspid/MVVM/StarterKit/Unity/Runtime/Binders/Sliders/Mono/SliderValueEnumGroupMonoBinder.cs
@@ -14,7 +14,7 @@ namespace Aspid.MVVM.StarterKit
     [AddComponentContextMenu(typeof(Slider),"Add Slider Binder/Slider Binder - Value EnumGroup")]
     public sealed class SliderValueEnumGroupMonoBinder : EnumGroupMonoBinder<Slider>
     {
-        [Header("Parameters")]
+        [Header("Values")]
         [SerializeField] private float _defaultValue;
         [SerializeField] private float _selectedValue;
         

--- a/Assets/Plugins/Aspid/MVVM/StarterKit/Unity/Runtime/Binders/Sliders/Mono/SliderValueEnumMonoBinder.cs
+++ b/Assets/Plugins/Aspid/MVVM/StarterKit/Unity/Runtime/Binders/Sliders/Mono/SliderValueEnumMonoBinder.cs
@@ -14,7 +14,6 @@ namespace Aspid.MVVM.StarterKit
     [AddComponentContextMenu(typeof(Slider),"Add Slider Binder/Slider Binder - Value Enum")]
     public sealed class SliderValueEnumMonoBinder : EnumMonoBinder<Slider, float>
     {
-        [Header("Converter")]
         [SerializeReferenceDropdown]
         [SerializeReference] private Converter _converter;
 

--- a/Assets/Plugins/Aspid/MVVM/StarterKit/Unity/Runtime/Binders/Sliders/Mono/SliderValueMonoBinder.cs
+++ b/Assets/Plugins/Aspid/MVVM/StarterKit/Unity/Runtime/Binders/Sliders/Mono/SliderValueMonoBinder.cs
@@ -22,7 +22,6 @@ namespace Aspid.MVVM.StarterKit
         public event Action<float> FloatValueChanged;
         public event Action<double> DoubleValueChanged;
         
-        [Header("Converter")]
         [SerializeReferenceDropdown]
         [SerializeReference] private Converter _converter;
 

--- a/Assets/Plugins/Aspid/MVVM/StarterKit/Unity/Runtime/Binders/Sliders/Mono/SliderValueSwitcherMonoBinder.cs
+++ b/Assets/Plugins/Aspid/MVVM/StarterKit/Unity/Runtime/Binders/Sliders/Mono/SliderValueSwitcherMonoBinder.cs
@@ -14,7 +14,7 @@ namespace Aspid.MVVM.StarterKit
     [AddComponentContextMenu(typeof(Slider),"Add Slider Binder/Slider Binder - Value Switcher")]
     public sealed class SliderValueSwitcherMonoBinder : SwitcherMonoBinder<Slider, float>
     {
-        [Header("Converter")]
+        [Header("Converters")]
         [SerializeReferenceDropdown]
         [SerializeReference] private Converter _converter;
         

--- a/Assets/Plugins/Aspid/MVVM/StarterKit/Unity/Runtime/Binders/Sliders/SliderMinMaxBinder.cs
+++ b/Assets/Plugins/Aspid/MVVM/StarterKit/Unity/Runtime/Binders/Sliders/SliderMinMaxBinder.cs
@@ -14,10 +14,8 @@ namespace Aspid.MVVM.StarterKit
     [Serializable]
     public class SliderMinMaxBinder : TargetBinder<Slider>, IBinder<Vector2>
     {
-        [Header("Parameter")]
         [SerializeField] private SliderValueMode _valueMode;
         
-        [Header("Converter")]
         [SerializeReferenceDropdown]
         [SerializeReference] private Converter? _converter;
         

--- a/Assets/Plugins/Aspid/MVVM/StarterKit/Unity/Runtime/Binders/Sliders/SliderMinMaxSwitcherBinder.cs
+++ b/Assets/Plugins/Aspid/MVVM/StarterKit/Unity/Runtime/Binders/Sliders/SliderMinMaxSwitcherBinder.cs
@@ -16,7 +16,7 @@ namespace Aspid.MVVM.StarterKit
     {
         [SerializeField] private SliderValueMode _valueMode;
         
-        [Header("Converter")]
+        [Header("Converters")]
         [SerializeReferenceDropdown]
         [SerializeReference] private Converter? _converter;
 

--- a/Assets/Plugins/Aspid/MVVM/StarterKit/Unity/Runtime/Binders/Sliders/SliderValueBinder.cs
+++ b/Assets/Plugins/Aspid/MVVM/StarterKit/Unity/Runtime/Binders/Sliders/SliderValueBinder.cs
@@ -22,7 +22,6 @@ namespace Aspid.MVVM.StarterKit
 
         private bool _isNotifyValueChanged = true;
         
-        [Header("Converter")]
         [SerializeReferenceDropdown]
         [SerializeReference] private Converter? _converter;
         

--- a/Assets/Plugins/Aspid/MVVM/StarterKit/Unity/Runtime/Binders/Texts/Localizations/TextLocalizationEntryBinder.cs
+++ b/Assets/Plugins/Aspid/MVVM/StarterKit/Unity/Runtime/Binders/Texts/Localizations/TextLocalizationEntryBinder.cs
@@ -21,7 +21,6 @@ namespace Aspid.MVVM.StarterKit
         [SerializeField] private LocalizedString _stringReference = new();
         [SerializeField] private List<Object> _formatArguments = new();
         
-        [Header("Converter")]
         [SerializeReferenceDropdown]
         [SerializeReference] private Converter? _converter;
 

--- a/Assets/Plugins/Aspid/MVVM/StarterKit/Unity/Runtime/Binders/Texts/Localizations/TextLocalizationEntrySwitcherBinder.cs
+++ b/Assets/Plugins/Aspid/MVVM/StarterKit/Unity/Runtime/Binders/Texts/Localizations/TextLocalizationEntrySwitcherBinder.cs
@@ -21,7 +21,7 @@ namespace Aspid.MVVM.StarterKit
         [SerializeField] private LocalizedString _stringReference = new();
         [SerializeField] private List<Object> _formatArguments = new();
         
-        [Header("Converter")]
+        [Header("Converters")]
         [SerializeReferenceDropdown]
         [SerializeReference] private Converter? _converter;
 

--- a/Assets/Plugins/Aspid/MVVM/StarterKit/Unity/Runtime/Binders/Texts/Mono/Localizations/TextLocalizationEntryEnumMonoBinder.cs
+++ b/Assets/Plugins/Aspid/MVVM/StarterKit/Unity/Runtime/Binders/Texts/Mono/Localizations/TextLocalizationEntryEnumMonoBinder.cs
@@ -20,7 +20,6 @@ namespace Aspid.MVVM.StarterKit
         [SerializeField] private LocalizedString _stringReference = new();
         [SerializeField] private List<Object> _formatArguments = new();
         
-        [Header("Converter")]
         [SerializeReferenceDropdown]
         [SerializeReference] private Converter _converter;
         

--- a/Assets/Plugins/Aspid/MVVM/StarterKit/Unity/Runtime/Binders/Texts/Mono/Localizations/TextLocalizationEntryMonoBinder.cs
+++ b/Assets/Plugins/Aspid/MVVM/StarterKit/Unity/Runtime/Binders/Texts/Mono/Localizations/TextLocalizationEntryMonoBinder.cs
@@ -21,7 +21,6 @@ namespace Aspid.MVVM.StarterKit
         [SerializeField] private LocalizedString _stringReference = new();
         [SerializeField] private List<Object> _formatArguments = new();
         
-        [Header("Converter")]
         [SerializeReferenceDropdown]
         [SerializeReference] private Converter _converter;
 

--- a/Assets/Plugins/Aspid/MVVM/StarterKit/Unity/Runtime/Binders/Texts/Mono/Localizations/TextLocalizationEntrySwitcherMonoBinder.cs
+++ b/Assets/Plugins/Aspid/MVVM/StarterKit/Unity/Runtime/Binders/Texts/Mono/Localizations/TextLocalizationEntrySwitcherMonoBinder.cs
@@ -20,7 +20,7 @@ namespace Aspid.MVVM.StarterKit
         [SerializeField] private LocalizedString _stringReference = new();
         [SerializeField] private List<Object> _formatArguments = new();
         
-        [Header("Converter")]
+        [Header("Converters")]
         [SerializeReferenceDropdown]
         [SerializeReference] private Converter _converter;
         

--- a/Assets/Plugins/Aspid/MVVM/StarterKit/Unity/Runtime/Binders/Texts/Mono/TextAlignmentEnumGroupMonoBinder.cs
+++ b/Assets/Plugins/Aspid/MVVM/StarterKit/Unity/Runtime/Binders/Texts/Mono/TextAlignmentEnumGroupMonoBinder.cs
@@ -8,7 +8,7 @@ namespace Aspid.MVVM.StarterKit
 {
     public sealed class TextAlignmentEnumGroupMonoBinder : EnumGroupMonoBinder<TMP_Text>
     {
-        [Header("Parameters")]
+        [Header("Values")]
         [SerializeField] private TextAlignmentOptions _defaultValue;
         [SerializeField] private TextAlignmentOptions _selectedValue;
 

--- a/Assets/Plugins/Aspid/MVVM/StarterKit/Unity/Runtime/Binders/Texts/Mono/TextEnumGroupMonoBinder.cs
+++ b/Assets/Plugins/Aspid/MVVM/StarterKit/Unity/Runtime/Binders/Texts/Mono/TextEnumGroupMonoBinder.cs
@@ -15,7 +15,7 @@ namespace Aspid.MVVM.StarterKit
     [AddComponentContextMenu(typeof(TMP_Text),"Add Text Binder/Text Binder - Text EnumGroup")]
     public sealed class TextEnumGroupMonoBinder : EnumGroupMonoBinder<TMP_Text>
     {
-        [Header("Parameters")]
+        [Header("Values")]
         [SerializeField] private string _defaultValue;
         [SerializeField] private string _selectedValue;
         

--- a/Assets/Plugins/Aspid/MVVM/StarterKit/Unity/Runtime/Binders/Texts/Mono/TextEnumMonoBinder.cs
+++ b/Assets/Plugins/Aspid/MVVM/StarterKit/Unity/Runtime/Binders/Texts/Mono/TextEnumMonoBinder.cs
@@ -15,7 +15,6 @@ namespace Aspid.MVVM.StarterKit
     [AddComponentContextMenu(typeof(TMP_Text),"Add Text Binder/Text Binder - Text Enum")]
     public sealed class TextEnumMonoBinder : EnumMonoBinder<TMP_Text, string>
     {
-        [Header("Converter")]
         [SerializeReferenceDropdown]
         [SerializeReference] private Converter _converter;
         

--- a/Assets/Plugins/Aspid/MVVM/StarterKit/Unity/Runtime/Binders/Texts/Mono/TextFontEnumGroupMonoBinder.cs
+++ b/Assets/Plugins/Aspid/MVVM/StarterKit/Unity/Runtime/Binders/Texts/Mono/TextFontEnumGroupMonoBinder.cs
@@ -10,7 +10,7 @@ namespace Aspid.MVVM.StarterKit
     [AddComponentContextMenu(typeof(TMP_Text),"Add Text Binder/Text Binder - Font Enum Group")]
     public sealed class TextFontEnumGroupMonoBinder : EnumGroupMonoBinder<TMP_Text>
     {
-        [Header("Parameters")]
+        [Header("Values")]
         [SerializeField] private TMP_FontAsset _defaultValue;
         [SerializeField] private TMP_FontAsset _selectedValue;
             

--- a/Assets/Plugins/Aspid/MVVM/StarterKit/Unity/Runtime/Binders/Texts/Mono/TextFontSizeEnumGroupMonoBinder.cs
+++ b/Assets/Plugins/Aspid/MVVM/StarterKit/Unity/Runtime/Binders/Texts/Mono/TextFontSizeEnumGroupMonoBinder.cs
@@ -15,7 +15,7 @@ namespace Aspid.MVVM.StarterKit
     [AddComponentContextMenu(typeof(TMP_Text),"Add Text Binder/Text Binder - FontSize EnumGroup")]
     public sealed class TextFontSizeEnumGroupMonoBinder : EnumGroupMonoBinder<TMP_Text>
     {
-        [Header("Parameters")]
+        [Header("Values")]
         [SerializeField] private float _defaultValue;
         [SerializeField] private float _selectedValue;
         

--- a/Assets/Plugins/Aspid/MVVM/StarterKit/Unity/Runtime/Binders/Texts/Mono/TextFontSizeEnumMonoBinder.cs
+++ b/Assets/Plugins/Aspid/MVVM/StarterKit/Unity/Runtime/Binders/Texts/Mono/TextFontSizeEnumMonoBinder.cs
@@ -15,7 +15,6 @@ namespace Aspid.MVVM.StarterKit
     [AddComponentContextMenu(typeof(TMP_Text),"Add Text Binder/Text Binder - FontSize Enum")]
     public sealed class TextFontSizeEnumMonoBinder : EnumMonoBinder<TMP_Text, float>
     {
-        [Header("Converter")]
         [SerializeReferenceDropdown]
         [SerializeReference] private Converter _converter;
         

--- a/Assets/Plugins/Aspid/MVVM/StarterKit/Unity/Runtime/Binders/Texts/Mono/TextFontSizeMonoBinder.cs
+++ b/Assets/Plugins/Aspid/MVVM/StarterKit/Unity/Runtime/Binders/Texts/Mono/TextFontSizeMonoBinder.cs
@@ -15,7 +15,6 @@ namespace Aspid.MVVM.StarterKit
     [AddComponentContextMenu(typeof(TMP_Text),"Add Text Binder/Text Binder - FontSize")]
     public partial class TextFontSizeMonoBinder : ComponentMonoBinder<TMP_Text>, INumberBinder
     {
-        [Header("Converter")]
         [SerializeReferenceDropdown]
         [SerializeReference] private Converter _converter;
         

--- a/Assets/Plugins/Aspid/MVVM/StarterKit/Unity/Runtime/Binders/Texts/Mono/TextFontSizeSwitcherMonoBinder.cs
+++ b/Assets/Plugins/Aspid/MVVM/StarterKit/Unity/Runtime/Binders/Texts/Mono/TextFontSizeSwitcherMonoBinder.cs
@@ -15,7 +15,7 @@ namespace Aspid.MVVM.StarterKit
     [AddComponentContextMenu(typeof(TMP_Text),"Add Text Binder/Text Binder - FontSize Switcher")]
     public sealed class TextFontSizeSwitcherMonoBinder : SwitcherMonoBinder<TMP_Text, float>
     {
-        [Header("Converter")]
+        [Header("Converters")]
         [SerializeReferenceDropdown]
         [SerializeReference] private Converter _converter;
         

--- a/Assets/Plugins/Aspid/MVVM/StarterKit/Unity/Runtime/Binders/Texts/Mono/TextMonoBinder.cs
+++ b/Assets/Plugins/Aspid/MVVM/StarterKit/Unity/Runtime/Binders/Texts/Mono/TextMonoBinder.cs
@@ -16,7 +16,6 @@ namespace Aspid.MVVM.StarterKit
     [AddComponentContextMenu(typeof(TMP_Text),"Add Text Binder/Text Binder - Text")]
     public partial class TextMonoBinder : ComponentMonoBinder<TMP_Text>, IBinder<string>, INumberBinder
     {
-        [Header("Converter")]
         [SerializeReferenceDropdown]
         [SerializeReference] private Converter _converter = new StringFormatConverter();
         

--- a/Assets/Plugins/Aspid/MVVM/StarterKit/Unity/Runtime/Binders/Texts/Mono/TextSwitcherMonoBinder.cs
+++ b/Assets/Plugins/Aspid/MVVM/StarterKit/Unity/Runtime/Binders/Texts/Mono/TextSwitcherMonoBinder.cs
@@ -15,7 +15,7 @@ namespace Aspid.MVVM.StarterKit
     [AddComponentContextMenu(typeof(TMP_Text),"Add Text Binder/Text Binder - Text Switcher")]
     public sealed class TextSwitcherMonoBinder : SwitcherMonoBinder<TMP_Text, string>
     {
-        [Header("Converter")]
+        [Header("Converters")]
         [SerializeReferenceDropdown]
         [SerializeReference] private Converter _converter;
         

--- a/Assets/Plugins/Aspid/MVVM/StarterKit/Unity/Runtime/Binders/Texts/TextBinder.cs
+++ b/Assets/Plugins/Aspid/MVVM/StarterKit/Unity/Runtime/Binders/Texts/TextBinder.cs
@@ -16,7 +16,6 @@ namespace Aspid.MVVM.StarterKit
     [Serializable]
     public class TextBinder : TargetBinder<TMP_Text>, IBinder<string?>, INumberBinder
     {
-        [Header("Converter")]
         [SerializeReferenceDropdown]
         [SerializeReference] private Converter? _converter;
 

--- a/Assets/Plugins/Aspid/MVVM/StarterKit/Unity/Runtime/Binders/Texts/TextFontSizeBinder.cs
+++ b/Assets/Plugins/Aspid/MVVM/StarterKit/Unity/Runtime/Binders/Texts/TextFontSizeBinder.cs
@@ -15,7 +15,6 @@ namespace Aspid.MVVM.StarterKit
     [Serializable]
     public class TextFontSizeBinder : TargetBinder<TMP_Text>, INumberBinder
     {
-        [Header("Converter")]
         [SerializeReferenceDropdown]
         [SerializeReference] private Converter? _converter;
         

--- a/Assets/Plugins/Aspid/MVVM/StarterKit/Unity/Runtime/Binders/Texts/TextFontSizeSwitcherBinder.cs
+++ b/Assets/Plugins/Aspid/MVVM/StarterKit/Unity/Runtime/Binders/Texts/TextFontSizeSwitcherBinder.cs
@@ -15,7 +15,7 @@ namespace Aspid.MVVM.StarterKit
     [Serializable]
     public sealed class TextFontSizeSwitcherBinder : SwitcherBinder<TMP_Text, float>
     {
-        [Header("Converter")]
+        [Header("Converters")]
         [SerializeReferenceDropdown]
         [SerializeReference] private Converter? _converter;
 

--- a/Assets/Plugins/Aspid/MVVM/StarterKit/Unity/Runtime/Binders/Texts/TextSwitcherBinder.cs
+++ b/Assets/Plugins/Aspid/MVVM/StarterKit/Unity/Runtime/Binders/Texts/TextSwitcherBinder.cs
@@ -15,7 +15,7 @@ namespace Aspid.MVVM.StarterKit
     [Serializable]
     public sealed class TextSwitcherBinder : SwitcherBinder<TMP_Text, string>
     {
-        [Header("Converter")]
+        [Header("Converters")]
         [SerializeReferenceDropdown]
         [SerializeReference] private Converter? _converter;
 

--- a/Assets/Plugins/Aspid/MVVM/StarterKit/Unity/Runtime/Binders/Toggles/Mono/ToggleIsOnMonoBinder.cs
+++ b/Assets/Plugins/Aspid/MVVM/StarterKit/Unity/Runtime/Binders/Toggles/Mono/ToggleIsOnMonoBinder.cs
@@ -13,7 +13,6 @@ namespace Aspid.MVVM.StarterKit
     {
         public event Action<bool> ValueChanged;
         
-        [Header("Converter")]
         [SerializeField] private bool _isInvert;
         
         private bool _isNotifyValueChanged = true;

--- a/Assets/Plugins/Aspid/MVVM/StarterKit/Unity/Runtime/Binders/Toggles/ToggleIsOnBinder.cs
+++ b/Assets/Plugins/Aspid/MVVM/StarterKit/Unity/Runtime/Binders/Toggles/ToggleIsOnBinder.cs
@@ -12,7 +12,6 @@ namespace Aspid.MVVM.StarterKit
     {
         public event Action<bool>? ValueChanged;
         
-        [Header("Converter")]
         [SerializeField] private bool _isInvert;
         
         private bool _isNotifyValueChanged = true;

--- a/Assets/Plugins/Aspid/MVVM/StarterKit/Unity/Runtime/Binders/Transforms/Mono/TransformEulerAnglesEnumGroupMonoBinder.cs
+++ b/Assets/Plugins/Aspid/MVVM/StarterKit/Unity/Runtime/Binders/Transforms/Mono/TransformEulerAnglesEnumGroupMonoBinder.cs
@@ -8,7 +8,7 @@ namespace Aspid.MVVM.StarterKit
     [AddComponentContextMenu(typeof(Transform),"Add Transform Binder/Transform Binder - EulerAngles EnumGroup")]
     public sealed class TransformEulerAnglesEnumGroupMonoBinder : EnumGroupMonoBinder<Transform>
     {
-        [Header("Parameters")]
+        [Header("Values")]
         [SerializeField] private Vector3 _defaultValue;
         [SerializeField] private Vector3 _selectedValue;
         

--- a/Assets/Plugins/Aspid/MVVM/StarterKit/Unity/Runtime/Binders/Transforms/Mono/TransformEulerAnglesEnumMonoBinder.cs
+++ b/Assets/Plugins/Aspid/MVVM/StarterKit/Unity/Runtime/Binders/Transforms/Mono/TransformEulerAnglesEnumMonoBinder.cs
@@ -8,10 +8,7 @@ namespace Aspid.MVVM.StarterKit
     [AddComponentContextMenu(typeof(Transform),"Add Transform Binder/Transform Binder - EulerAngles Enum")]
     public sealed class TransformEulerAnglesEnumMonoBinder : EnumMonoBinder<Vector3>
     {
-        [Header("Parameter")]
         [SerializeField] private Space _space = Space.World;
-
-        [Header("Converter")]
         [SerializeField] private Vector3CombineConverter _converter = Vector3CombineConverter.Default;
 
         protected override void SetValue(Vector3 value) =>

--- a/Assets/Plugins/Aspid/MVVM/StarterKit/Unity/Runtime/Binders/Transforms/Mono/TransformEulerAnglesMonoBinder.cs
+++ b/Assets/Plugins/Aspid/MVVM/StarterKit/Unity/Runtime/Binders/Transforms/Mono/TransformEulerAnglesMonoBinder.cs
@@ -8,10 +8,7 @@ namespace Aspid.MVVM.StarterKit
     [AddComponentContextMenu(typeof(Transform),"Add Transform Binder/Transform Binder - EulerAngles")]
     public partial class TransformEulerAnglesMonoBinder : MonoBinder, IVectorBinder, INumberBinder
     {
-        [Header("Parameter")]
         [SerializeField] private Space _space = Space.World;
-
-        [Header("Converter")]
         [SerializeField] private Vector3CombineConverter _converter = Vector3CombineConverter.Default;
         
         [BinderLog]

--- a/Assets/Plugins/Aspid/MVVM/StarterKit/Unity/Runtime/Binders/Transforms/Mono/TransformEulerAnglesSwitcherMonoBinder.cs
+++ b/Assets/Plugins/Aspid/MVVM/StarterKit/Unity/Runtime/Binders/Transforms/Mono/TransformEulerAnglesSwitcherMonoBinder.cs
@@ -10,7 +10,7 @@ namespace Aspid.MVVM.StarterKit
     {
         [SerializeField] private Space _space = Space.World;    
         
-        [Header("Converter")]
+        [Header("Converters")]
         [SerializeField] private Vector3CombineConverter _converter = Vector3CombineConverter.Default;
 
         protected override void SetValue(Vector3 value) =>

--- a/Assets/Plugins/Aspid/MVVM/StarterKit/Unity/Runtime/Binders/Transforms/Mono/TransformPositionEnumGroupMonoBinder.cs
+++ b/Assets/Plugins/Aspid/MVVM/StarterKit/Unity/Runtime/Binders/Transforms/Mono/TransformPositionEnumGroupMonoBinder.cs
@@ -8,7 +8,7 @@ namespace Aspid.MVVM.StarterKit
     [AddComponentContextMenu(typeof(Transform),"Add Transform Binder/Transform Binder - Position EnumGroup")]
     public sealed class TransformPositionEnumGroupMonoBinder : EnumGroupMonoBinder<Transform>
     {
-        [Header("Parameters")]
+        [Header("Values")]
         [SerializeField] private Vector3 _defaultValue;
         [SerializeField] private Vector3 _selectedValue;
         [SerializeField] private Space _space = Space.World;    

--- a/Assets/Plugins/Aspid/MVVM/StarterKit/Unity/Runtime/Binders/Transforms/Mono/TransformPositionEnumMonoBinder.cs
+++ b/Assets/Plugins/Aspid/MVVM/StarterKit/Unity/Runtime/Binders/Transforms/Mono/TransformPositionEnumMonoBinder.cs
@@ -8,10 +8,7 @@ namespace Aspid.MVVM.StarterKit
     [AddComponentContextMenu(typeof(Transform),"Add Transform Binder/Transform Binder - Position Enum")]
     public sealed class TransformPositionEnumMonoBinder : EnumMonoBinder<Vector3>
     {
-        [Header("Parameter")]
         [SerializeField] private Space _space = Space.World;    
-        
-        [Header("Converter")]
         [SerializeField] private Vector3CombineConverter _converter = Vector3CombineConverter.Default;
 
         protected override void SetValue(Vector3 value) =>

--- a/Assets/Plugins/Aspid/MVVM/StarterKit/Unity/Runtime/Binders/Transforms/Mono/TransformPositionMonoBinder.cs
+++ b/Assets/Plugins/Aspid/MVVM/StarterKit/Unity/Runtime/Binders/Transforms/Mono/TransformPositionMonoBinder.cs
@@ -8,10 +8,7 @@ namespace Aspid.MVVM.StarterKit
     [AddComponentContextMenu(typeof(Transform),"Add Transform Binder/Transform Binder - Position")]
     public partial class TransformPositionMonoBinder : MonoBinder, IVectorBinder, INumberBinder
     {
-        [Header("Parameter")]
         [SerializeField] private Space _space = Space.World;
-        
-        [Header("Converter")]
         [SerializeField] private Vector3CombineConverter _converter = Vector3CombineConverter.Default;
 
         [BinderLog]

--- a/Assets/Plugins/Aspid/MVVM/StarterKit/Unity/Runtime/Binders/Transforms/Mono/TransformPositionSwitcherMonoBinder.cs
+++ b/Assets/Plugins/Aspid/MVVM/StarterKit/Unity/Runtime/Binders/Transforms/Mono/TransformPositionSwitcherMonoBinder.cs
@@ -10,7 +10,7 @@ namespace Aspid.MVVM.StarterKit
     {
         [SerializeField] private Space _space = Space.World;    
         
-        [Header("Converter")]
+        [Header("Converters")]
         [SerializeField] private Vector3CombineConverter _converter = Vector3CombineConverter.Default;
 
         protected override void SetValue(Vector3 value) =>

--- a/Assets/Plugins/Aspid/MVVM/StarterKit/Unity/Runtime/Binders/Transforms/Mono/TransformRotationEnumGroupMonoBinder.cs
+++ b/Assets/Plugins/Aspid/MVVM/StarterKit/Unity/Runtime/Binders/Transforms/Mono/TransformRotationEnumGroupMonoBinder.cs
@@ -13,7 +13,7 @@ namespace Aspid.MVVM.StarterKit
     [AddComponentContextMenu(typeof(Transform),"Add Transform Binder/Transform Binder - Rotation EnumGroup")]
     public sealed class TransformRotationEnumGroupMonoBinder : EnumGroupMonoBinder<Transform>
     {
-        [Header("Parameters")]
+        [Header("Values")]
         [SerializeField] private Vector3 _defaultValue;
         [SerializeField] private Vector3 _selectedValue;
         [SerializeField] private Space _space = Space.World;

--- a/Assets/Plugins/Aspid/MVVM/StarterKit/Unity/Runtime/Binders/Transforms/Mono/TransformRotationEnumMonoBinder.cs
+++ b/Assets/Plugins/Aspid/MVVM/StarterKit/Unity/Runtime/Binders/Transforms/Mono/TransformRotationEnumMonoBinder.cs
@@ -13,10 +13,8 @@ namespace Aspid.MVVM.StarterKit
     [AddComponentContextMenu(typeof(Transform),"Add Transform Binder/Transform Binder - Rotation Enum")]
     public sealed class TransformRotationEnumMonoBinder : EnumMonoBinder<Vector3>
     {
-        [Header("Parameter")]
         [SerializeField] private Space _space = Space.World;
-
-        [Header("Converter")]
+        
         [SerializeReferenceDropdown]
         [SerializeReference] private Converter _converter;
 

--- a/Assets/Plugins/Aspid/MVVM/StarterKit/Unity/Runtime/Binders/Transforms/Mono/TransformRotationMonoBinder.cs
+++ b/Assets/Plugins/Aspid/MVVM/StarterKit/Unity/Runtime/Binders/Transforms/Mono/TransformRotationMonoBinder.cs
@@ -14,8 +14,7 @@ namespace Aspid.MVVM.StarterKit
     public partial class TransformRotationMonoBinder : MonoBinder, IRotationBinder, INumberBinder
     {
         [SerializeField] private Space _space = Space.World;
-
-        [Header("Converter")]
+        
         [SerializeReferenceDropdown]
         [SerializeReference] private Converter _converter;
         

--- a/Assets/Plugins/Aspid/MVVM/StarterKit/Unity/Runtime/Binders/Transforms/Mono/TransformRotationSwitcherMonoBinder.cs
+++ b/Assets/Plugins/Aspid/MVVM/StarterKit/Unity/Runtime/Binders/Transforms/Mono/TransformRotationSwitcherMonoBinder.cs
@@ -15,7 +15,7 @@ namespace Aspid.MVVM.StarterKit
     {
         [SerializeField] private Space _space = Space.World;
         
-        [Header("Converter")]
+        [Header("Converters")]
         [SerializeReferenceDropdown]
         [SerializeReference] private Converter _converter;
 

--- a/Assets/Plugins/Aspid/MVVM/StarterKit/Unity/Runtime/Binders/Transforms/Mono/TransformScaleEnumGroupMonoBinder.cs
+++ b/Assets/Plugins/Aspid/MVVM/StarterKit/Unity/Runtime/Binders/Transforms/Mono/TransformScaleEnumGroupMonoBinder.cs
@@ -8,11 +8,11 @@ namespace Aspid.MVVM.StarterKit
     [AddComponentContextMenu(typeof(Transform),"Add Transform Binder/Transform Binder - Scale EnumGroup")]
     public sealed class TransformScaleEnumGroupMonoBinder : EnumGroupMonoBinder<Transform>
     {
-        [Header("Parameters")]
+        [Header("Values")]
         [SerializeField] private Vector3 _defaultValue;
         [SerializeField] private Vector3 _selectedValue;
         
-        [Header("Converter")]
+        [Header("Converters")]
         [SerializeField] private Vector3CombineConverter _converter = Vector3CombineConverter.Default;
 
         protected override void SetDefaultValue(Transform element) =>

--- a/Assets/Plugins/Aspid/MVVM/StarterKit/Unity/Runtime/Binders/Transforms/Mono/TransformScaleEnumMonoBinder.cs
+++ b/Assets/Plugins/Aspid/MVVM/StarterKit/Unity/Runtime/Binders/Transforms/Mono/TransformScaleEnumMonoBinder.cs
@@ -8,7 +8,6 @@ namespace Aspid.MVVM.StarterKit
     [AddComponentContextMenu(typeof(Transform),"Add Transform Binder/Transform Binder - Scale Enum")]
     public sealed class TransformScaleEnumMonoBinder : EnumMonoBinder<Vector3>
     {
-        [Header("Converter")]
         [SerializeField] private Vector3CombineConverter _converter = Vector3CombineConverter.Default;
         
         protected override void SetValue(Vector3 value) =>

--- a/Assets/Plugins/Aspid/MVVM/StarterKit/Unity/Runtime/Binders/Transforms/Mono/TransformScaleMonoBinder.cs
+++ b/Assets/Plugins/Aspid/MVVM/StarterKit/Unity/Runtime/Binders/Transforms/Mono/TransformScaleMonoBinder.cs
@@ -8,7 +8,6 @@ namespace Aspid.MVVM.StarterKit
     [AddComponentContextMenu(typeof(Transform),"Add Transform Binder/Transform Binder - Scale")]
     public partial class TransformScaleMonoBinder : MonoBinder, IVectorBinder, INumberBinder
     {
-        [Header("Converter")]
         [SerializeField] private Vector3CombineConverter _converter = Vector3CombineConverter.Default;
         
         [BinderLog]

--- a/Assets/Plugins/Aspid/MVVM/StarterKit/Unity/Runtime/Binders/Transforms/Mono/TransformScaleSwitcherMonoBinder.cs
+++ b/Assets/Plugins/Aspid/MVVM/StarterKit/Unity/Runtime/Binders/Transforms/Mono/TransformScaleSwitcherMonoBinder.cs
@@ -8,7 +8,7 @@ namespace Aspid.MVVM.StarterKit
     [AddComponentContextMenu(typeof(Transform),"Add Transform Binder/Transform Binder - Scale Switcher")]
     public sealed class TransformScaleSwitcherMonoBinder : SwitcherMonoBinder<Vector3>
     {
-        [Header("Converter")]
+        [Header("Converters")]
         [SerializeField] private Vector3CombineConverter _converter = Vector3CombineConverter.Default;
 
         protected override void SetValue(Vector3 value) =>

--- a/Assets/Plugins/Aspid/MVVM/StarterKit/Unity/Runtime/Binders/Transforms/RectTransforms/Mono/RectTransformAnchoredPositionEnumGroupMonoBinder.cs
+++ b/Assets/Plugins/Aspid/MVVM/StarterKit/Unity/Runtime/Binders/Transforms/RectTransforms/Mono/RectTransformAnchoredPositionEnumGroupMonoBinder.cs
@@ -7,7 +7,7 @@ namespace Aspid.MVVM.StarterKit
     [AddComponentContextMenu(typeof(RectTransform),"Add RectTransform Binder/RectTransform Binder - AnchoredPosition EnumGroup")]
     public sealed class RectTransformAnchoredPositionEnumGroupMonoBinder : EnumGroupMonoBinder<RectTransform>
     {
-        [Header("Parameters")]
+        [Header("Values")]
         [SerializeField] private Vector3 _defaultValue;
         [SerializeField] private Vector3 _selectedValue;
         

--- a/Assets/Plugins/Aspid/MVVM/StarterKit/Unity/Runtime/Binders/Transforms/RectTransforms/Mono/RectTransformAnchoredPositionEnumMonoBinder.cs
+++ b/Assets/Plugins/Aspid/MVVM/StarterKit/Unity/Runtime/Binders/Transforms/RectTransforms/Mono/RectTransformAnchoredPositionEnumMonoBinder.cs
@@ -7,10 +7,7 @@ namespace Aspid.MVVM.StarterKit
     [AddComponentContextMenu(typeof(RectTransform),"Add RectTransform Binder/RectTransform Binder - AnchoredPosition Enum")]
     public sealed class RectTransformAnchoredPositionEnumMonoBinder : EnumMonoBinder<RectTransform, Vector3>
     {
-        [Header("Parameter")]
         [SerializeField] private Space _space = Space.World;
-
-        [Header("Converter")]
         [SerializeField] private Vector3CombineConverter _converter = Vector3CombineConverter.Default;
 
         protected override void SetValue(Vector3 value) =>

--- a/Assets/Plugins/Aspid/MVVM/StarterKit/Unity/Runtime/Binders/Transforms/RectTransforms/Mono/RectTransformAnchoredPositionMonoBinder.cs
+++ b/Assets/Plugins/Aspid/MVVM/StarterKit/Unity/Runtime/Binders/Transforms/RectTransforms/Mono/RectTransformAnchoredPositionMonoBinder.cs
@@ -7,10 +7,7 @@ namespace Aspid.MVVM.StarterKit
     [AddComponentContextMenu(typeof(RectTransform),"Add RectTransform Binder/RectTransform Binder - AnchoredPosition")]
     public partial class RectTransformAnchoredPositionMonoBinder : ComponentMonoBinder<RectTransform>, IVectorBinder, INumberBinder
     {
-        [Header("Parameter")]
         [SerializeField] private Space _space = Space.World;
-
-        [Header("Converter")]
         [SerializeField] private Vector3CombineConverter _converter = Vector3CombineConverter.Default;
         
         [BinderLog]

--- a/Assets/Plugins/Aspid/MVVM/StarterKit/Unity/Runtime/Binders/Transforms/RectTransforms/Mono/RectTransformAnchoredPositionSwitcherMonoBinder.cs
+++ b/Assets/Plugins/Aspid/MVVM/StarterKit/Unity/Runtime/Binders/Transforms/RectTransforms/Mono/RectTransformAnchoredPositionSwitcherMonoBinder.cs
@@ -9,7 +9,7 @@ namespace Aspid.MVVM.StarterKit
     {
         [SerializeField] private Space _space = Space.World;       
         
-        [Header("Converter")]
+        [Header("Converters")]
         [SerializeField] private Vector3CombineConverter _converter = Vector3CombineConverter.Default;
 
         protected override void SetValue(Vector3 value) =>

--- a/Assets/Plugins/Aspid/MVVM/StarterKit/Unity/Runtime/Binders/Transforms/RectTransforms/Mono/RectTransformSizeDeltaEnumGroupMonoBinder.cs
+++ b/Assets/Plugins/Aspid/MVVM/StarterKit/Unity/Runtime/Binders/Transforms/RectTransforms/Mono/RectTransformSizeDeltaEnumGroupMonoBinder.cs
@@ -12,12 +12,12 @@ namespace Aspid.MVVM.StarterKit
     [AddComponentContextMenu(typeof(RectTransform),"Add RectTransform Binder/RectTransform Binder - SizeDelta EnumGroup")]
     public sealed class RectTransformSizeDeltaEnumGroupMonoBinder : EnumGroupMonoBinder<RectTransform>
     {
-        [Header("Parameters")]
+        [Header("Values")]
         [SerializeField] private Vector3 _defaultValue;
         [SerializeField] private Vector3 _selectedValue;
         [SerializeField] private SizeDeltaMode _sizeMode = SizeDeltaMode.SizeDelta;
         
-        [Header("Converter")]
+        [Header("Converters")]
         [SerializeReferenceDropdown]
         [SerializeReference] private Converter _defaultValueConverter;
         

--- a/Assets/Plugins/Aspid/MVVM/StarterKit/Unity/Runtime/Binders/Transforms/RectTransforms/Mono/RectTransformSizeDeltaEnumMonoBinder.cs
+++ b/Assets/Plugins/Aspid/MVVM/StarterKit/Unity/Runtime/Binders/Transforms/RectTransforms/Mono/RectTransformSizeDeltaEnumMonoBinder.cs
@@ -12,10 +12,8 @@ namespace Aspid.MVVM.StarterKit
     [AddComponentContextMenu(typeof(RectTransform),"Add RectTransform Binder/RectTransform Binder - SizeDelta Enum")]
     public sealed class RectTransformSizeDeltaEnumMonoBinder : EnumMonoBinder<RectTransform, Vector2>
     {
-        [Header("Parameter")]
         [SerializeField] private SizeDeltaMode _sizeMode = SizeDeltaMode.SizeDelta;
         
-        [Header("Converter")]
         [SerializeReferenceDropdown]
         [SerializeReference] private Converter _converter;
         

--- a/Assets/Plugins/Aspid/MVVM/StarterKit/Unity/Runtime/Binders/Transforms/RectTransforms/Mono/RectTransformSizeDeltaMonoBinder.cs
+++ b/Assets/Plugins/Aspid/MVVM/StarterKit/Unity/Runtime/Binders/Transforms/RectTransforms/Mono/RectTransformSizeDeltaMonoBinder.cs
@@ -12,10 +12,8 @@ namespace Aspid.MVVM.StarterKit
     [AddComponentContextMenu(typeof(RectTransform),"Add RectTransform Binder/RectTransform Binder - SizeDelta")]
     public partial class RectTransformSizeDeltaMonoBinder : ComponentMonoBinder<RectTransform>, IBinder<Vector2>, INumberBinder
     {
-        [Header("Parameters")]
         [SerializeField] private SizeDeltaMode _sizeMode = SizeDeltaMode.SizeDelta;
         
-        [Header("Converter")]
         [SerializeReferenceDropdown]
         [SerializeReference] private Converter _converter;
 

--- a/Assets/Plugins/Aspid/MVVM/StarterKit/Unity/Runtime/Binders/Transforms/RectTransforms/Mono/RectTransformSizeDeltaSwitcherMonoBinder.cs
+++ b/Assets/Plugins/Aspid/MVVM/StarterKit/Unity/Runtime/Binders/Transforms/RectTransforms/Mono/RectTransformSizeDeltaSwitcherMonoBinder.cs
@@ -14,7 +14,7 @@ namespace Aspid.MVVM.StarterKit
     {
         [SerializeField] private SizeDeltaMode _sizeMode = SizeDeltaMode.SizeDelta;
         
-        [Header("Converter")]
+        [Header("Converters")]
         [SerializeReferenceDropdown]
         [SerializeReference] private Converter _converter;
         

--- a/Assets/Plugins/Aspid/MVVM/StarterKit/Unity/Runtime/Binders/Transforms/RectTransforms/RectTransformAnchoredPositionBinder.cs
+++ b/Assets/Plugins/Aspid/MVVM/StarterKit/Unity/Runtime/Binders/Transforms/RectTransforms/RectTransformAnchoredPositionBinder.cs
@@ -8,10 +8,7 @@ namespace Aspid.MVVM.StarterKit
     [Serializable]
     public class RectTransformAnchoredPositionBinder : TargetBinder<RectTransform>, IVectorBinder
     {
-        [Header("Parameters")]
         [SerializeField] private Space _space;
-        
-        [Header("Converter")]
         [SerializeField] private Vector3CombineConverter? _converter;
         
         public RectTransformAnchoredPositionBinder(

--- a/Assets/Plugins/Aspid/MVVM/StarterKit/Unity/Runtime/Binders/Transforms/RectTransforms/RectTransformAnchoredPositionSwitcherBinder.cs
+++ b/Assets/Plugins/Aspid/MVVM/StarterKit/Unity/Runtime/Binders/Transforms/RectTransforms/RectTransformAnchoredPositionSwitcherBinder.cs
@@ -10,7 +10,7 @@ namespace Aspid.MVVM.StarterKit
     {
         [SerializeField] private Space _space;
         
-        [Header("Converter")]
+        [Header("Converters")]
         [SerializeField] private Vector3CombineConverter? _converter;
 
         public RectTransformAnchoredPositionSwitcherBinder(

--- a/Assets/Plugins/Aspid/MVVM/StarterKit/Unity/Runtime/Binders/Transforms/RectTransforms/RectTransformSizeDeltaBinder.cs
+++ b/Assets/Plugins/Aspid/MVVM/StarterKit/Unity/Runtime/Binders/Transforms/RectTransforms/RectTransformSizeDeltaBinder.cs
@@ -13,10 +13,8 @@ namespace Aspid.MVVM.StarterKit
     [Serializable]
     public class RectTransformSizeDeltaBinder : TargetBinder<RectTransform>, IBinder<Vector2>, INumberBinder
     {
-        [Header("Parameter")]
         [SerializeField] private SizeDeltaMode _sizeMode;
         
-        [Header("Converter")]
         [SerializeReferenceDropdown]
         [SerializeReference] private Converter? _converter;
         

--- a/Assets/Plugins/Aspid/MVVM/StarterKit/Unity/Runtime/Binders/Transforms/RectTransforms/RectTransformSizeDeltaSwitcherBinder.cs
+++ b/Assets/Plugins/Aspid/MVVM/StarterKit/Unity/Runtime/Binders/Transforms/RectTransforms/RectTransformSizeDeltaSwitcherBinder.cs
@@ -15,7 +15,7 @@ namespace Aspid.MVVM.StarterKit
     {
         [SerializeField] private SizeDeltaMode _sizeMode;
         
-        [Header("Converter")]
+        [Header("Converters")]
         [SerializeReferenceDropdown]
         [SerializeReference] private Converter? _converter;
         

--- a/Assets/Plugins/Aspid/MVVM/StarterKit/Unity/Runtime/Binders/Transforms/TransformEulerAnglesBinder.cs
+++ b/Assets/Plugins/Aspid/MVVM/StarterKit/Unity/Runtime/Binders/Transforms/TransformEulerAnglesBinder.cs
@@ -8,10 +8,7 @@ namespace Aspid.MVVM.StarterKit
     [Serializable]
     public class TransformEulerAnglesBinder : TargetBinder<Transform>, IVectorBinder, INumberBinder
     {
-        [Header("Parameter")]
         [SerializeField] private Space _space;
-
-        [Header("Converter")]
         [SerializeField] private Vector3CombineConverter? _converter;
 
         public TransformEulerAnglesBinder(Transform target, BindMode mode)

--- a/Assets/Plugins/Aspid/MVVM/StarterKit/Unity/Runtime/Binders/Transforms/TransformEulerAnglesSwitcherBinder.cs
+++ b/Assets/Plugins/Aspid/MVVM/StarterKit/Unity/Runtime/Binders/Transforms/TransformEulerAnglesSwitcherBinder.cs
@@ -10,7 +10,7 @@ namespace Aspid.MVVM.StarterKit
     {
         [SerializeField] private Space _space;
         
-        [Header("Converter")]
+        [Header("Converters")]
         [SerializeField] private Vector3CombineConverter? _converter;
         
         public TransformEulerAnglesSwitcherBinder(

--- a/Assets/Plugins/Aspid/MVVM/StarterKit/Unity/Runtime/Binders/Transforms/TransformPositionBinder.cs
+++ b/Assets/Plugins/Aspid/MVVM/StarterKit/Unity/Runtime/Binders/Transforms/TransformPositionBinder.cs
@@ -8,10 +8,7 @@ namespace Aspid.MVVM.StarterKit
     [Serializable]
     public class TransformPositionBinder : TargetBinder<Transform>, IVectorBinder
     {
-        [Header("Parameter")]
         [SerializeField] private Space _space;
-        
-        [Header("Converter")]
         [SerializeField] private Vector3CombineConverter? _converter;
 
         public TransformPositionBinder(Transform transform, BindMode mode)

--- a/Assets/Plugins/Aspid/MVVM/StarterKit/Unity/Runtime/Binders/Transforms/TransformPositionSwitcherBinder.cs
+++ b/Assets/Plugins/Aspid/MVVM/StarterKit/Unity/Runtime/Binders/Transforms/TransformPositionSwitcherBinder.cs
@@ -10,7 +10,7 @@ namespace Aspid.MVVM.StarterKit
     {
         [SerializeField] private Space _space;
 
-        [Header("Converter")]
+        [Header("Converters")]
         [SerializeField] private Vector3CombineConverter? _converter;
        
         public TransformPositionSwitcherBinder(

--- a/Assets/Plugins/Aspid/MVVM/StarterKit/Unity/Runtime/Binders/Transforms/TransformRotationBinder.cs
+++ b/Assets/Plugins/Aspid/MVVM/StarterKit/Unity/Runtime/Binders/Transforms/TransformRotationBinder.cs
@@ -13,10 +13,8 @@ namespace Aspid.MVVM.StarterKit
     [Serializable]
     public class TransformRotationBinder : TargetBinder<Transform>, IRotationBinder, INumberBinder
     {
-        [Header("Parameter")]
         [SerializeField] private Space _space;
         
-        [Header("Converter")]
         [SerializeReferenceDropdown]
         [SerializeReference] private Converter? _converter;
 

--- a/Assets/Plugins/Aspid/MVVM/StarterKit/Unity/Runtime/Binders/Transforms/TransformRotationSwitcherBinder.cs
+++ b/Assets/Plugins/Aspid/MVVM/StarterKit/Unity/Runtime/Binders/Transforms/TransformRotationSwitcherBinder.cs
@@ -15,7 +15,7 @@ namespace Aspid.MVVM.StarterKit
     {
         [SerializeField] private Space _space;
         
-        [Header("Converter")]
+        [Header("Converters")]
         [SerializeReferenceDropdown]
         [SerializeReference] private Converter? _converter;
         

--- a/Assets/Plugins/Aspid/MVVM/StarterKit/Unity/Runtime/Binders/Transforms/TransformScaleBinder.cs
+++ b/Assets/Plugins/Aspid/MVVM/StarterKit/Unity/Runtime/Binders/Transforms/TransformScaleBinder.cs
@@ -8,7 +8,6 @@ namespace Aspid.MVVM.StarterKit
     [Serializable]
     public class TransformScaleBinder : TargetBinder<Transform>, IVectorBinder, INumberBinder
     {
-        [Header("Converter")]
         [SerializeField] private Vector3CombineConverter? _converter;
         
         public TransformScaleBinder(Transform target, BindMode mode = BindMode.OneWay)

--- a/Assets/Plugins/Aspid/MVVM/StarterKit/Unity/Runtime/Binders/Transforms/TransformScaleSwitcherBinder.cs
+++ b/Assets/Plugins/Aspid/MVVM/StarterKit/Unity/Runtime/Binders/Transforms/TransformScaleSwitcherBinder.cs
@@ -8,7 +8,7 @@ namespace Aspid.MVVM.StarterKit
     [Serializable]
     public sealed class TransformScaleSwitcherBinder : SwitcherBinder<Transform, Vector3>
     {
-        [Header("Converter")]
+        [Header("Converters")]
         [SerializeField] private Vector3CombineConverter? _converter;
 
         public TransformScaleSwitcherBinder(

--- a/Assets/Plugins/Aspid/MVVM/StarterKit/Unity/Runtime/Binders/UnityEvents/Mono/UnityEventBoolByBindMonoBinder.cs
+++ b/Assets/Plugins/Aspid/MVVM/StarterKit/Unity/Runtime/Binders/UnityEvents/Mono/UnityEventBoolByBindMonoBinder.cs
@@ -15,7 +15,6 @@ namespace Aspid.MVVM.StarterKit
             remove => _set.RemoveListener(value);
         }
         
-        [Header("Converter")]
         [SerializeField] private bool _isInvert;
         
         [Header("Events")]

--- a/Assets/Plugins/Aspid/MVVM/StarterKit/Unity/Runtime/Binders/UnityEvents/Mono/UnityEventBoolMonoBinder.cs
+++ b/Assets/Plugins/Aspid/MVVM/StarterKit/Unity/Runtime/Binders/UnityEvents/Mono/UnityEventBoolMonoBinder.cs
@@ -15,7 +15,6 @@ namespace Aspid.MVVM.StarterKit
             remove => _set.RemoveListener(value);
         }
         
-        [Header("Converter")]
         [SerializeField] private bool _isInvert;
         
         [Header("Events")]

--- a/Assets/Plugins/Aspid/MVVM/StarterKit/Unity/Runtime/Binders/UnityEvents/Mono/UnityEventColorMonoBinder.cs
+++ b/Assets/Plugins/Aspid/MVVM/StarterKit/Unity/Runtime/Binders/UnityEvents/Mono/UnityEventColorMonoBinder.cs
@@ -20,7 +20,6 @@ namespace Aspid.MVVM.StarterKit
             remove => _set.RemoveListener(value);
         }
         
-        [Header("Converter")]
         [SerializeReferenceDropdown]
         [SerializeReference] private Converter _converter;
         

--- a/Assets/Plugins/Aspid/MVVM/StarterKit/Unity/Runtime/Binders/UnityEvents/Mono/UnityEventDoubleMonoBinder.cs
+++ b/Assets/Plugins/Aspid/MVVM/StarterKit/Unity/Runtime/Binders/UnityEvents/Mono/UnityEventDoubleMonoBinder.cs
@@ -20,7 +20,6 @@ namespace Aspid.MVVM.StarterKit
             remove => _set.RemoveListener(value);
         }
         
-        [Header("Converter")]
         [SerializeReferenceDropdown]
         [SerializeReference] private Converter _converter;
         

--- a/Assets/Plugins/Aspid/MVVM/StarterKit/Unity/Runtime/Binders/UnityEvents/Mono/UnityEventFloatMonoBinder.cs
+++ b/Assets/Plugins/Aspid/MVVM/StarterKit/Unity/Runtime/Binders/UnityEvents/Mono/UnityEventFloatMonoBinder.cs
@@ -20,7 +20,6 @@ namespace Aspid.MVVM.StarterKit
             remove => _set.RemoveListener(value);
         }
         
-        [Header("Converter")]
         [SerializeReferenceDropdown]
         [SerializeReference] private Converter _converter;
         

--- a/Assets/Plugins/Aspid/MVVM/StarterKit/Unity/Runtime/Binders/UnityEvents/Mono/UnityEventIntMonoBinder.cs
+++ b/Assets/Plugins/Aspid/MVVM/StarterKit/Unity/Runtime/Binders/UnityEvents/Mono/UnityEventIntMonoBinder.cs
@@ -20,7 +20,6 @@ namespace Aspid.MVVM.StarterKit
             remove => _set.RemoveListener(value);
         }
         
-        [Header("Converter")]
         [SerializeReferenceDropdown]
         [SerializeReference] private Converter _converter;
         

--- a/Assets/Plugins/Aspid/MVVM/StarterKit/Unity/Runtime/Binders/UnityEvents/Mono/UnityEventLongMonoBinder.cs
+++ b/Assets/Plugins/Aspid/MVVM/StarterKit/Unity/Runtime/Binders/UnityEvents/Mono/UnityEventLongMonoBinder.cs
@@ -20,7 +20,6 @@ namespace Aspid.MVVM.StarterKit
             remove => _set.RemoveListener(value);
         }
         
-        [Header("Converter")]
         [SerializeReferenceDropdown]
         [SerializeReference] private Converter _converter;
         

--- a/Assets/Plugins/Aspid/MVVM/StarterKit/Unity/Runtime/Binders/UnityEvents/Mono/UnityEventNumberConditionMonoBinder.cs
+++ b/Assets/Plugins/Aspid/MVVM/StarterKit/Unity/Runtime/Binders/UnityEvents/Mono/UnityEventNumberConditionMonoBinder.cs
@@ -20,7 +20,6 @@ namespace Aspid.MVVM.StarterKit
             remove => _set.RemoveListener(value);
         }
         
-        [Header("Converter")]
         [SerializeReferenceDropdown]
         [SerializeReference] private Converter _converter;
         

--- a/Assets/Plugins/Aspid/MVVM/StarterKit/Unity/Runtime/Binders/UnityEvents/Mono/UnityEventNumberConditionSwitcherMonoBinder.cs
+++ b/Assets/Plugins/Aspid/MVVM/StarterKit/Unity/Runtime/Binders/UnityEvents/Mono/UnityEventNumberConditionSwitcherMonoBinder.cs
@@ -25,8 +25,7 @@ namespace Aspid.MVVM.StarterKit
             add => _falseSet.AddListener(value);
             remove => _falseSet.RemoveListener(value);
         }
-        
-        [Header("Converter")]
+
         [SerializeReferenceDropdown]
         [SerializeReference] private Converter _converter;
         

--- a/Assets/Plugins/Aspid/MVVM/StarterKit/Unity/Runtime/Binders/UnityEvents/Mono/UnityEventQuaternionMonoBinder.cs
+++ b/Assets/Plugins/Aspid/MVVM/StarterKit/Unity/Runtime/Binders/UnityEvents/Mono/UnityEventQuaternionMonoBinder.cs
@@ -19,8 +19,7 @@ namespace Aspid.MVVM.StarterKit
             add => _set.AddListener(value);
             remove => _set.RemoveListener(value);
         }
-
-        [Header("Converter")]
+        
         [SerializeReferenceDropdown]
         [SerializeReference] private Converter _converter;
         

--- a/Assets/Plugins/Aspid/MVVM/StarterKit/Unity/Runtime/Binders/UnityEvents/Mono/UnityEventStringMonoBinder.cs
+++ b/Assets/Plugins/Aspid/MVVM/StarterKit/Unity/Runtime/Binders/UnityEvents/Mono/UnityEventStringMonoBinder.cs
@@ -21,7 +21,6 @@ namespace Aspid.MVVM.StarterKit
             remove => _set.RemoveListener(value);
         }
         
-        [Header("Converter")]
         [SerializeReferenceDropdown]
         [SerializeReference] private Converter _converter;
         

--- a/Assets/Plugins/Aspid/MVVM/StarterKit/Unity/Runtime/Binders/UnityEvents/Mono/UnityEventVector2MonoBinder.cs
+++ b/Assets/Plugins/Aspid/MVVM/StarterKit/Unity/Runtime/Binders/UnityEvents/Mono/UnityEventVector2MonoBinder.cs
@@ -20,7 +20,6 @@ namespace Aspid.MVVM.StarterKit
             remove => _set.RemoveListener(value);
         }
         
-        [Header("Converter")]
         [SerializeReferenceDropdown]
         [SerializeReference] private Converter _converter;
         

--- a/Assets/Plugins/Aspid/MVVM/StarterKit/Unity/Runtime/Binders/UnityEvents/Mono/UnityEventVector3MonoBinder.cs
+++ b/Assets/Plugins/Aspid/MVVM/StarterKit/Unity/Runtime/Binders/UnityEvents/Mono/UnityEventVector3MonoBinder.cs
@@ -19,8 +19,7 @@ namespace Aspid.MVVM.StarterKit
             add => _set.AddListener(value);
             remove => _set.RemoveListener(value);
         }
-
-        [Header("Converter")]
+        
         [SerializeReferenceDropdown]
         [SerializeReference] private Converter _converter;
         

--- a/Assets/Plugins/Aspid/MVVM/StarterKit/Unity/Runtime/Views/EventMonoView.cs
+++ b/Assets/Plugins/Aspid/MVVM/StarterKit/Unity/Runtime/Views/EventMonoView.cs
@@ -8,7 +8,6 @@ namespace Aspid.MVVM.StarterKit
     [AddComponentMenu("Aspid/MVVM/Views/Event View")]
     public partial class EventMonoView : MonoView
     {
-        [Header("Events")]
         [SerializeField] private UnityEvent<IViewModel> _initialized;
         [SerializeField] private UnityEvent _deinitialized;
 


### PR DESCRIPTION
Improves the visual layout of binder inspector elements: removes redundant header sections and renames remaining headers for better readability in the Unity inspector.