### PR TITLE
Add EmptyExecution in RelayCommand

### DIFF
--- a/Assets/Plugins/Aspid/MVVM/Source/Commands/Extensions/RelayCommandExtensions.Action.cs
+++ b/Assets/Plugins/Aspid/MVVM/Source/Commands/Extensions/RelayCommandExtensions.Action.cs
@@ -6,6 +6,7 @@ namespace Aspid.MVVM
 {
     public static partial class RelayCommandExtensions
     {
+        #region CreateCommand Methods
         /// <summary>
         /// Creates a <see cref="RelayCommand"/> from the specified execute and canExecute delegates.
         /// </summary>
@@ -65,12 +66,14 @@ namespace Aspid.MVVM
             this Action<T1?, T2?, T3?, T4?> execute,
             Func<T1?, T2?, T3?, T4?, bool>? canExecute = null) =>
             new(execute, canExecute);
+        #endregion
 
+        #region CreateCommand Or Get Empty RelayCommand Methods
         /// <summary>
         /// Creates a <see cref="RelayCommand"/> using the provided delegates.
         /// If <paramref name="execute"/> is <c>null</c>, returns a non-executable empty command.
         /// </summary>
-        /// <param name="execute">The action to execute. If <c>null</c>, an empty command will be returned.</param>
+        /// <param name="execute">The action to execute. If <c>null</c>, a non-executable empty command will be returned.</param>
         /// <param name="canExecute">The function that determines whether the command can execute. Optional.</param>
         /// <returns>
         /// A new <see cref="RelayCommand"/> instance, or <see cref="RelayCommand.Empty"/> if <paramref name="execute"/> is <c>null</c>.
@@ -80,12 +83,29 @@ namespace Aspid.MVVM
             this Action? execute, 
             Func<bool>? canExecute = null) =>
             execute is not null ? new RelayCommand(execute, canExecute) : RelayCommand.Empty;
+        
+        /// <summary>
+        /// Creates a <see cref="RelayCommand"/> using the provided delegates.
+        /// If <paramref name="execute"/> is <c>null</c>, returns an executable empty command.
+        /// </summary>
+        /// <param name="execute">The action to execute. If <c>null</c>, an executable empty command will be returned.</param>
+        /// <param name="canExecute">The function that determines whether the command can execute. Optional.</param>
+        /// <returns>
+        /// A new <see cref="RelayCommand"/> instance, or <see cref="RelayCommand.EmptyExecution"/> if <paramref name="execute"/> is <c>null</c>.
+        /// </returns>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static RelayCommand CreateCommandOrEmptyExecution(
+            this Action? execute, 
+            Func<bool>? canExecute = null) =>
+            execute is not null ? new RelayCommand(execute, canExecute) : RelayCommand.EmptyExecution;
+        #endregion
 
+        #region CreateCommand Or Get Empty RelayCommand<T> Methods
         /// <summary>
         /// Creates a <see cref="RelayCommand{T}"/> using the provided delegates.
         /// If <paramref name="execute"/> is <c>null</c>, returns a non-executable empty command.
         /// </summary>
-        /// <param name="execute">The action to execute. If <c>null</c>, an empty command will be returned.</param>
+        /// <param name="execute">The action to execute. If <c>null</c>, a non-executable empty command will be returned.</param>
         /// <param name="canExecute">Optional function to determine whether the command can execute.</param>
         /// <returns>
         /// A new <see cref="RelayCommand{T}"/> instance, or  <see cref="RelayCommand{T}.Empty"/> if <paramref name="execute"/> is <c>null</c>.
@@ -95,12 +115,29 @@ namespace Aspid.MVVM
             this Action<T?>? execute, 
             Func<T?, bool>? canExecute = null) =>
             execute is not null ? new RelayCommand<T?>(execute, canExecute) : RelayCommand<T?>.Empty;
