### PR TITLE
Add LayoutGroup Binders

### DIFF
--- a/Aspid.MVVM/Assets/Plugins/Aspid/MVVM/StarterKit/Unity/Runtime/Binders/Layouts.meta
+++ b/Aspid.MVVM/Assets/Plugins/Aspid/MVVM/StarterKit/Unity/Runtime/Binders/Layouts.meta
@@ -1,0 +1,3 @@
+fileFormatVersion: 2
+guid: fb5002c11f9047dba3594b0e31cf729d
+timeCreated: 1769681333

--- a/Aspid.MVVM/Assets/Plugins/Aspid/MVVM/StarterKit/Unity/Runtime/Binders/Layouts/Extensions.meta
+++ b/Aspid.MVVM/Assets/Plugins/Aspid/MVVM/StarterKit/Unity/Runtime/Binders/Layouts/Extensions.meta
@@ -1,0 +1,3 @@
+fileFormatVersion: 2
+guid: 5826d20b69fe455c9c2c6cfd6155abb4
+timeCreated: 1769683266

--- a/Aspid.MVVM/Assets/Plugins/Aspid/MVVM/StarterKit/Unity/Runtime/Binders/Layouts/Extensions/LayoutSetters.cs
+++ b/Aspid.MVVM/Assets/Plugins/Aspid/MVVM/StarterKit/Unity/Runtime/Binders/Layouts/Extensions/LayoutSetters.cs
@@ -1,0 +1,31 @@
+using System;
+using UnityEngine.UI;
+using System.Runtime.CompilerServices;
+
+// ReSharper disable once CheckNamespace
+namespace Aspid.MVVM.StarterKit
+{
+    public static class LayoutSetters
+    {
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static void SetPadding(this LayoutGroup layout, int top, int right, int bottom, int left, PaddingMode mode)
+        {
+            switch (mode)
+            {
+                case PaddingMode.All: 
+                    layout.padding.top = top;
+                    layout.padding.left = left;
+                    layout.padding.right = right;
+                    layout.padding.bottom = bottom;
+                    break;
+                
+                case PaddingMode.Top: layout.padding.top = top; break;
+                case PaddingMode.Left: layout.padding.left = left; break;
+                case PaddingMode.Right: layout.padding.right = right; break;
+                case PaddingMode.Bottom: layout.padding.bottom = bottom; break;
+                
+                default: throw new ArgumentOutOfRangeException();
+            }
+        }
+    }
+}

--- a/Aspid.MVVM/Assets/Plugins/Aspid/MVVM/StarterKit/Unity/Runtime/Binders/Layouts/Extensions/LayoutSetters.cs.meta
+++ b/Aspid.MVVM/Assets/Plugins/Aspid/MVVM/StarterKit/Unity/Runtime/Binders/Layouts/Extensions/LayoutSetters.cs.meta
@@ -1,0 +1,3 @@
+fileFormatVersion: 2
+guid: 162766aa691c4d00990946971e658b43
+timeCreated: 1769683303

--- a/Aspid.MVVM/Assets/Plugins/Aspid/MVVM/StarterKit/Unity/Runtime/Binders/Layouts/HorizontalOrVerticalLayoutGroup.meta
+++ b/Aspid.MVVM/Assets/Plugins/Aspid/MVVM/StarterKit/Unity/Runtime/Binders/Layouts/HorizontalOrVerticalLayoutGroup.meta
@@ -1,0 +1,3 @@
+fileFormatVersion: 2
+guid: 789b19d1445c4d4b92d41ec3fec944e4
+timeCreated: 1769681347

