### PR TITLE
Add editor for enum mono binder

### DIFF
--- a/Aspid.MVVM/Assets/Plugins/Aspid/MVVM/StarterKit/Unity/Editor/Binders.meta
+++ b/Aspid.MVVM/Assets/Plugins/Aspid/MVVM/StarterKit/Unity/Editor/Binders.meta
@@ -1,0 +1,3 @@
+fileFormatVersion: 2
+guid: 9cf77a10af494f71a4851871e39c6772
+timeCreated: 1769764942

--- a/Aspid.MVVM/Assets/Plugins/Aspid/MVVM/StarterKit/Unity/Editor/Binders/EnumMonoBinderComponentEditor.cs
+++ b/Aspid.MVVM/Assets/Plugins/Aspid/MVVM/StarterKit/Unity/Editor/Binders/EnumMonoBinderComponentEditor.cs
@@ -74,6 +74,7 @@ namespace Aspid.MVVM.StarterKit
                 .Where(propertyField => propertyField.bindingPath is "_enumValues._enumType")
                 .First();
             
+            propertyField?.Bind(serializedObject);
             propertyField?.SetEnabled(RequiredEnumType is null);
         }
     }

--- a/Aspid.MVVM/Assets/Plugins/Aspid/MVVM/StarterKit/Unity/Editor/Binders/EnumMonoBinderComponentEditor.cs
+++ b/Aspid.MVVM/Assets/Plugins/Aspid/MVVM/StarterKit/Unity/Editor/Binders/EnumMonoBinderComponentEditor.cs
@@ -1,0 +1,80 @@
+using System;
+using System.Linq;
+using UnityEditor;
+using Aspid.UnityFastTools;
+using UnityEditor.UIElements;
+using UnityEngine.UIElements;
+
+// ReSharper disable once CheckNamespace
+namespace Aspid.MVVM.StarterKit
+{
+    [CustomEditor(typeof(EnumMonoBinder<,>), editorForChildClasses: true)]
+    public class EnumMonoBinderComponentEditor : MonoBinderEditor
+    {
+        private Type _requiredEnumType;
+        private SerializedProperty _enumTypeProperty;
+
+        private Type RequiredEnumType
+        {
+            get => _requiredEnumType;
+            set
+            {
+                _requiredEnumType = value;
+                DisableEnumTypeFieldIfNeeded(Root);
+            }
+        }
+
+        protected override void OnEnabled() =>
+            SyncEnumTypeFromRequireBinder();
+        
+        protected override void FindProperties()
+        {
+            base.FindProperties();
+            
+            var enumValuesProperty = serializedObject.FindProperty("_enumValues");
+            _enumTypeProperty = enumValuesProperty.FindPropertyRelative("_enumType");
+        }
+
+        protected override void OnCreatedInspectorGUI(MonoBinderVisualElement root)
+        {
+            base.OnCreatedInspectorGUI(root);
+            
+            root.IdDropdown.RegisterValueChangedCallback(_ => SyncEnumTypeFromRequireBinder());
+            root.ViewDropdown.RegisterValueChangedCallback(_ => SyncEnumTypeFromRequireBinder());
+            
+            root.RegisterCallback<GeometryChangedEvent>(_ => DisableEnumTypeFieldIfNeeded(root));
+        }
+        
+        private void SyncEnumTypeFromRequireBinder()
+        {
+            RequiredEnumType = null;
+            DisableEnumTypeFieldIfNeeded(Root);
+            
+            if (ViewProperty?.objectReferenceValue is not IView view) return;
+            if (string.IsNullOrWhiteSpace(IdProperty?.stringValue)) return;
+            if (!view.TryGetRequireBinderFieldsById(IdProperty.stringValue, out var field)) return;
+            
+            var enumType = field!.RequiredTypes.FirstOrDefault(t => t.IsEnum);
+            if (enumType is null) return;
+
+            RequiredEnumType = enumType;
+            
+            var assemblyQualifiedName = enumType.AssemblyQualifiedName;
+            if (_enumTypeProperty.stringValue == assemblyQualifiedName) return;
+            
+            _enumTypeProperty.SetStringAndApply(assemblyQualifiedName);
+            DisableEnumTypeFieldIfNeeded(Root);
+        }
+
+        private void DisableEnumTypeFieldIfNeeded(VisualElement root)
+        {
+            if (root is null) return;
+
+            var propertyField = root.Query<PropertyField>()
+                .Where(propertyField => propertyField.bindingPath is "_enumValues._enumType")
+                .First();
+            
+            propertyField?.SetEnabled(RequiredEnumType is null);
+        }
+    }
+}