+        
+        /// <summary>
+        /// Creates a <see cref="RelayCommand{T}"/> using the provided delegates.
+        /// If <paramref name="execute"/> is <c>null</c>, returns an executable empty command.
+        /// </summary>
+        /// <param name="execute">The action to execute. If <c>null</c>, an executable empty command will be returned.</param>
+        /// <param name="canExecute">Optional function to determine whether the command can execute.</param>
+        /// <returns>
+        /// A new <see cref="RelayCommand{T}"/> instance, or  <see cref="RelayCommand{T}.EmptyExecution"/> if <paramref name="execute"/> is <c>null</c>.
+        /// </returns>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static RelayCommand<T?> CreateCommandOrEmptyExecution<T>(
+            this Action<T?>? execute, 
+            Func<T?, bool>? canExecute = null) =>
+            execute is not null ? new RelayCommand<T?>(execute, canExecute) : RelayCommand<T?>.EmptyExecution;
+        #endregion
 
+        #region CreateCommand Or Get Empty RelayCommand<T1, T2> Methods
         /// <summary>
         /// Creates a <see cref="RelayCommand{T1, T2}"/> using the provided delegates.
         /// If <paramref name="execute"/> is <c>null</c>, returns a non-executable empty command.
         /// </summary>
-        /// <param name="execute">The action to execute. If <c>null</c>, an empty command will be returned.</param>
+        /// <param name="execute">The action to execute. If <c>null</c>, a non-executable empty command will be returned.</param>
         /// <param name="canExecute">Optional function to determine whether the command can execute.</param>
         /// <returns>
         /// A new <see cref="RelayCommand{T1, T2}"/> instance, or <see cref="RelayCommand{T1, T2}.Empty"/> if <paramref name="execute"/> is <c>null</c>.
@@ -110,12 +147,29 @@ namespace Aspid.MVVM
             this Action<T1?, T2?>? execute,
             Func<T1?, T2?, bool>? canExecute = null) =>
             execute is not null ? new RelayCommand<T1?, T2?>(execute, canExecute) : RelayCommand<T1?, T2?>.Empty;
+        
+        /// <summary>
+        /// Creates a <see cref="RelayCommand{T1, T2}"/> using the provided delegates.
+        /// If <paramref name="execute"/> is <c>null</c>, returns an executable empty command.
+        /// </summary>
+        /// <param name="execute">The action to execute. If <c>null</c>, an executable empty command will be returned.</param>
+        /// <param name="canExecute">Optional function to determine whether the command can execute.</param>
+        /// <returns>
+        /// A new <see cref="RelayCommand{T1, T2}"/> instance, or <see cref="RelayCommand{T1, T2}.EmptyExecution"/> if <paramref name="execute"/> is <c>null</c>.
+        /// </returns>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static RelayCommand<T1?, T2?> CreateCommandOrEmptyExecution<T1, T2>(
+            this Action<T1?, T2?>? execute,
+            Func<T1?, T2?, bool>? canExecute = null) =>
+            execute is not null ? new RelayCommand<T1?, T2?>(execute, canExecute) : RelayCommand<T1?, T2?>.EmptyExecution;
+        #endregion
 
+        #region CreateCommand Or Get Empty RelayCommand<T1, T2, T3> Methods
         /// <summary>
         /// Creates a <see cref="RelayCommand{T1, T2, T3}"/> using the provided delegates.
         /// If <paramref name="execute"/> is <c>null</c>, returns a non-executable empty command.
         /// </summary>
-        /// <param name="execute">The action to execute. If <c>null</c>, an empty command will be returned.</param>
+        /// <param name="execute">The action to execute. If <c>null</c>, a non-executable empty command will be returned.</param>
         /// <param name="canExecute">Optional function to determine whether the command can execute.</param>
         /// <returns>
         /// A new <see cref="RelayCommand{T1, T2, T3}"/> instance, or <see cref="RelayCommand{T1, T2, T3}.Empty"/> if <paramref name="execute"/> is <c>null</c>.
@@ -127,10 +181,27 @@ namespace Aspid.MVVM
             execute is not null ? new RelayCommand<T1?, T2?, T3?>(execute, canExecute) : RelayCommand<T1?, T2?, T3?>.Empty;
 
         /// <summary>
