### PR TITLE
Add Object Name Binders

### DIFF
--- a/Assets/Plugins/Aspid/MVVM/StarterKit/Unity/Runtime/Binders/Objects.meta
+++ b/Assets/Plugins/Aspid/MVVM/StarterKit/Unity/Runtime/Binders/Objects.meta
@@ -1,0 +1,3 @@
+fileFormatVersion: 2
+guid: 69e867f641844d4288fb2a2303b831c5
+timeCreated: 1761081240

--- a/Assets/Plugins/Aspid/MVVM/StarterKit/Unity/Runtime/Binders/Objects/Mono.meta
+++ b/Assets/Plugins/Aspid/MVVM/StarterKit/Unity/Runtime/Binders/Objects/Mono.meta
@@ -1,0 +1,3 @@
+fileFormatVersion: 2
+guid: ea2c9a2482524dd6858c308ec930242f
+timeCreated: 1761115079

--- a/Assets/Plugins/Aspid/MVVM/StarterKit/Unity/Runtime/Binders/Objects/Mono/ObjectNameMonoBinder.cs
+++ b/Assets/Plugins/Aspid/MVVM/StarterKit/Unity/Runtime/Binders/Objects/Mono/ObjectNameMonoBinder.cs
@@ -1,0 +1,30 @@
+using UnityEngine;
+#if UNITY_2023_1_OR_NEWER
+using Converter = Aspid.MVVM.StarterKit.IConverter<string, string>;
+#else
+using Converter = Aspid.MVVM.StarterKit.IConverterString;
+#endif
+
+// ReSharper disable once CheckNamespace
+namespace Aspid.MVVM.StarterKit
+{
+    [AddComponentMenu("Aspid/MVVM/Binders/Object/Object Binder - Name")]
+    [AddComponentContextMenu(typeof(Component),"Add General Binder/Object/Object Binder - Name")]
+    public sealed partial class ObjectNameMonoBinder : MonoBinder, IBinder<string>
+    {
+        [SerializeField] private Object _object;
+        
+        [SerializeReferenceDropdown]
+        [SerializeReference] private Converter _converter;
+
+        private void OnValidate()
+        {
+            if (!_object)
+                _object = gameObject;
+        }
+
+        [BinderLog]
+        public void SetValue(string value) =>
+            _object.name = _converter?.Convert(value) ?? value ?? string.Empty;
+    }
+}

--- a/Assets/Plugins/Aspid/MVVM/StarterKit/Unity/Runtime/Binders/Objects/Mono/ObjectNameMonoBinder.cs.meta
+++ b/Assets/Plugins/Aspid/MVVM/StarterKit/Unity/Runtime/Binders/Objects/Mono/ObjectNameMonoBinder.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 82ab2dbf975f4dbba9862fb48282d79e
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {fileID: 2800000, guid: 3f246f77b3b5a4b6ba0ab47ff519a0a9, type: 3}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Plugins/Aspid/MVVM/StarterKit/Unity/Runtime/Binders/Objects/ObjectNameBinder.cs
+++ b/Assets/Plugins/Aspid/MVVM/StarterKit/Unity/Runtime/Binders/Objects/ObjectNameBinder.cs
@@ -1,0 +1,33 @@
+#nullable enable
+using System;
+using UnityEngine;
+using Object = UnityEngine.Object;
+#if UNITY_2023_1_OR_NEWER
+using Converter = Aspid.MVVM.StarterKit.IConverter<string?, string?>;
+#else
+using Converter = Aspid.MVVM.StarterKit.IConverterString;
+#endif
+
+// ReSharper disable once CheckNamespace
+namespace Aspid.MVVM.StarterKit
+{
+    [Serializable]
+    public sealed class ObjectNameBinder : TargetBinder<Object>
+    {
+        [SerializeReferenceDropdown]
+        [SerializeReference] private Converter? _converter;
+
+        public ObjectNameBinder(GameObject target, BindMode mode)
+            : this(target, null, mode) { }
+        
+        public ObjectNameBinder(GameObject target, Converter? converter = null, BindMode mode = BindMode.OneWay)
+            : base(target, mode)
+        {
+            mode.ThrowExceptionIfTwo();
+            _converter = converter;
+        }
+
+        public void SetValue(string? value) =>
+            Target.name = _converter?.Convert(value) ?? value ?? string.Empty;
+    }
+}

--- a/Assets/Plugins/Aspid/MVVM/StarterKit/Unity/Runtime/Binders/Objects/ObjectNameBinder.cs.meta
+++ b/Assets/Plugins/Aspid/MVVM/StarterKit/Unity/Runtime/Binders/Objects/ObjectNameBinder.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: d5185909389c4a79b032d78ac61e3f90
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {fileID: 2800000, guid: 3f246f77b3b5a4b6ba0ab47ff519a0a9, type: 3}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 


### PR DESCRIPTION
Adds binder components for binding ViewModel properties to the `name` field of Unity `GameObject`s, enabling dynamic object naming driven by ViewModel data.