--- a/Aspid.MVVM/Assets/Plugins/Aspid/MVVM/StarterKit/Unity/Runtime/Binders/Layouts/HorizontalOrVerticalLayoutGroup/HorizontalOrVerticalLayoutSpacingBinder.cs
+++ b/Aspid.MVVM/Assets/Plugins/Aspid/MVVM/StarterKit/Unity/Runtime/Binders/Layouts/HorizontalOrVerticalLayoutGroup/HorizontalOrVerticalLayoutSpacingBinder.cs
@@ -1,0 +1,32 @@
+#nullable enable
+using System;
+using UnityEngine.UI;
+
+// ReSharper disable once CheckNamespace
+namespace Aspid.MVVM.StarterKit
+{
+    [Serializable]
+    public class HorizontalOrVerticalLayoutSpacingBinder : TargetBinder<HorizontalOrVerticalLayoutGroup>, INumberBinder
+    {
+        public HorizontalOrVerticalLayoutSpacingBinder(
+            HorizontalOrVerticalLayoutGroup target, 
+            BindMode bindMode = BindMode.OneWay)
+            : base(target, bindMode)
+        {
+            bindMode.ThrowExceptionIfTwo();
+        }
+
+        public void SetValue(int value) => 
+            Target.spacing = value;
+
+        public void SetValue(long value) =>
+            SetValue((int)value);
+
+        public void SetValue(float value) =>
+            Target.spacing = value;
+
+        public void SetValue(double value) =>
+            SetValue((float)value);
+    }
+}
+

--- a/Aspid.MVVM/Assets/Plugins/Aspid/MVVM/StarterKit/Unity/Runtime/Binders/Layouts/HorizontalOrVerticalLayoutGroup/HorizontalOrVerticalLayoutSpacingBinder.cs.meta
+++ b/Aspid.MVVM/Assets/Plugins/Aspid/MVVM/StarterKit/Unity/Runtime/Binders/Layouts/HorizontalOrVerticalLayoutGroup/HorizontalOrVerticalLayoutSpacingBinder.cs.meta
@@ -1,0 +1,3 @@
+fileFormatVersion: 2
+guid: 1f5895aebb594e068094ac0ebde40235
+timeCreated: 1769700649

--- a/Aspid.MVVM/Assets/Plugins/Aspid/MVVM/StarterKit/Unity/Runtime/Binders/Layouts/HorizontalOrVerticalLayoutGroup/HorizontalOrVerticalLayoutSpacingSwitcherBinder.cs
+++ b/Aspid.MVVM/Assets/Plugins/Aspid/MVVM/StarterKit/Unity/Runtime/Binders/Layouts/HorizontalOrVerticalLayoutGroup/HorizontalOrVerticalLayoutSpacingSwitcherBinder.cs
@@ -1,0 +1,21 @@
+#nullable enable
+using System;
+using UnityEngine.UI;
+
+// ReSharper disable once CheckNamespace
+namespace Aspid.MVVM.StarterKit
+{
+    [Serializable]
+    public sealed class HorizontalOrVerticalLayoutSpacingSwitcherBinder : SwitcherBinder<HorizontalOrVerticalLayoutGroup, float>
+    {
+        public HorizontalOrVerticalLayoutSpacingSwitcherBinder(
+            HorizontalOrVerticalLayoutGroup target,
+            float trueValue, 
+            float falseValue,
+            BindMode bindMode = BindMode.OneWay)
+            : base(target, trueValue, falseValue, bindMode) { }
+
+        protected override void SetValue(float value) =>
+            Target.spacing = value;
+    }
+}

--- a/Aspid.MVVM/Assets/Plugins/Aspid/MVVM/StarterKit/Unity/Runtime/Binders/Layouts/HorizontalOrVerticalLayoutGroup/HorizontalOrVerticalLayoutSpacingSwitcherBinder.cs.meta
+++ b/Aspid.MVVM/Assets/Plugins/Aspid/MVVM/StarterKit/Unity/Runtime/Binders/Layouts/HorizontalOrVerticalLayoutGroup/HorizontalOrVerticalLayoutSpacingSwitcherBinder.cs.meta
@@ -1,0 +1,3 @@
+fileFormatVersion: 2
+guid: b7f7e353b19343b7a28935b4c0a99163
+timeCreated: 1769700657