+        /// Creates a <see cref="RelayCommand{T1, T2, T3}"/> using the provided delegates.
+        /// If <paramref name="execute"/> is <c>null</c>, returns an executable empty command.
+        /// </summary>
+        /// <param name="execute">The action to execute. If <c>null</c>, an executable empty command will be returned.</param>
+        /// <param name="canExecute">Optional function to determine whether the command can execute.</param>
+        /// <returns>
+        /// A new <see cref="RelayCommand{T1, T2, T3}"/> instance, or <see cref="RelayCommand{T1, T2, T3}.EmptyExecution"/> if <paramref name="execute"/> is <c>null</c>.
+        /// </returns>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static RelayCommand<T1?, T2?, T3?> CreateCommandOrEmptyExecution<T1, T2, T3>(
+            this Action<T1?, T2?, T3?>? execute,
+            Func<T1?, T2?, T3?, bool>? canExecute = null) =>
+            execute is not null ? new RelayCommand<T1?, T2?, T3?>(execute, canExecute) : RelayCommand<T1?, T2?, T3?>.EmptyExecution;
+        #endregion
+
+        #region CreateCommand Or Get Empty RelayCommand<T1, T2, T3, T4> Methods
+        /// <summary>
         /// Creates a <see cref="RelayCommand{T1, T2, T3, T4}"/> using the provided delegates.
         /// If <paramref name="execute"/> is <c>null</c>, returns a non-executable empty command.
         /// </summary>
-        /// <param name="execute">The action to execute. If <c>null</c>, an empty command will be returned.</param>
+        /// <param name="execute">The action to execute. If <c>null</c>, a non-executable empty command will be returned.</param>
         /// <param name="canExecute">Optional function to determine whether the command can execute.</param>
         /// <returns>
         /// A new <see cref="RelayCommand{T1, T2, T3, T4}"/> instance, or <see cref="RelayCommand{T1, T2, T3, T4}.Empty"/> if <paramref name="execute"/> is <c>null</c>.
@@ -140,5 +211,21 @@ namespace Aspid.MVVM
             this Action<T1?, T2?, T3?, T4?>? execute,
             Func<T1?, T2?, T3?, T4?, bool>? canExecute = null) =>
             execute is not null ? new RelayCommand<T1?, T2?, T3?, T4?>(execute, canExecute) : RelayCommand<T1?, T2?, T3?, T4?>.Empty;
+        
+        /// <summary>
+        /// Creates a <see cref="RelayCommand{T1, T2, T3, T4}"/> using the provided delegates.
+        /// If <paramref name="execute"/> is <c>null</c>, returns an executable empty command.
+        /// </summary>
+        /// <param name="execute">The action to execute. If <c>null</c>, an executable empty command will be returned.</param>
+        /// <param name="canExecute">Optional function to determine whether the command can execute.</param>
+        /// <returns>
+        /// A new <see cref="RelayCommand{T1, T2, T3, T4}"/> instance, or <see cref="RelayCommand{T1, T2, T3, T4}.EmptyExecution"/> if <paramref name="execute"/> is <c>null</c>.
+        /// </returns>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static RelayCommand<T1?, T2?, T3?, T4?> CreateCommandOrEmptyExecution<T1, T2, T3, T4>(
+            this Action<T1?, T2?, T3?, T4?>? execute,
+            Func<T1?, T2?, T3?, T4?, bool>? canExecute = null) =>
+            execute is not null ? new RelayCommand<T1?, T2?, T3?, T4?>(execute, canExecute) : RelayCommand<T1?, T2?, T3?, T4?>.EmptyExecution;
+        #endregion
     }
 }