--- a/Aspid.MVVM/Assets/Plugins/Aspid/MVVM/StarterKit/Unity/Editor/Binders/EnumMonoBinderComponentEditor.cs.meta
+++ b/Aspid.MVVM/Assets/Plugins/Aspid/MVVM/StarterKit/Unity/Editor/Binders/EnumMonoBinderComponentEditor.cs.meta
@@ -1,0 +1,3 @@
+fileFormatVersion: 2
+guid: 9a4dbbdc8f654b2d901002ec51c75456
+timeCreated: 1769766646

--- a/Aspid.MVVM/Assets/Plugins/Aspid/MVVM/StarterKit/Unity/Editor/Binders/EnumMonoBinderEditor.cs
+++ b/Aspid.MVVM/Assets/Plugins/Aspid/MVVM/StarterKit/Unity/Editor/Binders/EnumMonoBinderEditor.cs
@@ -74,6 +74,7 @@ namespace Aspid.MVVM.StarterKit
                 .Where(propertyField => propertyField.bindingPath is "_enumValues._enumType")
                 .First();
             
+            propertyField?.Bind(serializedObject);
             propertyField?.SetEnabled(RequiredEnumType is null);
         }
     }

--- a/Aspid.MVVM/Assets/Plugins/Aspid/MVVM/StarterKit/Unity/Editor/Binders/EnumMonoBinderEditor.cs
+++ b/Aspid.MVVM/Assets/Plugins/Aspid/MVVM/StarterKit/Unity/Editor/Binders/EnumMonoBinderEditor.cs
@@ -1,0 +1,80 @@
+using System;
+using System.Linq;
+using UnityEditor;
+using Aspid.UnityFastTools;
+using UnityEditor.UIElements;
+using UnityEngine.UIElements;
+
+// ReSharper disable once CheckNamespace
+namespace Aspid.MVVM.StarterKit
+{
+    [CustomEditor(typeof(EnumMonoBinder<>), editorForChildClasses: true)]
+    public class EnumMonoBinderEditor : MonoBinderEditor
+    {
+         private Type _requiredEnumType;
+        private SerializedProperty _enumTypeProperty;
+
+        private Type RequiredEnumType
+        {
+            get => _requiredEnumType;
+            set
+            {
+                _requiredEnumType = value;
+                DisableEnumTypeFieldIfNeeded(Root);
+            }
+        }
+
+        protected override void OnEnabled() =>
+            SyncEnumTypeFromRequireBinder();
+        
+        protected override void FindProperties()
+        {
+            base.FindProperties();
+            
+            var enumValuesProperty = serializedObject.FindProperty("_enumValues");
+            _enumTypeProperty = enumValuesProperty.FindPropertyRelative("_enumType");
+        }
+
+        protected override void OnCreatedInspectorGUI(MonoBinderVisualElement root)
+        {
+            base.OnCreatedInspectorGUI(root);
+            
+            root.IdDropdown.RegisterValueChangedCallback(_ => SyncEnumTypeFromRequireBinder());
+            root.ViewDropdown.RegisterValueChangedCallback(_ => SyncEnumTypeFromRequireBinder());
+            
+            root.RegisterCallbackOnce<GeometryChangedEvent>(_ => DisableEnumTypeFieldIfNeeded(root));
+        }
+        
+        private void SyncEnumTypeFromRequireBinder()
+        {
+            RequiredEnumType = null;
+            DisableEnumTypeFieldIfNeeded(Root);
+            
+            if (ViewProperty?.objectReferenceValue is not IView view) return;
+            if (string.IsNullOrWhiteSpace(IdProperty?.stringValue)) return;
+            if (!view.TryGetRequireBinderFieldsById(IdProperty.stringValue, out var field)) return;
+            
+            var enumType = field!.RequiredTypes.FirstOrDefault(t => t.IsEnum);
+            if (enumType is null) return;
+
+            RequiredEnumType = enumType;
+            
+            var assemblyQualifiedName = enumType.AssemblyQualifiedName;
+            if (_enumTypeProperty.stringValue == assemblyQualifiedName) return;
+            
+            _enumTypeProperty.SetStringAndApply(assemblyQualifiedName);
+            DisableEnumTypeFieldIfNeeded(Root);
+        }
+
+        private void DisableEnumTypeFieldIfNeeded(VisualElement root)
+        {
+            if (root is null) return;
+
+            var propertyField = root.Query<PropertyField>()
+                .Where(propertyField => propertyField.bindingPath is "_enumValues._enumType")
+                .First();
+            
+            propertyField?.SetEnabled(RequiredEnumType is null);
+        }
+    }
+}