--- a/Aspid.MVVM/Assets/Plugins/Aspid/MVVM/StarterKit/Unity/Runtime/Binders/Layouts/HorizontalOrVerticalLayoutGroup/Mono.meta
+++ b/Aspid.MVVM/Assets/Plugins/Aspid/MVVM/StarterKit/Unity/Runtime/Binders/Layouts/HorizontalOrVerticalLayoutGroup/Mono.meta
@@ -1,0 +1,3 @@
+fileFormatVersion: 2
+guid: 9513c4cbf1554ff8814c1da4f5e9cf91
+timeCreated: 1769681353

--- a/Aspid.MVVM/Assets/Plugins/Aspid/MVVM/StarterKit/Unity/Runtime/Binders/Layouts/HorizontalOrVerticalLayoutGroup/Mono/HorizontalOrVerticalLayoutGroupSpacingEnumGroupMonoBinder.cs
+++ b/Aspid.MVVM/Assets/Plugins/Aspid/MVVM/StarterKit/Unity/Runtime/Binders/Layouts/HorizontalOrVerticalLayoutGroup/Mono/HorizontalOrVerticalLayoutGroupSpacingEnumGroupMonoBinder.cs
@@ -1,0 +1,20 @@
+using UnityEngine;
+using UnityEngine.UI;
+
+// ReSharper disable once CheckNamespace
+namespace Aspid.MVVM.StarterKit
+{
+    [AddBinderContextMenu(typeof(HorizontalOrVerticalLayoutGroup), serializePropertyNames: "m_Spacing")]
+    [AddComponentMenu("Aspid/MVVM/Binders/UI/Layout/Horizontal Or Vertical Layout Group/HorizontalOrVerticalLayoutGroup Binder – Spacing EnumGroup")]
+    public sealed class HorizontalOrVerticalLayoutGroupSpacingEnumGroupMonoBinder : EnumGroupMonoBinder<HorizontalOrVerticalLayoutGroup>
+    {
+        [SerializeField] private float _defaultValue;
+        [SerializeField] private float _selectedValue;
+
+        protected override void SetDefaultValue(HorizontalOrVerticalLayoutGroup element) =>
+            element.spacing = _defaultValue;
+
+        protected override void SetSelectedValue(HorizontalOrVerticalLayoutGroup element) =>
+            element.spacing = _selectedValue;
+    }
+}

--- a/Aspid.MVVM/Assets/Plugins/Aspid/MVVM/StarterKit/Unity/Runtime/Binders/Layouts/HorizontalOrVerticalLayoutGroup/Mono/HorizontalOrVerticalLayoutGroupSpacingEnumGroupMonoBinder.cs.meta
+++ b/Aspid.MVVM/Assets/Plugins/Aspid/MVVM/StarterKit/Unity/Runtime/Binders/Layouts/HorizontalOrVerticalLayoutGroup/Mono/HorizontalOrVerticalLayoutGroupSpacingEnumGroupMonoBinder.cs.meta
@@ -1,0 +1,3 @@
+fileFormatVersion: 2
+guid: 1113292ff5cf4e6587e7e52d085f48ab
+timeCreated: 1769701032

--- a/Aspid.MVVM/Assets/Plugins/Aspid/MVVM/StarterKit/Unity/Runtime/Binders/Layouts/HorizontalOrVerticalLayoutGroup/Mono/HorizontalOrVerticalLayoutSpacingEnumMonoBinder.cs
+++ b/Aspid.MVVM/Assets/Plugins/Aspid/MVVM/StarterKit/Unity/Runtime/Binders/Layouts/HorizontalOrVerticalLayoutGroup/Mono/HorizontalOrVerticalLayoutSpacingEnumMonoBinder.cs
@@ -1,0 +1,14 @@
+using UnityEngine;
+using UnityEngine.UI;
+
+// ReSharper disable once CheckNamespace
+namespace Aspid.MVVM.StarterKit
+{
+    [AddBinderContextMenu(typeof(HorizontalOrVerticalLayoutGroup), serializePropertyNames: "m_Spacing")]
+    [AddComponentMenu("Aspid/MVVM/Binders/UI/Layout/Horizontal Or Vertical Layout Group/HorizontalOrVerticalLayoutGroup Binder – Spacing Enum")]
+    public sealed class HorizontalOrVerticalLayoutSpacingEnumMonoBinder : EnumMonoBinder<HorizontalOrVerticalLayoutGroup, float>
+    {
+        protected override void SetValue(float value) =>
+            CachedComponent.spacing = value;
+    }
+}