--- a/Assets/Plugins/Aspid/MVVM/Source/Commands/Extensions/RelayCommandExtensions.WithoutParameters.cs
+++ b/Assets/Plugins/Aspid/MVVM/Source/Commands/Extensions/RelayCommandExtensions.WithoutParameters.cs
@@ -5,6 +5,7 @@ namespace Aspid.MVVM
 {
     public static partial class RelayCommandExtensions
     {
+        #region CreateCommandWithoutParameters Methods
         /// <summary>
         /// Creates a parameterless <see cref="IRelayCommand"/> that executes the original command with the specified argument.
         /// </summary>
@@ -50,10 +51,12 @@ namespace Aspid.MVVM
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static IRelayCommand CreateCommandWithoutParameters<T1, T2, T3, T4>(this IRelayCommand<T1, T2, T3, T4> command, T1 param1, T2 param2, T3 param3, T4 param4) => 
             new RelayCommand(() => command.Execute(param1, param2, param3, param4), () => command.CanExecute(param1, param2, param3, param4));
+        #endregion
         
+        #region CreateCommandWithoutParameters Or Get Empty RelayCommand<T> Methods
         /// <summary>
         /// Creates a parameterless <see cref="IRelayCommand"/> that wraps the original command and uses the specified parameter.
-        /// If the original command is <c>null</c>, returns an empty command.
+        /// If the original command is <c>null</c>, returns a non-executable empty command.
         /// </summary>
         /// <param name="command">The source command with a parameter, or <c>null</c>.</param>
         /// <param name="param">The value to pass to the command.</param>
@@ -65,10 +68,27 @@ namespace Aspid.MVVM
         public static IRelayCommand CreateCommandWithoutParametersOrEmpty<T>(this IRelayCommand<T>? command, T param) => command is not null
             ? new RelayCommand(() => command.Execute(param), () => command.CanExecute(param))
             : RelayCommand.Empty;
-
+        
         /// <summary>
         /// Creates a parameterless <see cref="IRelayCommand"/> that wraps the original command and uses the specified parameter.
-        /// If the original command is <c>null</c>, returns an empty command.
+        /// If the original command is <c>null</c>, returns an executable empty command.
+        /// </summary>
+        /// <param name="command">The source command with a parameter, or <c>null</c>.</param>
+        /// <param name="param">The value to pass to the command.</param>
+        /// <returns>
+        /// A parameterless command that invokes the original command with the given parameter,
+        /// or <see cref="RelayCommand.EmptyExecution"/> if the command is <c>null</c>.
+        /// </returns>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static IRelayCommand CreateCommandWithoutParametersOrEmptyExecution<T>(this IRelayCommand<T>? command, T param) => command is not null
+            ? new RelayCommand(() => command.Execute(param), () => command.CanExecute(param))
+            : RelayCommand.EmptyExecution;
+        #endregion
+
+        #region CreateCommandWithoutParameters Or Get Empty RelayCommand<T1, T2> Methods
+        /// <summary>
+        /// Creates a parameterless <see cref="IRelayCommand"/> that wraps the original command and uses the specified parameter.
+        /// If the original command is <c>null</c>, returns a non-executable empty command.
         /// </summary>
         /// <param name="command">The source command with a parameter, or <c>null</c>.</param>
         /// <param name="param1">The first value to pass to the command.</param>
@@ -84,7 +104,25 @@ namespace Aspid.MVVM
         
         /// <summary>
         /// Creates a parameterless <see cref="IRelayCommand"/> that wraps the original command and uses the specified parameter.
-        /// If the original command is <c>null</c>, returns an empty command.
+        /// If the original command is <c>null</c>, returns an executable empty command.
+        /// </summary>
+        /// <param name="command">The source command with a parameter, or <c>null</c>.</param>
+        /// <param name="param1">The first value to pass to the command.</param>
+        /// <param name="param2">The second value to pass to the command.</param>
+        /// <returns>
+        /// A parameterless command that invokes the original command with the given parameter,
+        /// or <see cref="RelayCommand.EmptyExecution"/> if the command is <c>null</c>.
+        /// </returns>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static IRelayCommand CreateCommandWithoutParametersOrEmptyExecution<T1, T2>(this IRelayCommand<T1, T2>? command, T1 param1, T2 param2) => command is not null
+            ? new RelayCommand(() => command.Execute(param1, param2), () => command.CanExecute(param1, param2))
+            : RelayCommand.EmptyExecution;
+        #endregion
+
+        #region CreateCommandWithoutParameters Or Get Empty RelayCommand<T1, T2, T3> Methods
+        /// <summary>
+        /// Creates a parameterless <see cref="IRelayCommand"/> that wraps the original command and uses the specified parameter.
+        /// If the original command is <c>null</c>, returns a non-executable empty command.
         /// </summary>
         /// <param name="command">The source command with a parameter, or <c>null</c>.</param>
         /// <param name="param1">The first value to pass to the command.</param>
@@ -101,7 +139,26 @@ namespace Aspid.MVVM
         
         /// <summary>
         /// Creates a parameterless <see cref="IRelayCommand"/> that wraps the original command and uses the specified parameter.
-        /// If the original command is <c>null</c>, returns an empty command.
+        /// If the original command is <c>null</c>, returns an executable empty command.
+        /// </summary>
+        /// <param name="command">The source command with a parameter, or <c>null</c>.</param>
+        /// <param name="param1">The first value to pass to the command.</param>
+        /// <param name="param2">The second value to pass to the command.</param>
+        /// <param name="param3">The third value to pass to the command.</param>
+        /// <returns>
+        /// A parameterless command that invokes the original command with the given parameter,
+        /// or <see cref="RelayCommand.EmptyExecution"/> if the command is <c>null</c>.
+        /// </returns>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static IRelayCommand CreateCommandWithoutParametersOrEmptyExecution<T1, T2, T3>(this IRelayCommand<T1, T2, T3>? command, T1 param1, T2 param2, T3 param3) => command is not null
+            ? new RelayCommand(() => command.Execute(param1, param2, param3), () => command.CanExecute(param1, param2, param3))
+            : RelayCommand.EmptyExecution;
+        #endregion
+        
+        #region CreateCommandWithoutParameters Or Get Empty RelayCommand<T1, T2, T3, T4> Methods
+        /// <summary>
+        /// Creates a parameterless <see cref="IRelayCommand"/> that wraps the original command and uses the specified parameter.
+        /// If the original command is <c>null</c>, returns a non-executable empty command.
         /// </summary>
         /// <param name="command">The source command with a parameter, or <c>null</c>.</param>
         /// <param name="param1">The first value to pass to the command.</param>
@@ -116,5 +173,24 @@ namespace Aspid.MVVM
         public static IRelayCommand CreateCommandWithoutParametersOrEmpty<T1, T2, T3, T4>(this IRelayCommand<T1, T2, T3, T4>? command, T1 param1, T2 param2, T3 param3, T4 param4) => command is not null
             ? new RelayCommand(() => command.Execute(param1, param2, param3, param4), () => command.CanExecute(param1, param2, param3, param4))
             : RelayCommand.Empty;
+        
+        /// <summary>
+        /// Creates a parameterless <see cref="IRelayCommand"/> that wraps the original command and uses the specified parameter.
+        /// If the original command is <c>null</c>, returns an executable empty command.
+        /// </summary>
+        /// <param name="command">The source command with a parameter, or <c>null</c>.</param>
+        /// <param name="param1">The first value to pass to the command.</param>
+        /// <param name="param2">The second value to pass to the command.</param>
+        /// <param name="param3">The third value to pass to the command.</param>
+        /// <param name="param4">The fourth value to pass to the command.</param>
+        /// <returns>
+        /// A parameterless command that invokes the original command with the given parameter,
+        /// or <see cref="RelayCommand.EmptyExecution"/> if the command is <c>null</c>.
+        /// </returns>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static IRelayCommand CreateCommandWithoutParametersOrEmptyExecution<T1, T2, T3, T4>(this IRelayCommand<T1, T2, T3, T4>? command, T1 param1, T2 param2, T3 param3, T4 param4) => command is not null
+            ? new RelayCommand(() => command.Execute(param1, param2, param3, param4), () => command.CanExecute(param1, param2, param3, param4))
+            : RelayCommand.EmptyExecution;
+        #endregion
     }
 }