--- a/Aspid.MVVM/Assets/Plugins/Aspid/MVVM/StarterKit/Unity/Editor/Binders/EnumMonoBinderEditor.cs
+++ b/Aspid.MVVM/Assets/Plugins/Aspid/MVVM/StarterKit/Unity/Editor/Binders/EnumMonoBinderEditor.cs
@@ -11,7 +11,7 @@ namespace Aspid.MVVM.StarterKit
     [CustomEditor(typeof(EnumMonoBinder<>), editorForChildClasses: true)]
     public class EnumMonoBinderEditor : MonoBinderEditor
     {
-         private Type _requiredEnumType;
+        private Type _requiredEnumType;
         private SerializedProperty _enumTypeProperty;
 
         private Type RequiredEnumType

--- a/Aspid.MVVM/Assets/Plugins/Aspid/MVVM/StarterKit/Unity/Editor/Binders/EnumMonoBinderEditor.cs.meta
+++ b/Aspid.MVVM/Assets/Plugins/Aspid/MVVM/StarterKit/Unity/Editor/Binders/EnumMonoBinderEditor.cs.meta
@@ -1,0 +1,3 @@
+fileFormatVersion: 2
+guid: aeb2f1c718394605947c9e7f09cf15c0
+timeCreated: 1769764955

--- a/Aspid.MVVM/Assets/Plugins/Aspid/MVVM/Unity/Editor/Scripts/Reflection/RequiredFieldForMonoBinder.cs
+++ b/Aspid.MVVM/Assets/Plugins/Aspid/MVVM/Unity/Editor/Scripts/Reflection/RequiredFieldForMonoBinder.cs
@@ -20,6 +20,8 @@ namespace Aspid.MVVM
         private bool? _isValidation;
         private readonly FieldInfo _field;
         private readonly IReadOnlyCollection<Type> _requiredTypes;
+        
+        public IReadOnlyCollection<Type> RequiredTypes => _requiredTypes;
 
         public RequiredFieldForMonoBinder(object fieldContainerObj, FieldInfo field)
             : this(fieldContainerObj, field, null) { }

--- a/Aspid.MVVM/Assets/Plugins/Aspid/UnityFastTools/Source/Editor/Enums/EnumValuePropertyDrawer.cs
+++ b/Aspid.MVVM/Assets/Plugins/Aspid/UnityFastTools/Source/Editor/Enums/EnumValuePropertyDrawer.cs
@@ -84,6 +84,8 @@ namespace Aspid.UnityFastTools
                     if (enumType.IsDefined(typeof(FlagsAttribute), false))
                     {
                         keyEnumFlagField.SetDisplay(DisplayStyle.Flex);
+
+                        keyEnumFlagField.value = null;
                         keyEnumFlagField.Init(enumValue);
                     }
                     else


### PR DESCRIPTION
Adds a custom Unity editor for the `EnumMonoBinder` component, providing an enum value dropdown in the inspector instead of a raw integer field.