--- a/Aspid.MVVM/Assets/Plugins/Aspid/MVVM/StarterKit/Unity/Runtime/Binders/Layouts/HorizontalOrVerticalLayoutGroup/Mono/HorizontalOrVerticalLayoutSpacingEnumMonoBinder.cs.meta
+++ b/Aspid.MVVM/Assets/Plugins/Aspid/MVVM/StarterKit/Unity/Runtime/Binders/Layouts/HorizontalOrVerticalLayoutGroup/Mono/HorizontalOrVerticalLayoutSpacingEnumMonoBinder.cs.meta
@@ -1,0 +1,3 @@
+fileFormatVersion: 2
+guid: f525b494b8304b448e1ae17daf73bd39
+timeCreated: 1769700627

--- a/Aspid.MVVM/Assets/Plugins/Aspid/MVVM/StarterKit/Unity/Runtime/Binders/Layouts/HorizontalOrVerticalLayoutGroup/Mono/HorizontalOrVerticalLayoutSpacingMonoBinder.cs
+++ b/Aspid.MVVM/Assets/Plugins/Aspid/MVVM/StarterKit/Unity/Runtime/Binders/Layouts/HorizontalOrVerticalLayoutGroup/Mono/HorizontalOrVerticalLayoutSpacingMonoBinder.cs
@@ -1,0 +1,27 @@
+using UnityEngine;
+using UnityEngine.UI;
+
+// ReSharper disable once CheckNamespace
+namespace Aspid.MVVM.StarterKit
+{
+    [AddBinderContextMenu(typeof(HorizontalOrVerticalLayoutGroup), serializePropertyNames: "m_Spacing")]
+    [AddComponentMenu("Aspid/MVVM/Binders/UI/Layout/Horizontal Or Vertical Layout Group/HorizontalOrVerticalLayoutGroup Binder – Spacing")]
+    public partial class HorizontalOrVerticalLayoutSpacingMonoBinder : ComponentMonoBinder<HorizontalOrVerticalLayoutGroup>, INumberBinder
+    {
+        [BinderLog]
+        public void SetValue(int value) =>
+            CachedComponent.spacing = value;
+
+        [BinderLog]
+        public void SetValue(long value) =>
+            SetValue((int)value);
+
+        [BinderLog]
+        public void SetValue(float value) =>
+            CachedComponent.spacing = value;
+
+        [BinderLog]
+        public void SetValue(double value) =>
+            SetValue((float)value);
+    }
+}

--- a/Aspid.MVVM/Assets/Plugins/Aspid/MVVM/StarterKit/Unity/Runtime/Binders/Layouts/HorizontalOrVerticalLayoutGroup/Mono/HorizontalOrVerticalLayoutSpacingMonoBinder.cs.meta
+++ b/Aspid.MVVM/Assets/Plugins/Aspid/MVVM/StarterKit/Unity/Runtime/Binders/Layouts/HorizontalOrVerticalLayoutGroup/Mono/HorizontalOrVerticalLayoutSpacingMonoBinder.cs.meta
@@ -1,0 +1,3 @@
+fileFormatVersion: 2
+guid: 58d2076498e84c7d9bec8db8641c70fa
+timeCreated: 1769700602