--- a/Assets/Plugins/Aspid/MVVM/Source/Commands/Extensions/RelayCommandExtensions.cs
+++ b/Assets/Plugins/Aspid/MVVM/Source/Commands/Extensions/RelayCommandExtensions.cs
@@ -5,35 +5,69 @@ namespace Aspid.MVVM
 {
     public static partial class RelayCommandExtensions
     {
+        #region Get Empty RelayCommand Methods
         /// <summary>
-        /// Returns the command if it's not null; otherwise, returns an empty no-op command.
+        /// Returns the command if it's not null; otherwise, returns an empty command.
         /// </summary>
         /// <param name="command">The command to check.</param>
         /// <returns>The original command if not null; otherwise, an empty command.</returns>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static IRelayCommand GetSelfOrEmpty(this IRelayCommand? command) =>
             command ?? RelayCommand.Empty;
-
+        
         /// <summary>
-        /// Returns the command if it's not null; otherwise, returns an empty no-op command.
+        /// Returns the command if it's not null; otherwise, returns an empty execution command.
+        /// </summary>
+        /// <param name="command">The command to check.</param>
+        /// <returns>The original command if not null; otherwise, an empty execution command.</returns>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static IRelayCommand GetSelfOrEmptyExecution(this IRelayCommand? command) =>
+            command ?? RelayCommand.EmptyExecution;
+        #endregion
+
+        #region Get Empty RelayCommand<T> Methods
+        /// <summary>
+        /// Returns the command if it's not null; otherwise, returns an empty command.
         /// </summary>
         /// <param name="command">The command to check.</param>
         /// <returns>The original command if not null; otherwise, an empty command.</returns>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static IRelayCommand<T?> GetSelfOrEmpty<T>(this IRelayCommand<T?>? command) =>
             command ?? RelayCommand<T?>.Empty;
-
+        
         /// <summary>
-        /// Returns the command if it's not null; otherwise, returns an empty no-op command.
+        /// Returns the command if it's not null; otherwise, returns an empty execution command.
+        /// </summary>
+        /// <param name="command">The command to check.</param>
+        /// <returns>The original command if not null; otherwise, an empty execution command.</returns>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static IRelayCommand<T?> GetSelfOrEmptyExecution<T>(this IRelayCommand<T?>? command) =>
+            command ?? RelayCommand<T?>.Empty;
+        #endregion
+
+        #region Get Empty RelayCommand<T1, T2> Methods
+        /// <summary>
+        /// Returns the command if it's not null; otherwise, returns an empty command.
         /// </summary>
         /// <param name="command">The command to check.</param>
         /// <returns>The original command if not null; otherwise, an empty command.</returns>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static IRelayCommand<T1?, T2?> GetSelfOrEmpty<T1, T2>(this IRelayCommand<T1?, T2?>? command) =>
             command ?? RelayCommand<T1?, T2?>.Empty;
-
+        
         /// <summary>
-        /// Returns the command if it's not null; otherwise, returns an empty no-op command.
+        /// Returns the command if it's not null; otherwise, returns an empty execution command.
+        /// </summary>
+        /// <param name="command">The command to check.</param>
+        /// <returns>The original command if not null; otherwise, an empty execution command.</returns>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static IRelayCommand<T1?, T2?> GetSelfOrEmptyExecution<T1, T2>(this IRelayCommand<T1?, T2?>? command) =>
+            command ?? RelayCommand<T1?, T2?>.Empty;
+        #endregion
+
+        #region Get Empty RelayCommand<T1, T2, T3> Methods
+        /// <summary>
+        /// Returns the command if it's not null; otherwise, returns an empty command.
         /// </summary>
         /// <param name="command">The command to check.</param>
         /// <returns>The original command if not null; otherwise, an empty command.</returns>
@@ -43,7 +77,19 @@ namespace Aspid.MVVM
             command ?? RelayCommand<T1?, T2?, T3?>.Empty;
 
         /// <summary>
-        /// Returns the command if it's not null; otherwise, returns an empty no-op command.
+        /// Returns the command if it's not null; otherwise, returns an empty execution command.
+        /// </summary>
+        /// <param name="command">The command to check.</param>
+        /// <returns>The original command if not null; otherwise, an empty execution command.</returns>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static IRelayCommand<T1?, T2?, T3?> GetSelfOrEmptyExecution<T1, T2, T3>(
+            this IRelayCommand<T1?, T2?, T3?>? command) =>
+            command ?? RelayCommand<T1?, T2?, T3?>.Empty;
+        #endregion
+        
+        #region Get Empty RelayCommand<T1, T2, T3, T4> Methods
+        /// <summary>
+        /// Returns the command if it's not null; otherwise, returns an empty command.
         /// </summary>
         /// <param name="command">The command to check.</param>
         /// <returns>The original command if not null; otherwise, an empty command.</returns>
@@ -51,5 +97,16 @@ namespace Aspid.MVVM
         public static IRelayCommand<T1?, T2?, T3?, T4?> GetSelfOrEmpty<T1, T2, T3, T4>(
             this IRelayCommand<T1?, T2?, T3?, T4?>? command) =>
             command ?? RelayCommand<T1?, T2?, T3?, T4?>.Empty;
+        
+        /// <summary>
+        /// Returns the command if it's not null; otherwise, returns an empty execution command.
+        /// </summary>
+        /// <param name="command">The command to check.</param>
+        /// <returns>The original command if not null; otherwise, an empty execution command.</returns>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static IRelayCommand<T1?, T2?, T3?, T4?> GetSelfOrEmptyExecution<T1, T2, T3, T4>(
+            this IRelayCommand<T1?, T2?, T3?, T4?>? command) =>
+            command ?? RelayCommand<T1?, T2?, T3?, T4?>.Empty;
+        #endregion
     }
 }

