### PR TITLE
Fix ViewInitializers

### DIFF
--- a/Aspid.MVVM/Assets/Plugins/Aspid/MVVM/StarterKit/Unity/Editor/Views/Initializers/ViewInitializerEditor.cs
+++ b/Aspid.MVVM/Assets/Plugins/Aspid/MVVM/StarterKit/Unity/Editor/Views/Initializers/ViewInitializerEditor.cs
@@ -74,7 +74,10 @@ namespace Aspid.MVVM.StarterKit
                 {
                     EditorGUILayout.PropertyField(_initializeStage);
 
-                    if (_initializeStage.enumValueIndex == 0) _isDeinitialize.boolValue = false;
+                    if (_initializeStage.enumValueIndex is 0 or 4)
+                    {
+                        _isDeinitialize.boolValue = false;
+                    }
                     else EditorGUILayout.PropertyField(_isDeinitialize);
                 }
                 serializedObject.ApplyModifiedProperties();

--- a/Aspid.MVVM/Assets/Plugins/Aspid/MVVM/StarterKit/Unity/Runtime/Views/Initializers/ViewInitializerBase.cs
+++ b/Aspid.MVVM/Assets/Plugins/Aspid/MVVM/StarterKit/Unity/Runtime/Views/Initializers/ViewInitializerBase.cs
@@ -1,12 +1,94 @@
+using System;
 using UnityEngine;
 
 // ReSharper disable once CheckNamespace
 namespace Aspid.MVVM.StarterKit
 {
     public abstract class ViewInitializerBase : MonoBehaviour
-    {
-        public bool IsInitialized { get; protected set; }
+    { 
+        [SerializeField] private bool _isDisposeViewOnDestroy = true;
+        [SerializeField] private InitializeComponent<IView>[] _viewComponents;
         
-        public IViewModel ViewModel { get; protected set; }
+        private IView[] _views;
+        
+#if ASPID_MVVM_ZENJECT_INTEGRATION
+        [Zenject.Inject]
+        private Zenject.DiContainer _zenjectContainer;
+#endif
+#if ASPID_MVVM_VCONTAINER_INTEGRATION
+        [VContainer.Inject] 
+        private VContainer.IObjectResolver _vcontainerContainer; 
+#endif
+        
+        public IView[] Views
+        {
+            get
+            {
+#if UNITY_EDITOR
+                if (!Application.isPlaying)
+                {
+                    return GetViews();
+                }
+#endif
+
+                return _views ??= GetViews();
+
+                IView[] GetViews()
+                {
+                    var views = new IView[_viewComponents.Length];
+                    
+                    for (var i = 0; i < views.Length; i++)
+                    {
+                        var view = GetFromInitializeComponent(_viewComponents[i]);
+                
+                        if (view is IComponentInitializable viewInitializable)
+                            viewInitializable.Initialize();
+                    
+                        views[i] = view;
+                    }
+
+                    return views;
+                }
+            }
+        }
+        
+        public abstract IViewModel ViewModel { get; }
+        
+        public bool IsInitialized { get; protected set; }
+
+        protected bool IsDisposeViewOnDestroy => _isDisposeViewOnDestroy;
+
+        protected virtual void OnValidate()
+        {
+            if (_viewComponents is not null)
+            {
+                foreach (var viewComponent in _viewComponents)
+                    viewComponent?.Validate();
+            }
+        }
+
+        protected T GetFromInitializeComponent<T>(InitializeComponent<T> initializeComponent)
+            where T : class
+        {
+            switch (initializeComponent.Resolve)
+            {
+#if ASPID_MVVM_ZENJECT_INTEGRATION || ASPID_MVVM_VCONTAINER_INTEGRATION
+                case InitializeComponent.ResolveType.Di:
+#if ASPID_MVVM_ZENJECT_INTEGRATION
+                    var zenjectResult = _zenjectContainer?.TryResolve(initializeComponent.Type);
+                    if (zenjectResult is T specificZenjectResult) return specificZenjectResult;
+#endif
+#if ASPID_MVVM_VCONTAINER_INTEGRATION
+                    if (_vcontainerContainer?.TryResolve(initializeComponent.Type, out var specificVContainerResult) ?? false)
+                        return specificVContainerResult as T;
+#endif
+                    throw new Exception("Unknown initialize component type: " + initializeComponent.Type);
+#endif
+                case InitializeComponent.ResolveType.Mono: return initializeComponent.Mono as T;
+                case InitializeComponent.ResolveType.References: return initializeComponent.References;
+                case InitializeComponent.ResolveType.ScriptableObject: return initializeComponent.Scriptable as T;
+                default: throw new ArgumentOutOfRangeException();
+            }
+        }
     }
 }

--- a/Aspid.MVVM/Assets/Plugins/Aspid/MVVM/StarterKit/Unity/Runtime/Views/Initializers/ViewInitializerManual.cs
+++ b/Aspid.MVVM/Assets/Plugins/Aspid/MVVM/StarterKit/Unity/Runtime/Views/Initializers/ViewInitializerManual.cs
@@ -8,76 +8,16 @@ namespace Aspid.MVVM.StarterKit
     [AddComponentMenu("Aspid/MVVM/View Initializers/View Initializer Manual")]
     public sealed class ViewInitializerManual : ViewInitializerBase
     {
-        [SerializeField] private bool _isDisposeViewOnDestroy = true;
-        [SerializeField] private InitializeComponent<IView>[] _viewComponents;
-        
-        private IView[] _views;
-        private bool _isConstructed;
-        
-#if ASPID_MVVM_ZENJECT_INTEGRATION
-        [Zenject.Inject]
-        private Zenject.DiContainer _zenjectContainer;
-#endif
-#if ASPID_MVVM_VCONTAINER_INTEGRATION
-        [VContainer.Inject] 
-        private VContainer.IObjectResolver _vcontainerContainer; 
-#endif
-        
-        private void Constructor()
-        {
-            if (_isConstructed) return;
-
-            _views = new IView[_viewComponents.Length];
-            
-            for (var i = 0; i < _views.Length; i++)
-            {
-                var view = Get(_viewComponents[i]);
-                
-                if (view is IComponentInitializable viewInitializable)
-                    viewInitializable.Initialize();
-                    
-                _views[i] = view;
-            }
-
-            _isConstructed = true;
-            return;
-
-            T Get<T>(InitializeComponent<T> initializeComponent) 
-                where T : class
-            {
-                switch (initializeComponent.Resolve)
-                {
-#if ASPID_MVVM_ZENJECT_INTEGRATION || ASPID_MVVM_VCONTAINER_INTEGRATION
-                    case InitializeComponent.ResolveType.Di:
-#if ASPID_MVVM_ZENJECT_INTEGRATION
-                        var result = _zenjectContainer?.Resolve(initializeComponent.Type);
-                        if (result is T specificResult) return specificResult;
-#endif
-#if ASPID_MVVM_VCONTAINER_INTEGRATION
-                        return _vcontainerContainer?.Resolve(initializeComponent.Type) as T;
-#endif
-#endif
-                    
-                    case InitializeComponent.ResolveType.Mono: return initializeComponent.Mono as T;
-                    case InitializeComponent.ResolveType.References: return initializeComponent.References;
-                    case InitializeComponent.ResolveType.ScriptableObject: return initializeComponent.Scriptable as T;
-                    default: throw new ArgumentOutOfRangeException();
-                }
-            }
-        }
+        private IViewModel _viewModel;
 
         public void Initialize(IViewModel viewModel)
         {
             if (IsInitialized)
                 throw new Exception($"{nameof(ViewInitializerManual)} can't be initialized twice");
+
+            _viewModel = viewModel ?? throw new ArgumentNullException(nameof(viewModel));
             
-            if (viewModel is null)
-	            if (viewModel is null) throw new ArgumentNullException(nameof(viewModel));
-
-            Constructor();
-
-            ViewModel = viewModel;
-            foreach (var view in _views)
+            foreach (var view in Views)
                 view.Initialize(viewModel);
             
             IsInitialized = true;
@@ -87,28 +27,22 @@ namespace Aspid.MVVM.StarterKit
         {
             if (!IsInitialized) return;
 
-            foreach (var view in _views)
+            foreach (var view in Views)
                 view.Deinitialize();
 
-            ViewModel = null;
+            _viewModel = null;
             IsInitialized = false;
-        }
-
-        private void OnValidate()
-        {
-            if (_viewComponents is null) return;
-            
-            foreach (var viewComponent in _viewComponents)
-                viewComponent?.Validate();
         }
 
         private void OnDestroy()
         {
-            if (_isDisposeViewOnDestroy)
+            if (IsDisposeViewOnDestroy)
             {
-                foreach (var view in _views)
+                foreach (var view in Views)
                     view.DisposeView();
             }
         }
+
+        public override IViewModel ViewModel => _viewModel;
     }
 }


### PR DESCRIPTION
Fixes bugs in `ViewInitializer` components where incorrect initialization order or missing setup steps caused bindings to not be applied when views are initialized dynamically at runtime.