--- a/Aspid.MVVM/Assets/Plugins/Aspid/MVVM/StarterKit/Unity/Runtime/Binders/Layouts/HorizontalOrVerticalLayoutGroup/Mono/HorizontalOrVerticalLayoutSpacingSwitcherMonoBinder.cs
+++ b/Aspid.MVVM/Assets/Plugins/Aspid/MVVM/StarterKit/Unity/Runtime/Binders/Layouts/HorizontalOrVerticalLayoutGroup/Mono/HorizontalOrVerticalLayoutSpacingSwitcherMonoBinder.cs
@@ -1,0 +1,14 @@
+using UnityEngine;
+using UnityEngine.UI;
+
+// ReSharper disable once CheckNamespace
+namespace Aspid.MVVM.StarterKit
+{
+    [AddBinderContextMenu(typeof(HorizontalOrVerticalLayoutGroup), serializePropertyNames: "m_Spacing")]
+    [AddComponentMenu("Aspid/MVVM/Binders/UI/Layout/Horizontal Or Vertical Layout Group/HorizontalOrVerticalLayoutGroup Binder – Spacing Switcher")]
+    public sealed class HorizontalOrVerticalLayoutSpacingSwitcherMonoBinder : SwitcherMonoBinder<HorizontalOrVerticalLayoutGroup, float>
+    {
+        protected override void SetValue(float value) =>
+            CachedComponent.spacing = value;
+    }
+}

--- a/Aspid.MVVM/Assets/Plugins/Aspid/MVVM/StarterKit/Unity/Runtime/Binders/Layouts/HorizontalOrVerticalLayoutGroup/Mono/HorizontalOrVerticalLayoutSpacingSwitcherMonoBinder.cs.meta
+++ b/Aspid.MVVM/Assets/Plugins/Aspid/MVVM/StarterKit/Unity/Runtime/Binders/Layouts/HorizontalOrVerticalLayoutGroup/Mono/HorizontalOrVerticalLayoutSpacingSwitcherMonoBinder.cs.meta
@@ -1,0 +1,3 @@
+fileFormatVersion: 2
+guid: 9b2eb6452ccf4172abaef851b6a7d432
+timeCreated: 1769700621

--- a/Aspid.MVVM/Assets/Plugins/Aspid/MVVM/StarterKit/Unity/Runtime/Binders/Layouts/LayoutGroupPaddingBinder.cs
+++ b/Aspid.MVVM/Assets/Plugins/Aspid/MVVM/StarterKit/Unity/Runtime/Binders/Layouts/LayoutGroupPaddingBinder.cs
@@ -1,0 +1,30 @@
+#nullable enable
+using System;
+using UnityEngine;
+using UnityEngine.UI;
+
+// ReSharper disable once CheckNamespace
+namespace Aspid.MVVM.StarterKit
+{
+    [Serializable]
+    public class LayoutGroupPaddingBinder : TargetBinder<LayoutGroup>, IBinder<RectOffset>
+    {
+        [SerializeField] private PaddingMode _paddingMode;
+        
+        public LayoutGroupPaddingBinder(
+            LayoutGroup target, 
+            PaddingMode paddingMode,
+            BindMode bindMode = BindMode.OneWay)
+            : base(target, bindMode)
+        {
+            bindMode.ThrowExceptionIfTwo();
+            _paddingMode = paddingMode;
+        }
+
+        public void SetValue(RectOffset? value)
+        {
+            if (value == null) return;
+            Target.SetPadding(value.top, value.right, value.bottom, value.left, _paddingMode);
+        }
+    }
+}

--- a/Aspid.MVVM/Assets/Plugins/Aspid/MVVM/StarterKit/Unity/Runtime/Binders/Layouts/LayoutGroupPaddingBinder.cs.meta
+++ b/Aspid.MVVM/Assets/Plugins/Aspid/MVVM/StarterKit/Unity/Runtime/Binders/Layouts/LayoutGroupPaddingBinder.cs.meta
@@ -1,0 +1,3 @@
+fileFormatVersion: 2
+guid: 53f14385c6a04b84a93229eb36eb6da7
+timeCreated: 1769700635