--- a/Assets/Plugins/Aspid/MVVM/Source/Commands/RelayCommand.cs
+++ b/Assets/Plugins/Aspid/MVVM/Source/Commands/RelayCommand.cs
@@ -24,6 +24,12 @@ namespace Aspid.MVVM
         public static RelayCommand Empty => _empty ??= new RelayCommand();
         
         /// <summary>
+        /// Gets an empty command that can be executed but performs no action.
+        /// Useful as a placeholder when a non-null executable command is required.
+        /// </summary>
+        public static RelayCommand EmptyExecution => _empty ?? new RelayCommand(true);
+        
+        /// <summary>
         /// Initializes a new instance of the <see cref="RelayCommand"/> class, taking an action to execute the command.
         /// </summary>
         /// <param name="execute">The action that will be executed by the command.</param>
@@ -47,7 +53,11 @@ namespace Aspid.MVVM
         }
         
 #pragma warning disable CS8618 // Non-nullable field must contain a non-null value when exiting constructor. Consider adding the 'required' modifier or declaring as nullable.
-        private RelayCommand() => _canExecute = () => false;
+        private RelayCommand(bool value = false)
+        {
+            if (value) _execute = () => { };
+            _canExecute = () => value;
+        }
 #pragma warning restore CS8618 // Non-nullable field must contain a non-null value when exiting constructor. Consider adding the 'required' modifier or declaring as nullable.
         
         /// <summary>