--- a/Aspid.MVVM/Assets/Plugins/Aspid/MVVM/StarterKit/Unity/Runtime/Binders/Layouts/LayoutGroupPaddingSwitcherBinder.cs
+++ b/Aspid.MVVM/Assets/Plugins/Aspid/MVVM/StarterKit/Unity/Runtime/Binders/Layouts/LayoutGroupPaddingSwitcherBinder.cs
@@ -1,0 +1,28 @@
+#nullable enable
+using System;
+using UnityEngine;
+using UnityEngine.UI;
+
+// ReSharper disable once CheckNamespace
+namespace Aspid.MVVM.StarterKit
+{
+    [Serializable]
+    public sealed class LayoutGroupPaddingSwitcherBinder : SwitcherBinder<LayoutGroup, RectOffset>
+    {
+        [SerializeField] private PaddingMode _paddingMode;
+        
+        public LayoutGroupPaddingSwitcherBinder(
+            LayoutGroup target,
+            RectOffset trueValue, 
+            RectOffset falseValue,
+            PaddingMode paddingMode,
+            BindMode bindMode = BindMode.OneWay)
+            : base(target, trueValue, falseValue, bindMode)
+        {
+            _paddingMode = paddingMode;
+        }
+
+        protected override void SetValue(RectOffset value) =>
+            Target.SetPadding(value.top, value.right, value.bottom, value.left, _paddingMode);
+    }
+}

--- a/Aspid.MVVM/Assets/Plugins/Aspid/MVVM/StarterKit/Unity/Runtime/Binders/Layouts/LayoutGroupPaddingSwitcherBinder.cs.meta
+++ b/Aspid.MVVM/Assets/Plugins/Aspid/MVVM/StarterKit/Unity/Runtime/Binders/Layouts/LayoutGroupPaddingSwitcherBinder.cs.meta
@@ -1,0 +1,3 @@
+fileFormatVersion: 2
+guid: 723c07ced62d4485962e4bc09a7a6082
+timeCreated: 1769700642

--- a/Aspid.MVVM/Assets/Plugins/Aspid/MVVM/StarterKit/Unity/Runtime/Binders/Layouts/Mono.meta
+++ b/Aspid.MVVM/Assets/Plugins/Aspid/MVVM/StarterKit/Unity/Runtime/Binders/Layouts/Mono.meta
@@ -1,0 +1,3 @@
+fileFormatVersion: 2
+guid: 630cef2baeb84a629252eb146b72852f
+timeCreated: 1769701290

--- a/Aspid.MVVM/Assets/Plugins/Aspid/MVVM/StarterKit/Unity/Runtime/Binders/Layouts/Mono/LayoutGroupPaddingEnumGroupMonoBinder.cs
+++ b/Aspid.MVVM/Assets/Plugins/Aspid/MVVM/StarterKit/Unity/Runtime/Binders/Layouts/Mono/LayoutGroupPaddingEnumGroupMonoBinder.cs
@@ -1,0 +1,25 @@
+using UnityEngine;
+using UnityEngine.UI;
+
+// ReSharper disable once CheckNamespace
+namespace Aspid.MVVM.StarterKit
+{
+    [AddBinderContextMenu(typeof(LayoutGroup), serializePropertyNames: "m_Padding")]
+    [AddComponentMenu("Aspid/MVVM/Binders/UI/Layout/LayoutGroup Binder – Padding EnumGroup")]
+    public sealed class LayoutGroupPaddingEnumGroupMonoBinder : EnumGroupMonoBinder<LayoutGroup>
+    {
+        [SerializeField] private RectOffset _defaultValue;
+        [SerializeField] private RectOffset _selectedValue;
+        
+        [SerializeField] private PaddingMode _paddingMode;
+
+        protected override void SetDefaultValue(LayoutGroup element) =>
+            SetValue(element, _defaultValue);
+
+        protected override void SetSelectedValue(LayoutGroup element) =>
+            SetValue(element, _selectedValue);
+        
+        private void SetValue(LayoutGroup element, RectOffset value) =>
+            element.SetPadding(value.top, value.right, value.bottom, value.left, _paddingMode);
+    }
+}

--- a/Aspid.MVVM/Assets/Plugins/Aspid/MVVM/StarterKit/Unity/Runtime/Binders/Layouts/Mono/LayoutGroupPaddingEnumGroupMonoBinder.cs.meta
+++ b/Aspid.MVVM/Assets/Plugins/Aspid/MVVM/StarterKit/Unity/Runtime/Binders/Layouts/Mono/LayoutGroupPaddingEnumGroupMonoBinder.cs.meta
@@ -1,0 +1,3 @@
+fileFormatVersion: 2
+guid: b3bcd3a77b2a4d9a919c782a62568268
+timeCreated: 1769701027

--- a/Aspid.MVVM/Assets/Plugins/Aspid/MVVM/StarterKit/Unity/Runtime/Binders/Layouts/Mono/LayoutGroupPaddingEnumMonoBinder.cs
+++ b/Aspid.MVVM/Assets/Plugins/Aspid/MVVM/StarterKit/Unity/Runtime/Binders/Layouts/Mono/LayoutGroupPaddingEnumMonoBinder.cs
@@ -1,0 +1,16 @@
+using UnityEngine;
+using UnityEngine.UI;
+
+// ReSharper disable once CheckNamespace
+namespace Aspid.MVVM.StarterKit
+{
+    [AddBinderContextMenu(typeof(LayoutGroup), serializePropertyNames: "m_Padding")]
+    [AddComponentMenu("Aspid/MVVM/Binders/UI/Layout/LayoutGroup Binder – Padding Enum")]
+    public sealed class LayoutGroupPaddingEnumMonoBinder : EnumMonoBinder<LayoutGroup, RectOffset>
+    {
+        [SerializeField] private PaddingMode _paddingMode;
+        
+        protected override void SetValue(RectOffset value) =>
+            CachedComponent.SetPadding(value.top, value.right, value.bottom, value.left, _paddingMode);
+    }
+}

--- a/Aspid.MVVM/Assets/Plugins/Aspid/MVVM/StarterKit/Unity/Runtime/Binders/Layouts/Mono/LayoutGroupPaddingEnumMonoBinder.cs.meta
+++ b/Aspid.MVVM/Assets/Plugins/Aspid/MVVM/StarterKit/Unity/Runtime/Binders/Layouts/Mono/LayoutGroupPaddingEnumMonoBinder.cs.meta
@@ -1,0 +1,3 @@
+fileFormatVersion: 2
+guid: 9ca7f515975a498a977ac8f507f071b1
+timeCreated: 1769700615

--- a/Aspid.MVVM/Assets/Plugins/Aspid/MVVM/StarterKit/Unity/Runtime/Binders/Layouts/Mono/LayoutGroupPaddingMonoBinder.cs
+++ b/Aspid.MVVM/Assets/Plugins/Aspid/MVVM/StarterKit/Unity/Runtime/Binders/Layouts/Mono/LayoutGroupPaddingMonoBinder.cs
@@ -1,0 +1,33 @@
+using UnityEngine;
+using UnityEngine.UI;
+
+// ReSharper disable once CheckNamespace
+namespace Aspid.MVVM.StarterKit
+{
+    [AddComponentMenu("Aspid/MVVM/Binders/UI/Layout/LayoutGroup Binder – Padding")]
+    [AddBinderContextMenu(typeof(LayoutGroup), serializePropertyNames: "m_Padding")]
+    public partial class LayoutGroupPaddingMonoBinder : ComponentMonoBinder<LayoutGroup>, IBinder<RectOffset>, INumberBinder
+    {
+        [SerializeField] private PaddingMode _paddingMode;
+        
+        [BinderLog]
+        public void SetValue(RectOffset value) =>
+            CachedComponent.SetPadding(value.top, value.right, value.bottom, value.left, _paddingMode);
+
+        [BinderLog]
+        public void SetValue(int value) =>
+            CachedComponent.SetPadding(top: value, right: value, bottom: value, left: value, _paddingMode);
+
+        [BinderLog]
+        public void SetValue(long value) =>
+            SetValue((int)value);
+
+        [BinderLog]
+        public void SetValue(float value) =>
+            SetValue((int)value);
+
+        [BinderLog]
+        public void SetValue(double value) =>
+            SetValue((int)value);
+    }
+}