@@ -95,6 +105,12 @@ namespace Aspid.MVVM
         public static RelayCommand<T> Empty => _empty ??= new RelayCommand<T>();
         
         /// <summary>
+        /// Gets an empty command that can be executed but performs no action.
+        /// Useful as a placeholder when a non-null executable command is required.
+        /// </summary>
+        public static RelayCommand<T> EmptyExecution => _empty ?? new RelayCommand<T>(true);
+        
+        /// <summary>
         /// Initializes a new instance of the <see cref="RelayCommand{T}"/> class, taking an action to execute the command.
         /// </summary>
         /// <param name="execute">The action that will be executed by the command.</param>
@@ -118,7 +134,11 @@ namespace Aspid.MVVM
         }
         
 #pragma warning disable CS8618 // Non-nullable field must contain a non-null value when exiting constructor. Consider adding the 'required' modifier or declaring as nullable.
-        private RelayCommand() => _canExecute = _ => false;
+        private RelayCommand(bool value = false)
+        {
+            if (value) _execute = (_) => { };
+            _canExecute = (_) => value;
+        }
 #pragma warning restore CS8618 // Non-nullable field must contain a non-null value when exiting constructor. Consider adding the 'required' modifier or declaring as nullable.
         
         /// <summary>
@@ -169,6 +189,12 @@ namespace Aspid.MVVM
         public static RelayCommand<T1, T2> Empty => _empty ??= new RelayCommand<T1, T2>();
         
         /// <summary>