--- a/Aspid.MVVM/Assets/Plugins/Aspid/MVVM/StarterKit/Unity/Runtime/Binders/Layouts/Mono/LayoutGroupPaddingMonoBinder.cs.meta
+++ b/Aspid.MVVM/Assets/Plugins/Aspid/MVVM/StarterKit/Unity/Runtime/Binders/Layouts/Mono/LayoutGroupPaddingMonoBinder.cs.meta
@@ -1,0 +1,3 @@
+fileFormatVersion: 2
+guid: 3e31995de8994ff6bf2cdcb1a66c658a
+timeCreated: 1769681406

--- a/Aspid.MVVM/Assets/Plugins/Aspid/MVVM/StarterKit/Unity/Runtime/Binders/Layouts/Mono/LayoutGroupPaddingSwitcherMonoBinder.cs
+++ b/Aspid.MVVM/Assets/Plugins/Aspid/MVVM/StarterKit/Unity/Runtime/Binders/Layouts/Mono/LayoutGroupPaddingSwitcherMonoBinder.cs
@@ -1,0 +1,16 @@
+using UnityEngine;
+using UnityEngine.UI;
+
+// ReSharper disable once CheckNamespace
+namespace Aspid.MVVM.StarterKit
+{
+    [AddBinderContextMenu(typeof(LayoutGroup), serializePropertyNames: "m_Padding")]
+    [AddComponentMenu("Aspid/MVVM/Binders/UI/Layout/LayoutGroup Binder – Padding Switcher")]
+    public sealed class LayoutGroupPaddingSwitcherMonoBinder : SwitcherMonoBinder<LayoutGroup, RectOffset>
+    {
+        [SerializeField] private PaddingMode _paddingMode;
+        
+        protected override void SetValue(RectOffset value) =>
+            CachedComponent.SetPadding(value.top, value.right, value.bottom, value.left, _paddingMode);
+    }
+}

--- a/Aspid.MVVM/Assets/Plugins/Aspid/MVVM/StarterKit/Unity/Runtime/Binders/Layouts/Mono/LayoutGroupPaddingSwitcherMonoBinder.cs.meta
+++ b/Aspid.MVVM/Assets/Plugins/Aspid/MVVM/StarterKit/Unity/Runtime/Binders/Layouts/Mono/LayoutGroupPaddingSwitcherMonoBinder.cs.meta
@@ -1,0 +1,3 @@
+fileFormatVersion: 2
+guid: 2b3e1129658d4697a1737f7ccc3f3cf2
+timeCreated: 1769700609

--- a/Aspid.MVVM/Assets/Plugins/Aspid/MVVM/StarterKit/Unity/Runtime/Binders/Layouts/PaddingMode.cs
+++ b/Aspid.MVVM/Assets/Plugins/Aspid/MVVM/StarterKit/Unity/Runtime/Binders/Layouts/PaddingMode.cs
@@ -1,0 +1,12 @@
+// ReSharper disable once CheckNamespace
+namespace Aspid.MVVM.StarterKit
+{
+    public enum PaddingMode
+    {
+        All,
+        Left,
+        Right,
+        Top,
+        Bottom,
+    }
+}

--- a/Aspid.MVVM/Assets/Plugins/Aspid/MVVM/StarterKit/Unity/Runtime/Binders/Layouts/PaddingMode.cs.meta
+++ b/Aspid.MVVM/Assets/Plugins/Aspid/MVVM/StarterKit/Unity/Runtime/Binders/Layouts/PaddingMode.cs.meta
@@ -1,0 +1,3 @@
+fileFormatVersion: 2
+guid: 6c24b5be175b4604b29c71a9f047d6e7
+timeCreated: 1769683554


### PR DESCRIPTION
Adds binder components for Unity UI `LayoutGroup` family — `HorizontalLayoutGroup`, `VerticalLayoutGroup`, and `GridLayoutGroup` — allowing ViewModel properties to control spacing, padding, child alignment, and other layout settings at runtime.