+        /// Gets an empty command that can be executed but performs no action.
+        /// Useful as a placeholder when a non-null executable command is required.
+        /// </summary>
+        public static RelayCommand<T1, T2> EmptyExecution => _empty ?? new RelayCommand<T1, T2>(true);
+        
+        /// <summary>
         /// Initializes a new instance of the <see cref="RelayCommand{T1, T2}"/> class, taking an action to execute the command.
         /// </summary>
         /// <param name="execute">The action that will be executed by the command.</param>
@@ -192,7 +218,11 @@ namespace Aspid.MVVM
         }
         
 #pragma warning disable CS8618 // Non-nullable field must contain a non-null value when exiting constructor. Consider adding the 'required' modifier or declaring as nullable.
-        private RelayCommand() => _canExecute = (_, _) => false;
+        private RelayCommand(bool value = false)
+        {
+            if (value) _execute = (_, _) => { };
+            _canExecute = (_, _) => value;
+        }
 #pragma warning restore CS8618 // Non-nullable field must contain a non-null value when exiting constructor. Consider adding the 'required' modifier or declaring as nullable.
         
         /// <summary>
@@ -246,6 +276,12 @@ namespace Aspid.MVVM
         public static RelayCommand<T1, T2, T3> Empty => _empty ??= new RelayCommand<T1, T2, T3>();
         
         /// <summary>
+        /// Gets an empty command that can be executed but performs no action.
+        /// Useful as a placeholder when a non-null executable command is required.
+        /// </summary>
+        public static RelayCommand<T1, T2, T3> EmptyExecution => _empty ?? new RelayCommand<T1, T2, T3>(true);
+        
+        /// <summary>
         /// Initializes a new instance of the <see cref="RelayCommand{T1, T2, T3}"/> class, taking an action to execute the command.
         /// </summary>
         /// <param name="execute">The action that will be executed by the command.</param>
@@ -268,7 +304,11 @@ namespace Aspid.MVVM
         }
         
 #pragma warning disable CS8618 // Non-nullable field must contain a non-null value when exiting constructor. Consider adding the 'required' modifier or declaring as nullable.
-        private RelayCommand() => _canExecute = (_, _, _) => false;
+        private RelayCommand(bool value = false)
+        {
+            if (value) _execute = (_, _, _) => { };
+            _canExecute = (_, _, _) => value;
+        }
 #pragma warning restore CS8618 // Non-nullable field must contain a non-null value when exiting constructor. Consider adding the 'required' modifier or declaring as nullable.
         
         /// <summary>
@@ -325,6 +365,12 @@ namespace Aspid.MVVM
         public static RelayCommand<T1, T2, T3, T4> Empty => _empty ??= new RelayCommand<T1, T2, T3, T4>();
         
         /// <summary>
+        /// Gets an empty command that can be executed but performs no action.
+        /// Useful as a placeholder when a non-null executable command is required.
+        /// </summary>
+        public static RelayCommand<T1, T2, T3, T4> EmptyExecution => _empty ?? new RelayCommand<T1, T2, T3, T4>(true);
+        
+        /// <summary>
         /// Initializes a new instance of the <see cref="RelayCommand{T1, T2, T3, T4}"/> class, taking an action to execute the command.
         /// </summary>
         /// <param name="execute">The action that will be executed by the command.</param>
@@ -347,7 +393,11 @@ namespace Aspid.MVVM
         }
         
 #pragma warning disable CS8618 // Non-nullable field must contain a non-null value when exiting constructor. Consider adding the 'required' modifier or declaring as nullable.
-        private RelayCommand() => _canExecute = (_, _, _, _) => false;
+        private RelayCommand(bool value = false)
+        {
+            if (value) _execute = (_, _, _, _) => { };
+            _canExecute = (_, _, _, _) => value;
+        }
 #pragma warning restore CS8618 // Non-nullable field must contain a non-null value when exiting constructor. Consider adding the 'required' modifier or declaring as nullable.
         
         /// <summary>


### PR DESCRIPTION
Adds `EmptyExecution` mode to `RelayCommand`, allowing commands to be declared without an execute delegate for cases where the command only needs `CanExecute` logic or delegates execution to another system.