### PR TITLE
Add OneWayToSourceComponentBinders

### DIFF
--- a/Aspid.MVVM/Assets/Plugins/Aspid/MVVM/StarterKit/Unity/Runtime/Binders/Animators/Mono/AnimatorToSourceMonoBinder.cs
+++ b/Aspid.MVVM/Assets/Plugins/Aspid/MVVM/StarterKit/Unity/Runtime/Binders/Animators/Mono/AnimatorToSourceMonoBinder.cs
@@ -1,0 +1,9 @@
+using UnityEngine;
+
+// ReSharper disable once CheckNamespace
+namespace Aspid.MVVM.StarterKit
+{
+    [AddBinderContextMenu(typeof(Animator))]
+    [AddComponentMenu("Aspid/MVVM/Binders/Animator/Animator To Source Binder")]
+    public sealed class AnimatorToSourceMonoBinder : ComponentToSourceMonoBinder<Animator> { }
+}

--- a/Aspid.MVVM/Assets/Plugins/Aspid/MVVM/StarterKit/Unity/Runtime/Binders/Animators/Mono/AnimatorToSourceMonoBinder.cs.meta
+++ b/Aspid.MVVM/Assets/Plugins/Aspid/MVVM/StarterKit/Unity/Runtime/Binders/Animators/Mono/AnimatorToSourceMonoBinder.cs.meta
@@ -1,0 +1,3 @@
+fileFormatVersion: 2
+guid: e13fd793706e40b8ac9f5f345bc90dd9
+timeCreated: 1770631177

--- a/Aspid.MVVM/Assets/Plugins/Aspid/MVVM/StarterKit/Unity/Runtime/Binders/Behaviours/Mono/BehaviourToSourceMonoBinder.cs
+++ b/Aspid.MVVM/Assets/Plugins/Aspid/MVVM/StarterKit/Unity/Runtime/Binders/Behaviours/Mono/BehaviourToSourceMonoBinder.cs
@@ -1,0 +1,9 @@
+using UnityEngine;
+
+// ReSharper disable once CheckNamespace
+namespace Aspid.MVVM.StarterKit
+{
+    [AddBinderContextMenu(typeof(Behaviour))]
+    [AddComponentMenu("Aspid/MVVM/Binders/Behaviour/Behaviour To Source Binder")]
+    public sealed class BehaviourToSourceMonoBinder : ComponentToSourceMonoBinder<Behaviour> { }
+}

--- a/Aspid.MVVM/Assets/Plugins/Aspid/MVVM/StarterKit/Unity/Runtime/Binders/Behaviours/Mono/BehaviourToSourceMonoBinder.cs.meta
+++ b/Aspid.MVVM/Assets/Plugins/Aspid/MVVM/StarterKit/Unity/Runtime/Binders/Behaviours/Mono/BehaviourToSourceMonoBinder.cs.meta
@@ -1,0 +1,3 @@
+fileFormatVersion: 2
+guid: f690a38ec8d0431b93df892c141fc4f6
+timeCreated: 1770636665

--- a/Aspid.MVVM/Assets/Plugins/Aspid/MVVM/StarterKit/Unity/Runtime/Binders/CanvasGroups/Mono/CanvasGroupAlphaEnumGroupMonoBinder.cs
+++ b/Aspid.MVVM/Assets/Plugins/Aspid/MVVM/StarterKit/Unity/Runtime/Binders/CanvasGroups/Mono/CanvasGroupAlphaEnumGroupMonoBinder.cs
@@ -9,7 +9,7 @@ using Converter = Aspid.MVVM.StarterKit.IConverterFloat;
 // ReSharper disable once CheckNamespace
 namespace Aspid.MVVM.StarterKit
 {
-    [AddComponentMenu("Aspid/MVVM/Binders/UI/Canvas Group/CanvasGroup Binder – Alpha EnumGroup")]
+    [AddComponentMenu("Aspid/MVVM/Binders/UI/CanvasGroup/CanvasGroup Binder – Alpha EnumGroup")]
     [AddBinderContextMenu(typeof(CanvasGroup), serializePropertyNames: "m_Alpha", SubPath = "EnumGroup")]
     public sealed class CanvasGroupAlphaEnumGroupMonoBinder : EnumGroupMonoBinder<CanvasGroup>
     {

--- a/Aspid.MVVM/Assets/Plugins/Aspid/MVVM/StarterKit/Unity/Runtime/Binders/CanvasGroups/Mono/CanvasGroupAlphaEnumMonoBinder.cs
+++ b/Aspid.MVVM/Assets/Plugins/Aspid/MVVM/StarterKit/Unity/Runtime/Binders/CanvasGroups/Mono/CanvasGroupAlphaEnumMonoBinder.cs
@@ -8,7 +8,7 @@ using Converter = Aspid.MVVM.StarterKit.IConverterFloat;
 // ReSharper disable once CheckNamespace
 namespace Aspid.MVVM.StarterKit
 {
-    [AddComponentMenu("Aspid/MVVM/Binders/UI/Canvas Group/CanvasGroup Binder – Alpha Enum")]
+    [AddComponentMenu("Aspid/MVVM/Binders/UI/CanvasGroup/CanvasGroup Binder – Alpha Enum")]
     [AddBinderContextMenu(typeof(CanvasGroup), serializePropertyNames: "m_Alpha", SubPath = "Enum")]
     public sealed class CanvasGroupAlphaEnumMonoBinder : EnumMonoBinder<CanvasGroup, float>
     {

--- a/Aspid.MVVM/Assets/Plugins/Aspid/MVVM/StarterKit/Unity/Runtime/Binders/CanvasGroups/Mono/CanvasGroupAlphaMonoBinder.cs
+++ b/Aspid.MVVM/Assets/Plugins/Aspid/MVVM/StarterKit/Unity/Runtime/Binders/CanvasGroups/Mono/CanvasGroupAlphaMonoBinder.cs
@@ -9,7 +9,7 @@ using Converter = Aspid.MVVM.StarterKit.IConverterFloat;
 namespace Aspid.MVVM.StarterKit
 {
     [AddBinderContextMenu(typeof(CanvasGroup), serializePropertyNames: "m_Alpha")]
-    [AddComponentMenu("Aspid/MVVM/Binders/UI/Canvas Group/CanvasGroup Binder – Alpha")]
+    [AddComponentMenu("Aspid/MVVM/Binders/UI/CanvasGroup/CanvasGroup Binder – Alpha")]
     public partial class CanvasGroupAlphaMonoBinder : ComponentMonoBinder<CanvasGroup>, INumberBinder
     {
         [SerializeReferenceDropdown]

--- a/Aspid.MVVM/Assets/Plugins/Aspid/MVVM/StarterKit/Unity/Runtime/Binders/CanvasGroups/Mono/CanvasGroupAlphaSwitcherMonoBinder.cs
+++ b/Aspid.MVVM/Assets/Plugins/Aspid/MVVM/StarterKit/Unity/Runtime/Binders/CanvasGroups/Mono/CanvasGroupAlphaSwitcherMonoBinder.cs
@@ -8,7 +8,7 @@ using Converter = Aspid.MVVM.StarterKit.IConverterFloat;
 // ReSharper disable once CheckNamespace
 namespace Aspid.MVVM.StarterKit
 {
-    [AddComponentMenu("Aspid/MVVM/Binders/UI/Canvas Group/CanvasGroup Binder – Alpha Switcher")]
+    [AddComponentMenu("Aspid/MVVM/Binders/UI/CanvasGroup/CanvasGroup Binder – Alpha Switcher")]
     [AddBinderContextMenu(typeof(CanvasGroup), serializePropertyNames: "m_Alpha", SubPath = "Switcher")]
     public sealed class CanvasGroupAlphaSwitcherMonoBinder : SwitcherMonoBinder<CanvasGroup, float>
     {

--- a/Aspid.MVVM/Assets/Plugins/Aspid/MVVM/StarterKit/Unity/Runtime/Binders/CanvasGroups/Mono/CanvasGroupBlocksRaycastsEnumGroupMonoBinder.cs
+++ b/Aspid.MVVM/Assets/Plugins/Aspid/MVVM/StarterKit/Unity/Runtime/Binders/CanvasGroups/Mono/CanvasGroupBlocksRaycastsEnumGroupMonoBinder.cs
@@ -3,7 +3,7 @@ using UnityEngine;
 // ReSharper disable once CheckNamespace
 namespace Aspid.MVVM.StarterKit
 {
-    [AddComponentMenu("Aspid/MVVM/Binders/UI/Canvas Group/CanvasGroup Binder – BlocksRaycasts EnumGroup")]
+    [AddComponentMenu("Aspid/MVVM/Binders/UI/CanvasGroup/CanvasGroup Binder – BlocksRaycasts EnumGroup")]
     [AddBinderContextMenu(typeof(CanvasGroup), serializePropertyNames: "m_BlocksRaycasts", SubPath = "EnumGroup")]
     public sealed class CanvasGroupBlocksRaycastsEnumGroupMonoBinder : EnumGroupMonoBinder<CanvasGroup, bool>
     {

--- a/Aspid.MVVM/Assets/Plugins/Aspid/MVVM/StarterKit/Unity/Runtime/Binders/CanvasGroups/Mono/CanvasGroupBlocksRaycastsEnumMonoBinder.cs
+++ b/Aspid.MVVM/Assets/Plugins/Aspid/MVVM/StarterKit/Unity/Runtime/Binders/CanvasGroups/Mono/CanvasGroupBlocksRaycastsEnumMonoBinder.cs
@@ -3,7 +3,7 @@ using UnityEngine;
 // ReSharper disable once CheckNamespace
 namespace Aspid.MVVM.StarterKit
 {
-    [AddComponentMenu("Aspid/MVVM/Binders/UI/Canvas Group/CanvasGroup Binder – BlocksRaycasts Enum")]
+    [AddComponentMenu("Aspid/MVVM/Binders/UI/CanvasGroup/CanvasGroup Binder – BlocksRaycasts Enum")]
     [AddBinderContextMenu(typeof(CanvasGroup), serializePropertyNames: "m_BlocksRaycasts", SubPath = "Enum")]
     public sealed class CanvasGroupBlocksRaycastsEnumMonoBinder : EnumMonoBinder<CanvasGroup, bool>
     {

--- a/Aspid.MVVM/Assets/Plugins/Aspid/MVVM/StarterKit/Unity/Runtime/Binders/CanvasGroups/Mono/CanvasGroupBlocksRaycastsMonoBinder.cs
+++ b/Aspid.MVVM/Assets/Plugins/Aspid/MVVM/StarterKit/Unity/Runtime/Binders/CanvasGroups/Mono/CanvasGroupBlocksRaycastsMonoBinder.cs
@@ -4,7 +4,7 @@ using UnityEngine;
 namespace Aspid.MVVM.StarterKit
 {
     [AddBinderContextMenu(typeof(CanvasGroup), serializePropertyNames: "m_BlocksRaycasts")]
-    [AddComponentMenu("Aspid/MVVM/Binders/UI/Canvas Group/CanvasGroup Binder – BlocksRaycasts")]
+    [AddComponentMenu("Aspid/MVVM/Binders/UI/CanvasGroup/CanvasGroup Binder – BlocksRaycasts")]
     public partial class CanvasGroupBlocksRaycastsMonoBinder : ComponentMonoBinder<CanvasGroup>, IBinder<bool>
     {
         [SerializeField] private bool _isInvert;

--- a/Aspid.MVVM/Assets/Plugins/Aspid/MVVM/StarterKit/Unity/Runtime/Binders/CanvasGroups/Mono/CanvasGroupIgnoreParentGroupsEnumGroupMonoBinder.cs
+++ b/Aspid.MVVM/Assets/Plugins/Aspid/MVVM/StarterKit/Unity/Runtime/Binders/CanvasGroups/Mono/CanvasGroupIgnoreParentGroupsEnumGroupMonoBinder.cs
@@ -3,7 +3,7 @@ using UnityEngine;
 // ReSharper disable once CheckNamespace
 namespace Aspid.MVVM.StarterKit
 {
-    [AddComponentMenu("Aspid/MVVM/Binders/UI/Canvas Group/CanvasGroup Binder – IgnoreParentGroups EnumGroup")]
+    [AddComponentMenu("Aspid/MVVM/Binders/UI/CanvasGroup/CanvasGroup Binder – IgnoreParentGroups EnumGroup")]
     [AddBinderContextMenu(typeof(CanvasGroup), serializePropertyNames: "m_IgnoreParentGroups", SubPath = "EnumGroup")]
     public sealed class CanvasGroupIgnoreParentGroupsEnumGroupMonoBinder : EnumGroupMonoBinder<CanvasGroup, bool>
     {

--- a/Aspid.MVVM/Assets/Plugins/Aspid/MVVM/StarterKit/Unity/Runtime/Binders/CanvasGroups/Mono/CanvasGroupIgnoreParentGroupsEnumMonoBinder.cs
+++ b/Aspid.MVVM/Assets/Plugins/Aspid/MVVM/StarterKit/Unity/Runtime/Binders/CanvasGroups/Mono/CanvasGroupIgnoreParentGroupsEnumMonoBinder.cs
@@ -3,7 +3,7 @@ using UnityEngine;
 // ReSharper disable once CheckNamespace
 namespace Aspid.MVVM.StarterKit
 {
-    [AddComponentMenu("Aspid/MVVM/Binders/UI/Canvas Group/CanvasGroup Binder – IgnoreParentGroups Enum")]
+    [AddComponentMenu("Aspid/MVVM/Binders/UI/CanvasGroup/CanvasGroup Binder – IgnoreParentGroups Enum")]
     [AddBinderContextMenu(typeof(CanvasGroup), serializePropertyNames: "m_IgnoreParentGroups", SubPath = "Enum")]
     public sealed class CanvasGroupIgnoreParentGroupsEnumMonoBinder : EnumMonoBinder<CanvasGroup, bool>
     {

--- a/Aspid.MVVM/Assets/Plugins/Aspid/MVVM/StarterKit/Unity/Runtime/Binders/CanvasGroups/Mono/CanvasGroupIgnoreParentGroupsMonoBinder.cs
+++ b/Aspid.MVVM/Assets/Plugins/Aspid/MVVM/StarterKit/Unity/Runtime/Binders/CanvasGroups/Mono/CanvasGroupIgnoreParentGroupsMonoBinder.cs
@@ -4,7 +4,7 @@ using UnityEngine;
 namespace Aspid.MVVM.StarterKit
 {
     [AddBinderContextMenu(typeof(CanvasGroup), serializePropertyNames: "m_IgnoreParentGroups")]
-    [AddComponentMenu("Aspid/MVVM/Binders/UI/Canvas Group/CanvasGroup Binder – IgnoreParentGroups")]
+    [AddComponentMenu("Aspid/MVVM/Binders/UI/CanvasGroup/CanvasGroup Binder – IgnoreParentGroups")]
     public partial class CanvasGroupIgnoreParentGroupsMonoBinder : ComponentMonoBinder<CanvasGroup>, IBinder<bool>
     {
         [SerializeField] private bool _isInvert;

--- a/Aspid.MVVM/Assets/Plugins/Aspid/MVVM/StarterKit/Unity/Runtime/Binders/CanvasGroups/Mono/CanvasGroupInteractableEnumGroupMonoBinder.cs
+++ b/Aspid.MVVM/Assets/Plugins/Aspid/MVVM/StarterKit/Unity/Runtime/Binders/CanvasGroups/Mono/CanvasGroupInteractableEnumGroupMonoBinder.cs
@@ -3,7 +3,7 @@ using UnityEngine;
 // ReSharper disable once CheckNamespace
 namespace Aspid.MVVM.StarterKit
 {
-    [AddComponentMenu("Aspid/MVVM/Binders/UI/Canvas Group/CanvasGroup Binder – Interactable EnumGroup")]
+    [AddComponentMenu("Aspid/MVVM/Binders/UI/CanvasGroup/CanvasGroup Binder – Interactable EnumGroup")]
     [AddBinderContextMenu(typeof(CanvasGroup), serializePropertyNames: "m_Interactable", SubPath = "EnumGroup")]
     public sealed class CanvasGroupInteractableEnumGroupMonoBinder : EnumGroupMonoBinder<CanvasGroup, bool>
     {

--- a/Aspid.MVVM/Assets/Plugins/Aspid/MVVM/StarterKit/Unity/Runtime/Binders/CanvasGroups/Mono/CanvasGroupInteractableEnumMonoBinder.cs
+++ b/Aspid.MVVM/Assets/Plugins/Aspid/MVVM/StarterKit/Unity/Runtime/Binders/CanvasGroups/Mono/CanvasGroupInteractableEnumMonoBinder.cs
@@ -3,7 +3,7 @@ using UnityEngine;
 // ReSharper disable once CheckNamespace
 namespace Aspid.MVVM.StarterKit
 {
-    [AddComponentMenu("Aspid/MVVM/Binders/UI/Canvas Group/CanvasGroup Binder – Interactable Enum")]
+    [AddComponentMenu("Aspid/MVVM/Binders/UI/CanvasGroup/CanvasGroup Binder – Interactable Enum")]
     [AddBinderContextMenu(typeof(CanvasGroup), serializePropertyNames: "m_Interactable", SubPath = "Enum")]
     public sealed class CanvasGroupInteractableEnumMonoBinder : EnumMonoBinder<CanvasGroup, bool>
     {

--- a/Aspid.MVVM/Assets/Plugins/Aspid/MVVM/StarterKit/Unity/Runtime/Binders/CanvasGroups/Mono/CanvasGroupInteractableMonoBinder.cs
+++ b/Aspid.MVVM/Assets/Plugins/Aspid/MVVM/StarterKit/Unity/Runtime/Binders/CanvasGroups/Mono/CanvasGroupInteractableMonoBinder.cs
@@ -4,7 +4,7 @@ using UnityEngine;
 namespace Aspid.MVVM.StarterKit
 {
     [AddBinderContextMenu(typeof(CanvasGroup), serializePropertyNames: "m_Interactable")]
-    [AddComponentMenu("Aspid/MVVM/Binders/UI/Canvas Group/CanvasGroup Binder – Interactable")]
+    [AddComponentMenu("Aspid/MVVM/Binders/UI/CanvasGroup/CanvasGroup Binder – Interactable")]
     public partial class CanvasGroupInteractableMonoBinder : ComponentMonoBinder<CanvasGroup>, IBinder<bool>
     {
         [SerializeField] private bool _isInvert;

--- a/Aspid.MVVM/Assets/Plugins/Aspid/MVVM/StarterKit/Unity/Runtime/Binders/CanvasGroups/Mono/CanvasGroupToSourceMonoBinder.cs
+++ b/Aspid.MVVM/Assets/Plugins/Aspid/MVVM/StarterKit/Unity/Runtime/Binders/CanvasGroups/Mono/CanvasGroupToSourceMonoBinder.cs
@@ -1,0 +1,9 @@
+using UnityEngine;
+
+// ReSharper disable once CheckNamespace
+namespace Aspid.MVVM.StarterKit
+{
+    [AddBinderContextMenu(typeof(CanvasGroup))]
+    [AddComponentMenu("Aspid/MVVM/Binders/UI/CanvasGroup/CanvasGroup To Source Binder")]
+    public sealed class CanvasGroupToSourceMonoBinder : ComponentToSourceMonoBinder<CanvasGroup> { }
+}

--- a/Aspid.MVVM/Assets/Plugins/Aspid/MVVM/StarterKit/Unity/Runtime/Binders/CanvasGroups/Mono/CanvasGroupToSourceMonoBinder.cs.meta
+++ b/Aspid.MVVM/Assets/Plugins/Aspid/MVVM/StarterKit/Unity/Runtime/Binders/CanvasGroups/Mono/CanvasGroupToSourceMonoBinder.cs.meta
@@ -1,0 +1,3 @@
+fileFormatVersion: 2
+guid: 8e33f6044cca4ab7aa688ec3fb360035
+timeCreated: 1770636713

--- a/Aspid.MVVM/Assets/Plugins/Aspid/MVVM/StarterKit/Unity/Runtime/Binders/Collections/Lists/Mono/ViewModelObservableListMonoBinder.cs
+++ b/Aspid.MVVM/Assets/Plugins/Aspid/MVVM/StarterKit/Unity/Runtime/Binders/Collections/Lists/Mono/ViewModelObservableListMonoBinder.cs
@@ -14,8 +14,8 @@ using Comparer = Aspid.MVVM.StarterKit.IViewModelCollectionComparer;
 // ReSharper disable once CheckNamespace
 namespace Aspid.MVVM.StarterKit
 {
-    [AddComponentMenu("Aspid/MVVM/Binders/Collections/Observable List Binder – ViewModel")]
-    [AddBinderContextMenu(typeof(Component), Path = "Add General Binder/Collections/Observable List Binder – ViewModel")]
+    [AddComponentMenu("Aspid/MVVM/Binders/Collection/Observable List Binder – ViewModel")]
+    [AddBinderContextMenu(typeof(Component), Path = "Add General Binder/Collection/Observable List Binder – ViewModel")]
     public class ViewModelObservableListMonoBinder : ViewModelObservableListMonoBinder<MonoView, ViewFactory> { }
 
 #if UNITY_2023_1_OR_NEWER

--- a/Aspid.MVVM/Assets/Plugins/Aspid/MVVM/StarterKit/Unity/Runtime/Binders/Collections/Mono/ViewModelCollectionMonoBinder.cs
+++ b/Aspid.MVVM/Assets/Plugins/Aspid/MVVM/StarterKit/Unity/Runtime/Binders/Collections/Mono/ViewModelCollectionMonoBinder.cs
@@ -4,8 +4,8 @@ using System.Collections.Generic;
 // ReSharper disable once CheckNamespace
 namespace Aspid.MVVM.StarterKit
 {
-    [AddComponentMenu("Aspid/MVVM/Binders/Collections/Collection Binder – ViewModel")]
-    [AddBinderContextMenu(typeof(Component), Path = "Add General Binder/Collections/Collection Binder – ViewModel")]
+    [AddComponentMenu("Aspid/MVVM/Binders/Collection/Collection Binder – ViewModel")]
+    [AddBinderContextMenu(typeof(Component), Path = "Add General Binder/Collection/Collection Binder – ViewModel")]
     public class ViewModelCollectionMonoBinder : ViewModelCollectionMonoBinder<MonoView> { }
     
     public abstract class ViewModelCollectionMonoBinder<T> : CollectionMonoBinder<IViewModel>

--- a/Aspid.MVVM/Assets/Plugins/Aspid/MVVM/StarterKit/Unity/Runtime/Binders/Colliders/BoxColliders/Mono/BoxColliderToSourceMonoBinder.cs
+++ b/Aspid.MVVM/Assets/Plugins/Aspid/MVVM/StarterKit/Unity/Runtime/Binders/Colliders/BoxColliders/Mono/BoxColliderToSourceMonoBinder.cs
@@ -1,0 +1,9 @@
+using UnityEngine;
+
+// ReSharper disable once CheckNamespace
+namespace Aspid.MVVM.StarterKit
+{
+    [AddBinderContextMenu(typeof(BoxCollider))]
+    [AddComponentMenu("Aspid/MVVM/Binders/Collider/Box/BoxCollider To Source Binder")]
+    public sealed class BoxColliderToSourceMonoBinder : ComponentToSourceMonoBinder<BoxCollider> { }
+}

--- a/Aspid.MVVM/Assets/Plugins/Aspid/MVVM/StarterKit/Unity/Runtime/Binders/Colliders/BoxColliders/Mono/BoxColliderToSourceMonoBinder.cs.meta
+++ b/Aspid.MVVM/Assets/Plugins/Aspid/MVVM/StarterKit/Unity/Runtime/Binders/Colliders/BoxColliders/Mono/BoxColliderToSourceMonoBinder.cs.meta
@@ -1,0 +1,3 @@
+fileFormatVersion: 2
+guid: 81cc74b4870141e8b3b151f829740533
+timeCreated: 1770636752

--- a/Aspid.MVVM/Assets/Plugins/Aspid/MVVM/StarterKit/Unity/Runtime/Binders/Colliders/CapsuleColliders/Mono/CapsuleColliderToSourceMonoBinder.cs
+++ b/Aspid.MVVM/Assets/Plugins/Aspid/MVVM/StarterKit/Unity/Runtime/Binders/Colliders/CapsuleColliders/Mono/CapsuleColliderToSourceMonoBinder.cs
@@ -1,0 +1,9 @@
+using UnityEngine;
+
+// ReSharper disable once CheckNamespace
+namespace Aspid.MVVM.StarterKit
+{
+    [AddBinderContextMenu(typeof(CapsuleCollider))]
+    [AddComponentMenu("Aspid/MVVM/Binders/Collider/Capsule/CapsuleCollider To Source Binder")]
+    public sealed class CapsuleColliderToSourceMonoBinder : ComponentToSourceMonoBinder<CapsuleCollider> { }
+}

--- a/Aspid.MVVM/Assets/Plugins/Aspid/MVVM/StarterKit/Unity/Runtime/Binders/Colliders/CapsuleColliders/Mono/CapsuleColliderToSourceMonoBinder.cs.meta
+++ b/Aspid.MVVM/Assets/Plugins/Aspid/MVVM/StarterKit/Unity/Runtime/Binders/Colliders/CapsuleColliders/Mono/CapsuleColliderToSourceMonoBinder.cs.meta
@@ -1,0 +1,3 @@
+fileFormatVersion: 2
+guid: 5fd814e2d767410598cdf54859cf8e21
+timeCreated: 1770636797

--- a/Aspid.MVVM/Assets/Plugins/Aspid/MVVM/StarterKit/Unity/Runtime/Binders/Colliders/MeshColliders/Mono/MeshColliderToSourceMonoBinder.cs
+++ b/Aspid.MVVM/Assets/Plugins/Aspid/MVVM/StarterKit/Unity/Runtime/Binders/Colliders/MeshColliders/Mono/MeshColliderToSourceMonoBinder.cs
@@ -1,0 +1,9 @@
+using UnityEngine;
+
+// ReSharper disable once CheckNamespace
+namespace Aspid.MVVM.StarterKit
+{
+    [AddBinderContextMenu(typeof(MeshCollider))]
+    [AddComponentMenu("Aspid/MVVM/Binders/Collider/Mesh/MeshCollider To Source Binder")]
+    public sealed class MeshColliderToSourceMonoBinder : ComponentToSourceMonoBinder<MeshCollider> { }
+}

--- a/Aspid.MVVM/Assets/Plugins/Aspid/MVVM/StarterKit/Unity/Runtime/Binders/Colliders/MeshColliders/Mono/MeshColliderToSourceMonoBinder.cs.meta
+++ b/Aspid.MVVM/Assets/Plugins/Aspid/MVVM/StarterKit/Unity/Runtime/Binders/Colliders/MeshColliders/Mono/MeshColliderToSourceMonoBinder.cs.meta
@@ -1,0 +1,3 @@
+fileFormatVersion: 2
+guid: 46279dfafd5642dd8d1ff4a15e738e53
+timeCreated: 1770636876

--- a/Aspid.MVVM/Assets/Plugins/Aspid/MVVM/StarterKit/Unity/Runtime/Binders/Colliders/Mono/ColliderToSourceMonoBinder.cs
+++ b/Aspid.MVVM/Assets/Plugins/Aspid/MVVM/StarterKit/Unity/Runtime/Binders/Colliders/Mono/ColliderToSourceMonoBinder.cs
@@ -1,0 +1,9 @@
+using UnityEngine;
+
+// ReSharper disable once CheckNamespace
+namespace Aspid.MVVM.StarterKit
+{
+    [AddBinderContextMenu(typeof(Collider))]
+    [AddComponentMenu("Aspid/MVVM/Binders/Collider/Collider To Source Binder")]
+    public sealed class ColliderToSourceMonoBinder : ComponentToSourceMonoBinder<Collider> { }
+}

--- a/Aspid.MVVM/Assets/Plugins/Aspid/MVVM/StarterKit/Unity/Runtime/Binders/Colliders/Mono/ColliderToSourceMonoBinder.cs.meta
+++ b/Aspid.MVVM/Assets/Plugins/Aspid/MVVM/StarterKit/Unity/Runtime/Binders/Colliders/Mono/ColliderToSourceMonoBinder.cs.meta
@@ -1,0 +1,3 @@
+fileFormatVersion: 2
+guid: 1896c69fb9594f33a5eb467581a5a093
+timeCreated: 1770636907

--- a/Aspid.MVVM/Assets/Plugins/Aspid/MVVM/StarterKit/Unity/Runtime/Binders/Colliders/SphereColliders/Mono/SphereColliderToSourceMonoBinder.cs
+++ b/Aspid.MVVM/Assets/Plugins/Aspid/MVVM/StarterKit/Unity/Runtime/Binders/Colliders/SphereColliders/Mono/SphereColliderToSourceMonoBinder.cs
@@ -1,0 +1,9 @@
+using UnityEngine;
+
+// ReSharper disable once CheckNamespace
+namespace Aspid.MVVM.StarterKit
+{
+    [AddBinderContextMenu(typeof(SphereCollider))]
+    [AddComponentMenu("Aspid/MVVM/Binders/Collider/Sphere/SphereCollider To Source Binder")]
+    public sealed class SphereColliderToSourceMonoBinder : ComponentToSourceMonoBinder<SphereCollider> { }
+}

--- a/Aspid.MVVM/Assets/Plugins/Aspid/MVVM/StarterKit/Unity/Runtime/Binders/Colliders/SphereColliders/Mono/SphereColliderToSourceMonoBinder.cs.meta
+++ b/Aspid.MVVM/Assets/Plugins/Aspid/MVVM/StarterKit/Unity/Runtime/Binders/Colliders/SphereColliders/Mono/SphereColliderToSourceMonoBinder.cs.meta
@@ -1,0 +1,3 @@
+fileFormatVersion: 2
+guid: 1a70df963b0942619af0c29e48645707
+timeCreated: 1770636959

--- a/Aspid.MVVM/Assets/Plugins/Aspid/MVVM/StarterKit/Unity/Runtime/Binders/Commands/Mono/ButtonCommandMonoBinder.cs
+++ b/Aspid.MVVM/Assets/Plugins/Aspid/MVVM/StarterKit/Unity/Runtime/Binders/Commands/Mono/ButtonCommandMonoBinder.cs
@@ -5,7 +5,7 @@ using UnityEngine.UI;
 namespace Aspid.MVVM.StarterKit
 {
     [AddBinderContextMenu(typeof(Button), serializePropertyNames: "m_Calls")]
-    [AddComponentMenu("Aspid/MVVM/Binders/UI/Commands/Button Binder – Command")]
+    [AddComponentMenu("Aspid/MVVM/Binders/UI/Command/Button Binder – Command")]
     public sealed partial class ButtonCommandMonoBinder : ComponentMonoBinder<Button>,
         IBinder<IRelayCommand>,
         IBinder<IRelayCommand<bool>>

--- a/Aspid.MVVM/Assets/Plugins/Aspid/MVVM/StarterKit/Unity/Runtime/Binders/Commands/Mono/DropdownCommandMonoBinder.cs
+++ b/Aspid.MVVM/Assets/Plugins/Aspid/MVVM/StarterKit/Unity/Runtime/Binders/Commands/Mono/DropdownCommandMonoBinder.cs
@@ -5,7 +5,7 @@ using UnityEngine;
 // ReSharper disable once CheckNamespace
 namespace Aspid.MVVM.StarterKit
 {
-    [AddComponentMenu("Aspid/MVVM/Binders/UI/Commands/Dropdown Binder – Command")]
+    [AddComponentMenu("Aspid/MVVM/Binders/UI/Command/Dropdown Binder – Command")]
     [AddBinderContextMenu(typeof(TMP_Dropdown), serializePropertyNames: "m_Calls")]
     public sealed partial class DropdownCommandMonoBinder : ComponentMonoBinder<TMP_Dropdown>,
         IBinder<IRelayCommand<int>>,

--- a/Aspid.MVVM/Assets/Plugins/Aspid/MVVM/StarterKit/Unity/Runtime/Binders/Commands/Mono/InputFieldCommandMonoBinder.cs
+++ b/Aspid.MVVM/Assets/Plugins/Aspid/MVVM/StarterKit/Unity/Runtime/Binders/Commands/Mono/InputFieldCommandMonoBinder.cs
@@ -6,7 +6,7 @@ using UnityEngine;
 // ReSharper disable once CheckNamespace
 namespace Aspid.MVVM.StarterKit
 {
-    [AddComponentMenu("Aspid/MVVM/Binders/UI/Commands/InputField Binder – Command")]
+    [AddComponentMenu("Aspid/MVVM/Binders/UI/Command/InputField Binder – Command")]
     [AddBinderContextMenu(typeof(TMP_InputField), serializePropertyNames: "m_Calls")]
     public sealed partial class InputFieldCommandMonoBinder : ComponentMonoBinder<TMP_InputField>, 
         IBinder<IRelayCommand>,

--- a/Aspid.MVVM/Assets/Plugins/Aspid/MVVM/StarterKit/Unity/Runtime/Binders/Commands/Mono/MonoCommandBinder.cs
+++ b/Aspid.MVVM/Assets/Plugins/Aspid/MVVM/StarterKit/Unity/Runtime/Binders/Commands/Mono/MonoCommandBinder.cs
@@ -3,8 +3,8 @@ using UnityEngine;
 // ReSharper disable once CheckNamespace
 namespace Aspid.MVVM.StarterKit
 {
-    [AddComponentMenu("Aspid/MVVM/Binders/Commands/Binder – Command")]
-    [AddBinderContextMenu(typeof(Component), serializePropertyNames: "m_Calls", Path = "Add General Binder/Commands/Binder – Command")]
+    [AddComponentMenu("Aspid/MVVM/Binders/Command/Binder – Command")]
+    [AddBinderContextMenu(typeof(Component), serializePropertyNames: "m_Calls", Path = "Add General Binder/Command/Command Binder")]
     public partial class MonoCommandBinder : MonoBinder, IBinder<IRelayCommand>
     {
         private IRelayCommand _command;

--- a/Aspid.MVVM/Assets/Plugins/Aspid/MVVM/StarterKit/Unity/Runtime/Binders/Commands/Mono/ScrollBarCommandMonoBinder.cs
+++ b/Aspid.MVVM/Assets/Plugins/Aspid/MVVM/StarterKit/Unity/Runtime/Binders/Commands/Mono/ScrollBarCommandMonoBinder.cs
@@ -5,7 +5,7 @@ using UnityEngine.UI;
 namespace Aspid.MVVM.StarterKit
 {
     [AddBinderContextMenu(typeof(Scrollbar), serializePropertyNames: "m_Calls")]
-    [AddComponentMenu("Aspid/MVVM/Binders/UI/Commands/Scrollbar Binder – Command")]
+    [AddComponentMenu("Aspid/MVVM/Binders/UI/Command/Scrollbar Binder – Command")]
     public sealed partial class ScrollBarCommandMonoBinder : ComponentMonoBinder<Scrollbar>, 
         IBinder<IRelayCommand<int>>, 
         IBinder<IRelayCommand<long>>, 

--- a/Aspid.MVVM/Assets/Plugins/Aspid/MVVM/StarterKit/Unity/Runtime/Binders/Commands/Mono/ScrollRectCommandMonoBinder.cs
+++ b/Aspid.MVVM/Assets/Plugins/Aspid/MVVM/StarterKit/Unity/Runtime/Binders/Commands/Mono/ScrollRectCommandMonoBinder.cs
@@ -5,7 +5,7 @@ using UnityEngine.UI;
 namespace Aspid.MVVM.StarterKit
 {
     [AddBinderContextMenu(typeof(ScrollRect), serializePropertyNames: "m_Calls")]
-    [AddComponentMenu("Aspid/MVVM/Binders/UI/Commands/ScrollRect Binder – Command")]
+    [AddComponentMenu("Aspid/MVVM/Binders/UI/Command/ScrollRect Binder – Command")]
     public sealed partial class ScrollRectCommandMonoBinder : ComponentMonoBinder<ScrollRect>, 
         IBinder<IRelayCommand<Vector2>>, 
         IBinder<IRelayCommand<Vector3>>

--- a/Aspid.MVVM/Assets/Plugins/Aspid/MVVM/StarterKit/Unity/Runtime/Binders/Commands/Mono/SliderCommandMonoBinder.cs
+++ b/Aspid.MVVM/Assets/Plugins/Aspid/MVVM/StarterKit/Unity/Runtime/Binders/Commands/Mono/SliderCommandMonoBinder.cs
@@ -5,7 +5,7 @@ using UnityEngine.UI;
 namespace Aspid.MVVM.StarterKit
 {
     [AddBinderContextMenu(typeof(Slider), serializePropertyNames: "m_Calls")]
-    [AddComponentMenu("Aspid/MVVM/Binders/UI/Commands/Slider Binder – Command")]
+    [AddComponentMenu("Aspid/MVVM/Binders/UI/Command/Slider Binder – Command")]
     public sealed partial class SliderCommandMonoBinder : ComponentMonoBinder<Slider>, 
         IBinder<IRelayCommand<int>>, 
         IBinder<IRelayCommand<long>>,

--- a/Aspid.MVVM/Assets/Plugins/Aspid/MVVM/StarterKit/Unity/Runtime/Binders/Commands/Mono/ToggleCommandMonoBinder.cs
+++ b/Aspid.MVVM/Assets/Plugins/Aspid/MVVM/StarterKit/Unity/Runtime/Binders/Commands/Mono/ToggleCommandMonoBinder.cs
@@ -5,7 +5,7 @@ using UnityEngine.UI;
 namespace Aspid.MVVM.StarterKit
 {
     [AddBinderContextMenu(typeof(Toggle), serializePropertyNames: "m_Calls")]
-    [AddComponentMenu("Aspid/MVVM/Binders/UI/Commands/Toggle Binder – Command")]
+    [AddComponentMenu("Aspid/MVVM/Binders/UI/Command/Toggle Binder – Command")]
     public partial class ToggleCommandMonoBinder : ComponentMonoBinder<Toggle>, IBinder<IRelayCommand>, IBinder<IRelayCommand<bool>>
     {
         [SerializeField] private InteractableMode _interactableMode = InteractableMode.Interactable;

--- a/Aspid.MVVM/Assets/Plugins/Aspid/MVVM/StarterKit/Unity/Runtime/Binders/Graphics/Mono/GraphicToSourceMonoBinder.cs
+++ b/Aspid.MVVM/Assets/Plugins/Aspid/MVVM/StarterKit/Unity/Runtime/Binders/Graphics/Mono/GraphicToSourceMonoBinder.cs
@@ -1,0 +1,10 @@
+using UnityEngine;
+using UnityEngine.UI;
+
+// ReSharper disable once CheckNamespace
+namespace Aspid.MVVM.StarterKit
+{
+    [AddBinderContextMenu(typeof(Graphic))]
+    [AddComponentMenu("Aspid/MVVM/Binders/UI/Graphic/Graphic To Source Binder")]
+    public sealed class GraphicToSourceMonoBinder : ComponentToSourceMonoBinder<Graphic> { }
+}

--- a/Aspid.MVVM/Assets/Plugins/Aspid/MVVM/StarterKit/Unity/Runtime/Binders/Graphics/Mono/GraphicToSourceMonoBinder.cs.meta
+++ b/Aspid.MVVM/Assets/Plugins/Aspid/MVVM/StarterKit/Unity/Runtime/Binders/Graphics/Mono/GraphicToSourceMonoBinder.cs.meta
@@ -1,0 +1,3 @@
+fileFormatVersion: 2
+guid: 40afffb1291848418b7db2c4ce9f5154
+timeCreated: 1770637092

--- a/Aspid.MVVM/Assets/Plugins/Aspid/MVVM/StarterKit/Unity/Runtime/Binders/Images/Mono/ImageToSourceMonoBinder.cs
+++ b/Aspid.MVVM/Assets/Plugins/Aspid/MVVM/StarterKit/Unity/Runtime/Binders/Images/Mono/ImageToSourceMonoBinder.cs
@@ -1,0 +1,10 @@
+using UnityEngine;
+using UnityEngine.UI;
+
+// ReSharper disable once CheckNamespace
+namespace Aspid.MVVM.StarterKit
+{
+    [AddBinderContextMenu(typeof(Image))]
+    [AddComponentMenu("Aspid/MVVM/Binders/UI/Image/Image To Source Binder")]
+    public sealed class ImageToSourceMonoBinder : ComponentToSourceMonoBinder<Image> { }
+}

--- a/Aspid.MVVM/Assets/Plugins/Aspid/MVVM/StarterKit/Unity/Runtime/Binders/Images/Mono/ImageToSourceMonoBinder.cs.meta
+++ b/Aspid.MVVM/Assets/Plugins/Aspid/MVVM/StarterKit/Unity/Runtime/Binders/Images/Mono/ImageToSourceMonoBinder.cs.meta
@@ -1,0 +1,3 @@
+fileFormatVersion: 2
+guid: 12fbebe225f54ba88766da3e4da33d61
+timeCreated: 1770637120

--- a/Aspid.MVVM/Assets/Plugins/Aspid/MVVM/StarterKit/Unity/Runtime/Binders/InputFields/Mono/InputFieldToSourceMonoBinder.cs
+++ b/Aspid.MVVM/Assets/Plugins/Aspid/MVVM/StarterKit/Unity/Runtime/Binders/InputFields/Mono/InputFieldToSourceMonoBinder.cs
@@ -1,0 +1,12 @@
+#if UNITY_2023_1_OR_NEWER || ASPID_MVVM_TEXT_MESH_PRO_INTEGRATION
+using TMPro;
+using UnityEngine;
+
+// ReSharper disable once CheckNamespace
+namespace Aspid.MVVM.StarterKit
+{
+    [AddBinderContextMenu(typeof(TMP_InputField))]
+    [AddComponentMenu("Aspid/MVVM/Binders/UI/InputField/InputField To Source Binder")]
+    public sealed class InputFieldToSourceMonoBinder : ComponentToSourceMonoBinder<TMP_InputField> { }
+}
+#endif

--- a/Aspid.MVVM/Assets/Plugins/Aspid/MVVM/StarterKit/Unity/Runtime/Binders/InputFields/Mono/InputFieldToSourceMonoBinder.cs.meta
+++ b/Aspid.MVVM/Assets/Plugins/Aspid/MVVM/StarterKit/Unity/Runtime/Binders/InputFields/Mono/InputFieldToSourceMonoBinder.cs.meta
@@ -1,0 +1,3 @@
+fileFormatVersion: 2
+guid: 62ab8e8eca9a4302a925603959aeb338
+timeCreated: 1770637149

--- a/Aspid.MVVM/Assets/Plugins/Aspid/MVVM/StarterKit/Unity/Runtime/Binders/Layouts/HorizontalOrVerticalLayoutGroup/Mono/HorizontalOrVerticalLayoutGroupSpacingEnumGroupMonoBinder.cs
+++ b/Aspid.MVVM/Assets/Plugins/Aspid/MVVM/StarterKit/Unity/Runtime/Binders/Layouts/HorizontalOrVerticalLayoutGroup/Mono/HorizontalOrVerticalLayoutGroupSpacingEnumGroupMonoBinder.cs
@@ -10,7 +10,7 @@ using Converter = Aspid.MVVM.StarterKit.IConverterFloat;
 namespace Aspid.MVVM.StarterKit
 {
     [AddBinderContextMenu(typeof(HorizontalOrVerticalLayoutGroup), serializePropertyNames: "m_Spacing", SubPath = "EnumGroup")]
-    [AddComponentMenu("Aspid/MVVM/Binders/UI/Layout/Horizontal Or Vertical Layout Group/HorizontalOrVerticalLayoutGroup Binder – Spacing EnumGroup")]
+    [AddComponentMenu("Aspid/MVVM/Binders/UI/LayoutGroup/HorizontalOrVertical/HorizontalOrVerticalLayoutGroup Binder – Spacing EnumGroup")]
     public sealed class HorizontalOrVerticalLayoutGroupSpacingEnumGroupMonoBinder : EnumGroupMonoBinder<HorizontalOrVerticalLayoutGroup>
     {
         [SerializeField] private float _defaultValue;

--- a/Aspid.MVVM/Assets/Plugins/Aspid/MVVM/StarterKit/Unity/Runtime/Binders/Layouts/HorizontalOrVerticalLayoutGroup/Mono/HorizontalOrVerticalLayoutSpacingEnumMonoBinder.cs
+++ b/Aspid.MVVM/Assets/Plugins/Aspid/MVVM/StarterKit/Unity/Runtime/Binders/Layouts/HorizontalOrVerticalLayoutGroup/Mono/HorizontalOrVerticalLayoutSpacingEnumMonoBinder.cs
@@ -5,7 +5,7 @@ using UnityEngine.UI;
 namespace Aspid.MVVM.StarterKit
 {
     [AddBinderContextMenu(typeof(HorizontalOrVerticalLayoutGroup), serializePropertyNames: "m_Spacing", SubPath = "Enum")]
-    [AddComponentMenu("Aspid/MVVM/Binders/UI/Layout/Horizontal Or Vertical Layout Group/HorizontalOrVerticalLayoutGroup Binder – Spacing Enum")]
+    [AddComponentMenu("Aspid/MVVM/Binders/UI/LayoutGroup/HorizontalOrVertical/HorizontalOrVerticalLayoutGroup Binder – Spacing Enum")]
     public sealed class HorizontalOrVerticalLayoutSpacingEnumMonoBinder : EnumMonoBinder<HorizontalOrVerticalLayoutGroup, float>
     {
         protected override void SetValue(float value) =>

--- a/Aspid.MVVM/Assets/Plugins/Aspid/MVVM/StarterKit/Unity/Runtime/Binders/Layouts/HorizontalOrVerticalLayoutGroup/Mono/HorizontalOrVerticalLayoutSpacingMonoBinder.cs
+++ b/Aspid.MVVM/Assets/Plugins/Aspid/MVVM/StarterKit/Unity/Runtime/Binders/Layouts/HorizontalOrVerticalLayoutGroup/Mono/HorizontalOrVerticalLayoutSpacingMonoBinder.cs
@@ -5,7 +5,7 @@ using UnityEngine.UI;
 namespace Aspid.MVVM.StarterKit
 {
     [AddBinderContextMenu(typeof(HorizontalOrVerticalLayoutGroup), serializePropertyNames: "m_Spacing")]
-    [AddComponentMenu("Aspid/MVVM/Binders/UI/Layout/Horizontal Or Vertical Layout Group/HorizontalOrVerticalLayoutGroup Binder – Spacing")]
+    [AddComponentMenu("Aspid/MVVM/Binders/UI/LayoutGroup/HorizontalOrVertical/HorizontalOrVerticalLayoutGroup Binder – Spacing")]
     public partial class HorizontalOrVerticalLayoutSpacingMonoBinder : ComponentMonoBinder<HorizontalOrVerticalLayoutGroup>, INumberBinder
     {
         [BinderLog]

--- a/Aspid.MVVM/Assets/Plugins/Aspid/MVVM/StarterKit/Unity/Runtime/Binders/Layouts/HorizontalOrVerticalLayoutGroup/Mono/HorizontalOrVerticalLayoutSpacingSwitcherMonoBinder.cs
+++ b/Aspid.MVVM/Assets/Plugins/Aspid/MVVM/StarterKit/Unity/Runtime/Binders/Layouts/HorizontalOrVerticalLayoutGroup/Mono/HorizontalOrVerticalLayoutSpacingSwitcherMonoBinder.cs
@@ -5,7 +5,7 @@ using UnityEngine.UI;
 namespace Aspid.MVVM.StarterKit
 {
     [AddBinderContextMenu(typeof(HorizontalOrVerticalLayoutGroup), serializePropertyNames: "m_Spacing", SubPath = "Switcher")]
-    [AddComponentMenu("Aspid/MVVM/Binders/UI/Layout/Horizontal Or Vertical Layout Group/HorizontalOrVerticalLayoutGroup Binder – Spacing Switcher")]
+    [AddComponentMenu("Aspid/MVVM/Binders/UI/LayoutGroup/HorizontalOrVertical/HorizontalOrVerticalLayoutGroup Binder – Spacing Switcher")]
     public sealed class HorizontalOrVerticalLayoutSpacingSwitcherMonoBinder : SwitcherMonoBinder<HorizontalOrVerticalLayoutGroup, float>
     {
         protected override void SetValue(float value) =>

--- a/Aspid.MVVM/Assets/Plugins/Aspid/MVVM/StarterKit/Unity/Runtime/Binders/Layouts/HorizontalOrVerticalLayoutGroup/Mono/HorizontalOrVerticalLayoutToSourceMonoBinder.cs
+++ b/Aspid.MVVM/Assets/Plugins/Aspid/MVVM/StarterKit/Unity/Runtime/Binders/Layouts/HorizontalOrVerticalLayoutGroup/Mono/HorizontalOrVerticalLayoutToSourceMonoBinder.cs
@@ -1,0 +1,10 @@
+using UnityEngine;
+using UnityEngine.UI;
+
+// ReSharper disable once CheckNamespace
+namespace Aspid.MVVM.StarterKit
+{
+    [AddBinderContextMenu(typeof(HorizontalOrVerticalLayoutGroup))]
+    [AddComponentMenu("Aspid/MVVM/Binders/UI/LayoutGroup/HorizontalOrVertical/HorizontalOrVerticalLayoutGroup To Source Binder")]
+    public sealed class HorizontalOrVerticalLayoutToSourceMonoBinder : ComponentToSourceMonoBinder<HorizontalOrVerticalLayoutGroup> { }
+}

--- a/Aspid.MVVM/Assets/Plugins/Aspid/MVVM/StarterKit/Unity/Runtime/Binders/Layouts/HorizontalOrVerticalLayoutGroup/Mono/HorizontalOrVerticalLayoutToSourceMonoBinder.cs.meta
+++ b/Aspid.MVVM/Assets/Plugins/Aspid/MVVM/StarterKit/Unity/Runtime/Binders/Layouts/HorizontalOrVerticalLayoutGroup/Mono/HorizontalOrVerticalLayoutToSourceMonoBinder.cs.meta
@@ -1,0 +1,3 @@
+fileFormatVersion: 2
+guid: 213a80c6372d4efd88b05b934c203244
+timeCreated: 1770637304

--- a/Aspid.MVVM/Assets/Plugins/Aspid/MVVM/StarterKit/Unity/Runtime/Binders/Layouts/Mono/LayoutGroupPaddingEnumGroupMonoBinder.cs
+++ b/Aspid.MVVM/Assets/Plugins/Aspid/MVVM/StarterKit/Unity/Runtime/Binders/Layouts/Mono/LayoutGroupPaddingEnumGroupMonoBinder.cs
@@ -9,7 +9,7 @@ using Converter = Aspid.MVVM.StarterKit.IConverterRectOffset;
 // ReSharper disable once CheckNamespace
 namespace Aspid.MVVM.StarterKit
 {
-    [AddComponentMenu("Aspid/MVVM/Binders/UI/Layout/LayoutGroup Binder – Padding EnumGroup")]
+    [AddComponentMenu("Aspid/MVVM/Binders/UI/LayoutGroup/LayoutGroup Binder – Padding EnumGroup")]
     [AddBinderContextMenu(typeof(LayoutGroup), serializePropertyNames: "m_Padding", SubPath = "EnumGroup")]
     public sealed class LayoutGroupPaddingEnumGroupMonoBinder : EnumGroupMonoBinder<LayoutGroup>
     {

--- a/Aspid.MVVM/Assets/Plugins/Aspid/MVVM/StarterKit/Unity/Runtime/Binders/Layouts/Mono/LayoutGroupPaddingEnumMonoBinder.cs
+++ b/Aspid.MVVM/Assets/Plugins/Aspid/MVVM/StarterKit/Unity/Runtime/Binders/Layouts/Mono/LayoutGroupPaddingEnumMonoBinder.cs
@@ -4,7 +4,7 @@ using UnityEngine.UI;
 // ReSharper disable once CheckNamespace
 namespace Aspid.MVVM.StarterKit
 {
-    [AddComponentMenu("Aspid/MVVM/Binders/UI/Layout/LayoutGroup Binder – Padding Enum")]
+    [AddComponentMenu("Aspid/MVVM/Binders/UI/LayoutGroup/LayoutGroup Binder – Padding Enum")]
     [AddBinderContextMenu(typeof(LayoutGroup), serializePropertyNames: "m_Padding", SubPath = "Enum")]
     public sealed class LayoutGroupPaddingEnumMonoBinder : EnumMonoBinder<LayoutGroup, RectOffset>
     {

--- a/Aspid.MVVM/Assets/Plugins/Aspid/MVVM/StarterKit/Unity/Runtime/Binders/Layouts/Mono/LayoutGroupPaddingMonoBinder.cs
+++ b/Aspid.MVVM/Assets/Plugins/Aspid/MVVM/StarterKit/Unity/Runtime/Binders/Layouts/Mono/LayoutGroupPaddingMonoBinder.cs
@@ -4,7 +4,7 @@ using UnityEngine.UI;
 // ReSharper disable once CheckNamespace
 namespace Aspid.MVVM.StarterKit
 {
-    [AddComponentMenu("Aspid/MVVM/Binders/UI/Layout/LayoutGroup Binder – Padding")]
+    [AddComponentMenu("Aspid/MVVM/Binders/UI/LayoutGroup/LayoutGroup Binder – Padding")]
     [AddBinderContextMenu(typeof(LayoutGroup), serializePropertyNames: "m_Padding")]
     public partial class LayoutGroupPaddingMonoBinder : ComponentMonoBinder<LayoutGroup>, IBinder<RectOffset>, INumberBinder
     {

--- a/Aspid.MVVM/Assets/Plugins/Aspid/MVVM/StarterKit/Unity/Runtime/Binders/Layouts/Mono/LayoutGroupPaddingSwitcherMonoBinder.cs
+++ b/Aspid.MVVM/Assets/Plugins/Aspid/MVVM/StarterKit/Unity/Runtime/Binders/Layouts/Mono/LayoutGroupPaddingSwitcherMonoBinder.cs
@@ -4,7 +4,7 @@ using UnityEngine.UI;
 // ReSharper disable once CheckNamespace
 namespace Aspid.MVVM.StarterKit
 {
-    [AddComponentMenu("Aspid/MVVM/Binders/UI/Layout/LayoutGroup Binder – Padding Switcher")]
+    [AddComponentMenu("Aspid/MVVM/Binders/UI/LayoutGroup/LayoutGroup Binder – Padding Switcher")]
     [AddBinderContextMenu(typeof(LayoutGroup), serializePropertyNames: "m_Padding", SubPath = "Switcher")]
     public sealed class LayoutGroupPaddingSwitcherMonoBinder : SwitcherMonoBinder<LayoutGroup, RectOffset>
     {

--- a/Aspid.MVVM/Assets/Plugins/Aspid/MVVM/StarterKit/Unity/Runtime/Binders/Layouts/Mono/LayoutGroupToSourceMonoBinder.cs
+++ b/Aspid.MVVM/Assets/Plugins/Aspid/MVVM/StarterKit/Unity/Runtime/Binders/Layouts/Mono/LayoutGroupToSourceMonoBinder.cs
@@ -1,0 +1,10 @@
+using UnityEngine;
+using UnityEngine.UI;
+
+// ReSharper disable once CheckNamespace
+namespace Aspid.MVVM.StarterKit
+{
+    [AddBinderContextMenu(typeof(LayoutGroup))]
+    [AddComponentMenu("Aspid/MVVM/Binders/UI/LayoutGroup/LayoutGroup To Source Binder")]
+    public sealed class LayoutGroupToSourceMonoBinder : ComponentToSourceMonoBinder<LayoutGroup> { }
+}

--- a/Aspid.MVVM/Assets/Plugins/Aspid/MVVM/StarterKit/Unity/Runtime/Binders/Layouts/Mono/LayoutGroupToSourceMonoBinder.cs.meta
+++ b/Aspid.MVVM/Assets/Plugins/Aspid/MVVM/StarterKit/Unity/Runtime/Binders/Layouts/Mono/LayoutGroupToSourceMonoBinder.cs.meta
@@ -1,0 +1,3 @@
+fileFormatVersion: 2
+guid: 64d54d085f9d45789c4d71049dee7317
+timeCreated: 1770637191

--- a/Aspid.MVVM/Assets/Plugins/Aspid/MVVM/StarterKit/Unity/Runtime/Binders/LineRenderers/Mono/LineRendererColorEnumGroupMonoBinder.cs
+++ b/Aspid.MVVM/Assets/Plugins/Aspid/MVVM/StarterKit/Unity/Runtime/Binders/LineRenderers/Mono/LineRendererColorEnumGroupMonoBinder.cs
@@ -8,7 +8,7 @@ using Converter = Aspid.MVVM.StarterKit.IConverterColor;
 // ReSharper disable once CheckNamespace
 namespace Aspid.MVVM.StarterKit
 {
-    [AddComponentMenu("Aspid/MVVM/Binders/Line Renderers/LineRenderer Binder – Color EnumGroup")]
+    [AddComponentMenu("Aspid/MVVM/Binders/LineRenderer/LineRenderer Binder – Color EnumGroup")]
     [AddBinderContextMenu(typeof(LineRenderer), serializePropertyNames: "colorGradient", SubPath = "EnumGroup")]
     public sealed class LineRendererColorEnumGroupMonoBinder : EnumGroupMonoBinder<LineRenderer>
     {

--- a/Aspid.MVVM/Assets/Plugins/Aspid/MVVM/StarterKit/Unity/Runtime/Binders/LineRenderers/Mono/LineRendererColorEnumMonoBinder.cs
+++ b/Aspid.MVVM/Assets/Plugins/Aspid/MVVM/StarterKit/Unity/Runtime/Binders/LineRenderers/Mono/LineRendererColorEnumMonoBinder.cs
@@ -8,7 +8,7 @@ using Converter = Aspid.MVVM.StarterKit.IConverterColor;
 // ReSharper disable once CheckNamespace
 namespace Aspid.MVVM.StarterKit
 {
-    [AddComponentMenu("Aspid/MVVM/Binders/Line Renderers/LineRenderer Binder – Color Enum")]
+    [AddComponentMenu("Aspid/MVVM/Binders/LineRenderer/LineRenderer Binder – Color Enum")]
     [AddBinderContextMenu(typeof(LineRenderer), serializePropertyNames: "colorGradient", SubPath = "Enum")]
     public sealed class LineRendererColorEnumMonoBinder : EnumMonoBinder<LineRenderer, Color>
     {

--- a/Aspid.MVVM/Assets/Plugins/Aspid/MVVM/StarterKit/Unity/Runtime/Binders/LineRenderers/Mono/LineRendererColorMonoBinder.cs
+++ b/Aspid.MVVM/Assets/Plugins/Aspid/MVVM/StarterKit/Unity/Runtime/Binders/LineRenderers/Mono/LineRendererColorMonoBinder.cs
@@ -8,7 +8,7 @@ using Converter = Aspid.MVVM.StarterKit.IConverterColor;
 // ReSharper disable once CheckNamespace
 namespace Aspid.MVVM.StarterKit
 {
-    [AddComponentMenu("Aspid/MVVM/Binders/Line Renderers/LineRenderer Binder – Color")]
+    [AddComponentMenu("Aspid/MVVM/Binders/LineRenderer/LineRenderer Binder – Color")]
     [AddBinderContextMenu(typeof(LineRenderer), serializePropertyNames: "colorGradient")]
     public partial class LineRendererColorMonoBinder : ComponentMonoBinder<LineRenderer>, IColorBinder
     {

--- a/Aspid.MVVM/Assets/Plugins/Aspid/MVVM/StarterKit/Unity/Runtime/Binders/LineRenderers/Mono/LineRendererColorSwitcherMonoBinder.cs
+++ b/Aspid.MVVM/Assets/Plugins/Aspid/MVVM/StarterKit/Unity/Runtime/Binders/LineRenderers/Mono/LineRendererColorSwitcherMonoBinder.cs
@@ -8,7 +8,7 @@ using Converter = Aspid.MVVM.StarterKit.IConverterColor;
 // ReSharper disable once CheckNamespace
 namespace Aspid.MVVM.StarterKit
 {
-    [AddComponentMenu("Aspid/MVVM/Binders/Line Renderers/LineRenderer Binder – Color Switcher")]
+    [AddComponentMenu("Aspid/MVVM/Binders/LineRenderer/LineRenderer Binder – Color Switcher")]
     [AddBinderContextMenu(typeof(LineRenderer), serializePropertyNames: "colorGradient", SubPath = "Switcher")]
     public sealed class LineRendererColorSwitcherMonoBinder : SwitcherMonoBinder<LineRenderer, Color>
     {

--- a/Aspid.MVVM/Assets/Plugins/Aspid/MVVM/StarterKit/Unity/Runtime/Binders/LineRenderers/Mono/LineRendererToSourceMonoBinder.cs
+++ b/Aspid.MVVM/Assets/Plugins/Aspid/MVVM/StarterKit/Unity/Runtime/Binders/LineRenderers/Mono/LineRendererToSourceMonoBinder.cs
@@ -1,0 +1,9 @@
+using UnityEngine;
+
+// ReSharper disable once CheckNamespace
+namespace Aspid.MVVM.StarterKit
+{
+    [AddBinderContextMenu(typeof(LineRenderer))]
+    [AddComponentMenu("Aspid/MVVM/Binders/LineRenderer/LineRenderer To Source Binder")]
+    public sealed class LineRendererToSourceMonoBinder : ComponentToSourceMonoBinder<LineRenderer> { }
+}

--- a/Aspid.MVVM/Assets/Plugins/Aspid/MVVM/StarterKit/Unity/Runtime/Binders/LineRenderers/Mono/LineRendererToSourceMonoBinder.cs.meta
+++ b/Aspid.MVVM/Assets/Plugins/Aspid/MVVM/StarterKit/Unity/Runtime/Binders/LineRenderers/Mono/LineRendererToSourceMonoBinder.cs.meta
@@ -1,0 +1,3 @@
+fileFormatVersion: 2
+guid: 63f2268766214b07bba016fe974ad5ac
+timeCreated: 1770637352

--- a/Aspid.MVVM/Assets/Plugins/Aspid/MVVM/StarterKit/Unity/Runtime/Binders/LocalizeStringEvents/Mono/LocalizeStringEventToSourceMonoBinder.cs
+++ b/Aspid.MVVM/Assets/Plugins/Aspid/MVVM/StarterKit/Unity/Runtime/Binders/LocalizeStringEvents/Mono/LocalizeStringEventToSourceMonoBinder.cs
@@ -1,0 +1,12 @@
+#if ASPID_MVVM_UNITY_LOCALIZATION_INTEGRATION
+using UnityEngine;
+using UnityEngine.Localization.Components;
+
+// ReSharper disable once CheckNamespace
+namespace Aspid.MVVM.StarterKit
+{
+    [AddBinderContextMenu(typeof(LocalizeStringEvent))]
+    [AddComponentMenu("Aspid/MVVM/Binders/LocalizeStringEvent/LocalizeStringEvent To Source Binder")]
+    public class LocalizeStringEventToSourceMonoBinder : ComponentToSourceMonoBinder<LocalizeStringEvent> { }
+}
+#endif

--- a/Aspid.MVVM/Assets/Plugins/Aspid/MVVM/StarterKit/Unity/Runtime/Binders/LocalizeStringEvents/Mono/LocalizeStringEventToSourceMonoBinder.cs.meta
+++ b/Aspid.MVVM/Assets/Plugins/Aspid/MVVM/StarterKit/Unity/Runtime/Binders/LocalizeStringEvents/Mono/LocalizeStringEventToSourceMonoBinder.cs.meta
@@ -1,0 +1,3 @@
+fileFormatVersion: 2
+guid: cd4f1c0c94db4d45b8b68998f0b659be
+timeCreated: 1770639281

--- a/Aspid.MVVM/Assets/Plugins/Aspid/MVVM/StarterKit/Unity/Runtime/Binders/Mono/ComponentToSourceMonoBinder.cs
+++ b/Aspid.MVVM/Assets/Plugins/Aspid/MVVM/StarterKit/Unity/Runtime/Binders/Mono/ComponentToSourceMonoBinder.cs
@@ -1,0 +1,29 @@
+using System;
+using UnityEngine;
+
+// ReSharper disable once CheckNamespace
+namespace Aspid.MVVM.StarterKit
+{
+    [BindModeOverride(modes: BindMode.OneWayToSource)]
+    public abstract class ComponentToSourceMonoBinder<TComponent> : ComponentMonoBinder<TComponent>, IReverseBinder<TComponent>
+        where TComponent : Component
+    {
+        public event Action<TComponent> ValueChanged;
+        
+        protected override void OnBound() =>
+            ValueChanged?.Invoke(CachedComponent);
+    }
+
+    [AddComponentMenu("Aspid/MVVM/Binders/Components/Component To Source Binder")]
+    [AddBinderContextMenu(typeof(Component), Path = "Add General Binder/Component/Component To Source Binder")]
+    public sealed class ComponentToSourceMonoBinder : ComponentToSourceMonoBinder<Component>, IAnyReverseBinder
+    {
+        public new event Action<object> ValueChanged;
+
+        protected override void OnBound()
+        {
+            base.OnBound();
+            ValueChanged?.Invoke(CachedComponent);
+        }
+    }
+}

--- a/Aspid.MVVM/Assets/Plugins/Aspid/MVVM/StarterKit/Unity/Runtime/Binders/Mono/ComponentToSourceMonoBinder.cs.meta
+++ b/Aspid.MVVM/Assets/Plugins/Aspid/MVVM/StarterKit/Unity/Runtime/Binders/Mono/ComponentToSourceMonoBinder.cs.meta
@@ -1,0 +1,3 @@
+fileFormatVersion: 2
+guid: 3e1384c7d5c841bd9df96738a40c3dad
+timeCreated: 1770629466

--- a/Aspid.MVVM/Assets/Plugins/Aspid/MVVM/StarterKit/Unity/Runtime/Binders/RawImages/Mono/RawImageMaterialEnumGroupMonoBinder.cs
+++ b/Aspid.MVVM/Assets/Plugins/Aspid/MVVM/StarterKit/Unity/Runtime/Binders/RawImages/Mono/RawImageMaterialEnumGroupMonoBinder.cs
@@ -9,7 +9,7 @@ using Converter = Aspid.MVVM.StarterKit.IConverterMaterial;
 // ReSharper disable once CheckNamespace
 namespace Aspid.MVVM.StarterKit
 {
-    [AddComponentMenu("Aspid/MVVM/Binders/UI/Raw Image/RawImage Binder – Material EnumGroup")]
+    [AddComponentMenu("Aspid/MVVM/Binders/UI/RawImage/RawImage Binder – Material EnumGroup")]
     [AddBinderContextMenu(typeof(RawImage), serializePropertyNames: "m_Material", SubPath = "EnumGroup")]
     public sealed class RawImageMaterialEnumGroupMonoBinder : EnumGroupMonoBinder<RawImage>
     {

--- a/Aspid.MVVM/Assets/Plugins/Aspid/MVVM/StarterKit/Unity/Runtime/Binders/RawImages/Mono/RawImageMaterialEnumMonoBinder.cs
+++ b/Aspid.MVVM/Assets/Plugins/Aspid/MVVM/StarterKit/Unity/Runtime/Binders/RawImages/Mono/RawImageMaterialEnumMonoBinder.cs
@@ -9,7 +9,7 @@ using Converter = Aspid.MVVM.StarterKit.IConverterMaterial;
 // ReSharper disable once CheckNamespace
 namespace Aspid.MVVM.StarterKit
 {
-    [AddComponentMenu("Aspid/MVVM/Binders/UI/Raw Image/RawImage Binder – Material Enum")]
+    [AddComponentMenu("Aspid/MVVM/Binders/UI/RawImage/RawImage Binder – Material Enum")]
     [AddBinderContextMenu(typeof(RawImage), serializePropertyNames: "m_Material", SubPath = "Enum")]
     public sealed class RawImageMaterialEnumMonoBinder : EnumMonoBinder<RawImage, Material>
     {

--- a/Aspid.MVVM/Assets/Plugins/Aspid/MVVM/StarterKit/Unity/Runtime/Binders/RawImages/Mono/RawImageMaterialMonoBinder.cs
+++ b/Aspid.MVVM/Assets/Plugins/Aspid/MVVM/StarterKit/Unity/Runtime/Binders/RawImages/Mono/RawImageMaterialMonoBinder.cs
@@ -10,7 +10,7 @@ using Converter = Aspid.MVVM.StarterKit.IConverterMaterial;
 namespace Aspid.MVVM.StarterKit
 {
     [AddBinderContextMenu(typeof(RawImage), serializePropertyNames: "m_Material")]
-    [AddComponentMenu("Aspid/MVVM/Binders/UI/Raw Image/RawImage Binder – Material")]
+    [AddComponentMenu("Aspid/MVVM/Binders/UI/RawImage/RawImage Binder – Material")]
     public partial class RawImageMaterialMonoBinder : ComponentMonoBinder<RawImage>, IBinder<Material>
     {
         [SerializeReferenceDropdown]

--- a/Aspid.MVVM/Assets/Plugins/Aspid/MVVM/StarterKit/Unity/Runtime/Binders/RawImages/Mono/RawImageMaterialSwitcherMonoBinder.cs
+++ b/Aspid.MVVM/Assets/Plugins/Aspid/MVVM/StarterKit/Unity/Runtime/Binders/RawImages/Mono/RawImageMaterialSwitcherMonoBinder.cs
@@ -9,7 +9,7 @@ using Converter = Aspid.MVVM.StarterKit.IConverterMaterial;
 // ReSharper disable once CheckNamespace
 namespace Aspid.MVVM.StarterKit
 {
-    [AddComponentMenu("Aspid/MVVM/Binders/UI/Raw Image/RawImage Binder – Material Switcher")]
+    [AddComponentMenu("Aspid/MVVM/Binders/UI/RawImage/RawImage Binder – Material Switcher")]
     [AddBinderContextMenu(typeof(RawImage), serializePropertyNames: "m_Material", SubPath = "Switcher")]
     public sealed class RawImageMaterialSwitcherMonoBinder : SwitcherMonoBinder<RawImage, Material>
     {

--- a/Aspid.MVVM/Assets/Plugins/Aspid/MVVM/StarterKit/Unity/Runtime/Binders/RawImages/Mono/RawImageTextureAddressableMonoBinder.cs
+++ b/Aspid.MVVM/Assets/Plugins/Aspid/MVVM/StarterKit/Unity/Runtime/Binders/RawImages/Mono/RawImageTextureAddressableMonoBinder.cs
@@ -6,7 +6,7 @@ using UnityEngine.UI;
 namespace Aspid.MVVM.StarterKit
 {
     [AddBinderContextMenu(typeof(RawImage), serializePropertyNames: "m_Texture")]
-    [AddComponentMenu("Aspid/MVVM/Binders/UI/Raw Image/RawImage Binder – Texture Addressable")]
+    [AddComponentMenu("Aspid/MVVM/Binders/UI/RawImage/RawImage Binder – Texture Addressable")]
     public sealed class RawImageTextureAddressableMonoBinder : AddressableMonoBinder<Texture2D, RawImage>
     {
         [SerializeField] private Texture2D _defaultTexture;

--- a/Aspid.MVVM/Assets/Plugins/Aspid/MVVM/StarterKit/Unity/Runtime/Binders/RawImages/Mono/RawImageTextureEnumGroupMonoBinder.cs
+++ b/Aspid.MVVM/Assets/Plugins/Aspid/MVVM/StarterKit/Unity/Runtime/Binders/RawImages/Mono/RawImageTextureEnumGroupMonoBinder.cs
@@ -9,7 +9,7 @@ using Converter = Aspid.MVVM.StarterKit.IConverterTexture2D;
 // ReSharper disable once CheckNamespace
 namespace Aspid.MVVM.StarterKit
 {
-    [AddComponentMenu("Aspid/MVVM/Binders/UI/Raw Image/RawImage Binder – Texture EnumGroup")]
+    [AddComponentMenu("Aspid/MVVM/Binders/UI/RawImage/RawImage Binder – Texture EnumGroup")]
     [AddBinderContextMenu(typeof(RawImage), serializePropertyNames: "m_Texture", SubPath = "EnumGroup")]
     public sealed class RawImageTextureEnumGroupMonoBinder : EnumGroupMonoBinder<RawImage>
     {

--- a/Aspid.MVVM/Assets/Plugins/Aspid/MVVM/StarterKit/Unity/Runtime/Binders/RawImages/Mono/RawImageTextureEnumMonoBinder.cs
+++ b/Aspid.MVVM/Assets/Plugins/Aspid/MVVM/StarterKit/Unity/Runtime/Binders/RawImages/Mono/RawImageTextureEnumMonoBinder.cs
@@ -4,7 +4,7 @@ using UnityEngine.UI;
 // ReSharper disable once CheckNamespace
 namespace Aspid.MVVM.StarterKit
 {
-    [AddComponentMenu("Aspid/MVVM/Binders/UI/Raw Image/RawImage Binder – Texture Enum")]
+    [AddComponentMenu("Aspid/MVVM/Binders/UI/RawImage/RawImage Binder – Texture Enum")]
     [AddBinderContextMenu(typeof(RawImage), serializePropertyNames: "m_Texture", SubPath = "Enum")]
     public sealed class RawImageTextureEnumMonoBinder : EnumMonoBinder<RawImage, Texture2D>
     {

--- a/Aspid.MVVM/Assets/Plugins/Aspid/MVVM/StarterKit/Unity/Runtime/Binders/RawImages/Mono/RawImageTextureMonoBinder.cs
+++ b/Aspid.MVVM/Assets/Plugins/Aspid/MVVM/StarterKit/Unity/Runtime/Binders/RawImages/Mono/RawImageTextureMonoBinder.cs
@@ -5,7 +5,7 @@ using UnityEngine.UI;
 namespace Aspid.MVVM.StarterKit
 {
     [AddBinderContextMenu(typeof(RawImage), serializePropertyNames: "m_Texture")]
-    [AddComponentMenu("Aspid/MVVM/Binders/UI/Raw Image/RawImage Binder – Texture")]
+    [AddComponentMenu("Aspid/MVVM/Binders/UI/RawImage/RawImage Binder – Texture")]
     public partial class RawImageTextureMonoBinder : ComponentMonoBinder<RawImage>, IBinder<Texture2D>, IBinder<Sprite>
     {
         [SerializeField] private bool _disabledWhenNull = true;

--- a/Aspid.MVVM/Assets/Plugins/Aspid/MVVM/StarterKit/Unity/Runtime/Binders/RawImages/Mono/RawImageTextureSwitcherMonoBinder.cs
+++ b/Aspid.MVVM/Assets/Plugins/Aspid/MVVM/StarterKit/Unity/Runtime/Binders/RawImages/Mono/RawImageTextureSwitcherMonoBinder.cs
@@ -4,7 +4,7 @@ using UnityEngine.UI;
 // ReSharper disable once CheckNamespace
 namespace Aspid.MVVM.StarterKit
 {
-    [AddComponentMenu("Aspid/MVVM/Binders/UI/Raw Image/RawImage Binder – Texture Switcher")]
+    [AddComponentMenu("Aspid/MVVM/Binders/UI/RawImage/RawImage Binder – Texture Switcher")]
     [AddBinderContextMenu(typeof(RawImage), serializePropertyNames: "m_Texture", SubPath = "Switcher")]
     public sealed class RawImageTextureSwitcherMonoBinder : SwitcherMonoBinder<RawImage, Texture2D>
     {

--- a/Aspid.MVVM/Assets/Plugins/Aspid/MVVM/StarterKit/Unity/Runtime/Binders/RawImages/Mono/RawImageToSourceMonoBinder.cs
+++ b/Aspid.MVVM/Assets/Plugins/Aspid/MVVM/StarterKit/Unity/Runtime/Binders/RawImages/Mono/RawImageToSourceMonoBinder.cs
@@ -1,0 +1,10 @@
+using UnityEngine;
+using UnityEngine.UI;
+
+// ReSharper disable once CheckNamespace
+namespace Aspid.MVVM.StarterKit
+{
+    [AddBinderContextMenu(typeof(RawImage))]
+    [AddComponentMenu("Aspid/MVVM/Binders/UI/RawImage/RawImage To Source Binder")]
+    public sealed class RawImageToSourceMonoBinder : ComponentToSourceMonoBinder<RawImage> { }
+}

--- a/Aspid.MVVM/Assets/Plugins/Aspid/MVVM/StarterKit/Unity/Runtime/Binders/RawImages/Mono/RawImageToSourceMonoBinder.cs.meta
+++ b/Aspid.MVVM/Assets/Plugins/Aspid/MVVM/StarterKit/Unity/Runtime/Binders/RawImages/Mono/RawImageToSourceMonoBinder.cs.meta
@@ -1,0 +1,3 @@
+fileFormatVersion: 2
+guid: e82c95cb94df416fb6804cc75bd787dc
+timeCreated: 1770639542

--- a/Aspid.MVVM/Assets/Plugins/Aspid/MVVM/StarterKit/Unity/Runtime/Binders/Renderers/Mono/RendererToSourceMonoBinder.cs
+++ b/Aspid.MVVM/Assets/Plugins/Aspid/MVVM/StarterKit/Unity/Runtime/Binders/Renderers/Mono/RendererToSourceMonoBinder.cs
@@ -1,0 +1,9 @@
+using UnityEngine;
+
+// ReSharper disable once CheckNamespace
+namespace Aspid.MVVM.StarterKit
+{
+    [AddBinderContextMenu(typeof(Renderer))]
+    [AddComponentMenu("Aspid/MVVM/Binders/Renderer/Renderer To Source Binder")]
+    public sealed class RendererToSourceMonoBinder : ComponentToSourceMonoBinder<Renderer> { }
+}

--- a/Aspid.MVVM/Assets/Plugins/Aspid/MVVM/StarterKit/Unity/Runtime/Binders/Renderers/Mono/RendererToSourceMonoBinder.cs.meta
+++ b/Aspid.MVVM/Assets/Plugins/Aspid/MVVM/StarterKit/Unity/Runtime/Binders/Renderers/Mono/RendererToSourceMonoBinder.cs.meta
@@ -1,0 +1,3 @@
+fileFormatVersion: 2
+guid: 8d68d044098a4112a5bbee93f6c2a778
+timeCreated: 1770639577

--- a/Aspid.MVVM/Assets/Plugins/Aspid/MVVM/StarterKit/Unity/Runtime/Binders/Sliders/Mono/SliderToSourceMonoBinder.cs
+++ b/Aspid.MVVM/Assets/Plugins/Aspid/MVVM/StarterKit/Unity/Runtime/Binders/Sliders/Mono/SliderToSourceMonoBinder.cs
@@ -1,0 +1,10 @@
+using UnityEngine;
+using UnityEngine.UI;
+
+// ReSharper disable once CheckNamespace
+namespace Aspid.MVVM.StarterKit
+{
+    [AddBinderContextMenu(typeof(Slider))]
+    [AddComponentMenu("Aspid/MVVM/Binders/UI/Slider/Slider To Source Binder")]
+    public sealed class SliderToSourceMonoBinder : ComponentToSourceMonoBinder<Slider> { }
+}

--- a/Aspid.MVVM/Assets/Plugins/Aspid/MVVM/StarterKit/Unity/Runtime/Binders/Sliders/Mono/SliderToSourceMonoBinder.cs.meta
+++ b/Aspid.MVVM/Assets/Plugins/Aspid/MVVM/StarterKit/Unity/Runtime/Binders/Sliders/Mono/SliderToSourceMonoBinder.cs.meta
@@ -1,0 +1,3 @@
+fileFormatVersion: 2
+guid: 28ac6c469c334f06964bfea64eabb422
+timeCreated: 1770639797

--- a/Aspid.MVVM/Assets/Plugins/Aspid/MVVM/StarterKit/Unity/Runtime/Binders/Texts/Mono/TextToSourceMonoBinder.cs
+++ b/Aspid.MVVM/Assets/Plugins/Aspid/MVVM/StarterKit/Unity/Runtime/Binders/Texts/Mono/TextToSourceMonoBinder.cs
@@ -1,0 +1,12 @@
+#if UNITY_2023_1_OR_NEWER || ASPID_MVVM_TEXT_MESH_PRO_INTEGRATION
+using TMPro;
+using UnityEngine;
+
+// ReSharper disable once CheckNamespace
+namespace Aspid.MVVM.StarterKit
+{
+    [AddBinderContextMenu(typeof(TMP_Text))]
+    [AddComponentMenu("Aspid/MVVM/Binders/UI/Text/Text To Source Binder")]
+    public sealed class TextToSourceMonoBinder : ComponentToSourceMonoBinder<TMP_Text> { }
+}
+#endif

--- a/Aspid.MVVM/Assets/Plugins/Aspid/MVVM/StarterKit/Unity/Runtime/Binders/Texts/Mono/TextToSourceMonoBinder.cs.meta
+++ b/Aspid.MVVM/Assets/Plugins/Aspid/MVVM/StarterKit/Unity/Runtime/Binders/Texts/Mono/TextToSourceMonoBinder.cs.meta
@@ -1,0 +1,3 @@
+fileFormatVersion: 2
+guid: 0e7a923c85d744ddba19578f2de516fc
+timeCreated: 1770640143

--- a/Aspid.MVVM/Assets/Plugins/Aspid/MVVM/StarterKit/Unity/Runtime/Binders/Toggles/Mono/ToggleIsOnMonoBinder.cs
+++ b/Aspid.MVVM/Assets/Plugins/Aspid/MVVM/StarterKit/Unity/Runtime/Binders/Toggles/Mono/ToggleIsOnMonoBinder.cs
@@ -6,7 +6,7 @@ using UnityEngine.UI;
 namespace Aspid.MVVM.StarterKit
 {
     [BindModeOverride(IsAll = true)]
-    [AddComponentMenu("Aspid/MVVM/Binders/UI/Toggles/Toggle Binder – IsOn")]
+    [AddComponentMenu("Aspid/MVVM/Binders/UI/Toggle/Toggle Binder – IsOn")]
     [AddBinderContextMenu(typeof(Toggle), serializePropertyNames: "m_IsOn")]
     public partial class ToggleIsOnMonoBinder : ComponentMonoBinder<Toggle>, IBinder<bool>, IReverseBinder<bool>
     {

--- a/Aspid.MVVM/Assets/Plugins/Aspid/MVVM/StarterKit/Unity/Runtime/Binders/Toggles/Mono/ToggleToSourceMonoBinder.cs
+++ b/Aspid.MVVM/Assets/Plugins/Aspid/MVVM/StarterKit/Unity/Runtime/Binders/Toggles/Mono/ToggleToSourceMonoBinder.cs
@@ -1,0 +1,10 @@
+using UnityEngine;
+using UnityEngine.UI;
+
+// ReSharper disable once CheckNamespace
+namespace Aspid.MVVM.StarterKit
+{
+    [AddBinderContextMenu(typeof(Toggle))]
+    [AddComponentMenu("Aspid/MVVM/Binders/UI/Toggle/Toggle To Source Binder")]
+    public sealed class ToggleToSourceMonoBinder : ComponentToSourceMonoBinder<Toggle> { }
+}

--- a/Aspid.MVVM/Assets/Plugins/Aspid/MVVM/StarterKit/Unity/Runtime/Binders/Toggles/Mono/ToggleToSourceMonoBinder.cs.meta
+++ b/Aspid.MVVM/Assets/Plugins/Aspid/MVVM/StarterKit/Unity/Runtime/Binders/Toggles/Mono/ToggleToSourceMonoBinder.cs.meta
@@ -1,0 +1,3 @@
+fileFormatVersion: 2
+guid: 5e1641892d364c53ac3bcde712bda3cf
+timeCreated: 1770640301

--- a/Aspid.MVVM/Assets/Plugins/Aspid/MVVM/StarterKit/Unity/Runtime/Binders/Transforms/Mono/TransformToSourceMonoBinder.cs
+++ b/Aspid.MVVM/Assets/Plugins/Aspid/MVVM/StarterKit/Unity/Runtime/Binders/Transforms/Mono/TransformToSourceMonoBinder.cs
@@ -1,0 +1,9 @@
+using UnityEngine;
+
+// ReSharper disable once CheckNamespace
+namespace Aspid.MVVM.StarterKit
+{
+    [AddBinderContextMenu(typeof(Transform))]
+    [AddComponentMenu("Aspid/MVVM/Binders/Transform/Transform To Source Binder")]
+    public sealed class TransformToSourceMonoBinder : ComponentToSourceMonoBinder<Transform> { }
+}

--- a/Aspid.MVVM/Assets/Plugins/Aspid/MVVM/StarterKit/Unity/Runtime/Binders/Transforms/Mono/TransformToSourceMonoBinder.cs.meta
+++ b/Aspid.MVVM/Assets/Plugins/Aspid/MVVM/StarterKit/Unity/Runtime/Binders/Transforms/Mono/TransformToSourceMonoBinder.cs.meta
@@ -1,0 +1,3 @@
+fileFormatVersion: 2
+guid: 481a80405d264073bd57e61402c40774
+timeCreated: 1770641180

--- a/Aspid.MVVM/Assets/Plugins/Aspid/MVVM/StarterKit/Unity/Runtime/Binders/Transforms/RectTransforms/Mono/RectTransformToSourceMonoBinder.cs
+++ b/Aspid.MVVM/Assets/Plugins/Aspid/MVVM/StarterKit/Unity/Runtime/Binders/Transforms/RectTransforms/Mono/RectTransformToSourceMonoBinder.cs
@@ -1,0 +1,9 @@
+using UnityEngine;
+
+// ReSharper disable once CheckNamespace
+namespace Aspid.MVVM.StarterKit
+{
+    [AddBinderContextMenu(typeof(RectTransform))]
+    [AddComponentMenu("Aspid/MVVM/Binders/UI/RectTransform/RectTransform To Source Binder")]
+    public sealed class RectTransformToSourceMonoBinder : ComponentToSourceMonoBinder<RectTransform> { }
+}

--- a/Aspid.MVVM/Assets/Plugins/Aspid/MVVM/StarterKit/Unity/Runtime/Binders/Transforms/RectTransforms/Mono/RectTransformToSourceMonoBinder.cs.meta
+++ b/Aspid.MVVM/Assets/Plugins/Aspid/MVVM/StarterKit/Unity/Runtime/Binders/Transforms/RectTransforms/Mono/RectTransformToSourceMonoBinder.cs.meta
@@ -1,0 +1,3 @@
+fileFormatVersion: 2
+guid: 91562b92426e4d7ab29b904f01313ea4
+timeCreated: 1770641150

--- a/Aspid.MVVM/Assets/Plugins/Aspid/MVVM/StarterKit/Unity/Runtime/Binders/VirtualizedLists/Mono/VirtualizedListToSourceMonoBinder.cs
+++ b/Aspid.MVVM/Assets/Plugins/Aspid/MVVM/StarterKit/Unity/Runtime/Binders/VirtualizedLists/Mono/VirtualizedListToSourceMonoBinder.cs
@@ -1,0 +1,9 @@
+using UnityEngine;
+
+// ReSharper disable once CheckNamespace
+namespace Aspid.MVVM.StarterKit
+{
+    [AddBinderContextMenu(typeof(VirtualizedList))]
+    [AddComponentMenu("Aspid/MVVM/Binders/UI/VirtualizedList/VirtualizedList To Source Binder")]
+    public sealed class VirtualizedListToSourceMonoBinder : ComponentToSourceMonoBinder<VirtualizedList> { }
+}

--- a/Aspid.MVVM/Assets/Plugins/Aspid/MVVM/StarterKit/Unity/Runtime/Binders/VirtualizedLists/Mono/VirtualizedListToSourceMonoBinder.cs.meta
+++ b/Aspid.MVVM/Assets/Plugins/Aspid/MVVM/StarterKit/Unity/Runtime/Binders/VirtualizedLists/Mono/VirtualizedListToSourceMonoBinder.cs.meta
@@ -1,0 +1,3 @@
+fileFormatVersion: 2
+guid: c9528a7a2f9149ef8bfa300ec99cf9e7
+timeCreated: 1770640364

--- a/Aspid.MVVM/Assets/Plugins/Aspid/MVVM/Unity/Runtime/Binders/Impls/ComponentMonoBinder.cs
+++ b/Aspid.MVVM/Assets/Plugins/Aspid/MVVM/Unity/Runtime/Binders/Impls/ComponentMonoBinder.cs
@@ -4,7 +4,7 @@ using UnityEngine;
 namespace Aspid.MVVM
 {
     public abstract class ComponentMonoBinder<TComponent> : MonoBinder
-        where TComponent : Object
+        where TComponent : Component
     {
         [SerializeField] private TComponent _component;
         

--- a/Aspid.MVVM/Assets/Plugins/Aspid/MVVM/Unity/Runtime/Binders/Impls/Views/MonoViewBinder.cs
+++ b/Aspid.MVVM/Assets/Plugins/Aspid/MVVM/Unity/Runtime/Binders/Impls/Views/MonoViewBinder.cs
@@ -4,7 +4,7 @@ using UnityEngine;
 namespace Aspid.MVVM
 {
     public class MonoViewBinder<TView> : TargetBinder<TView>, IBinder<IViewModel>
-        where TView : Object, IView
+        where TView : Component, IView
     {
         public MonoViewBinder(TView target, BindMode mode = BindMode.OneWay)
             : base(target, mode)

--- a/Aspid.MVVM/Assets/Plugins/Aspid/MVVM/Unity/Runtime/Binders/Impls/Views/MonoViewMonoBinder.cs
+++ b/Aspid.MVVM/Assets/Plugins/Aspid/MVVM/Unity/Runtime/Binders/Impls/Views/MonoViewMonoBinder.cs
@@ -3,8 +3,8 @@ using UnityEngine;
 // ReSharper disable once CheckNamespace
 namespace Aspid.MVVM
 {
-    public abstract class MonoViewMonoBinder<TView> : ComponentMonoBinder<TView>
-        where TView : Object, IView
+    public abstract class MonoViewMonoBinder<TView> : ComponentMonoBinder<TView>, IBinder<IViewModel>
+        where TView : Component, IView
     {
         [BinderLog]
         public void SetValue(IViewModel viewModel)

--- a/Aspid.MVVM/Assets/Plugins/Aspid/MVVM/Unity/Runtime/Binders/Impls/Views/ScriptableViewBinder.cs
+++ b/Aspid.MVVM/Assets/Plugins/Aspid/MVVM/Unity/Runtime/Binders/Impls/Views/ScriptableViewBinder.cs
@@ -1,7 +1,36 @@
+using UnityEngine;
+
 // ReSharper disable once CheckNamespace
 namespace Aspid.MVVM
 {
-    public class ScriptableViewBinder : MonoViewBinder<ScriptableView>
+    public class ScriptableViewBinder<TView> : TargetBinder<TView>
+        where TView : ScriptableObject, IView
+    {
+        public ScriptableViewBinder(TView target, BindMode mode = BindMode.OneWay)
+            : base(target, mode)
+        {
+            mode.ThrowExceptionIfNotOne();
+        }
+
+        public void SetValue(IViewModel viewModel)
+        {
+            DeinitializeView();
+
+            if (viewModel is not null)
+                InitializeView(viewModel);
+        }
+
+        protected override void OnUnbound() =>
+            DeinitializeView();
+        
+        protected void InitializeView(IViewModel viewModel) => 
+            Target.Initialize(viewModel);
+        
+        protected void DeinitializeView() => 
+            Target.Deinitialize();
+    }
+    
+    public class ScriptableViewBinder : ScriptableViewBinder<ScriptableView>
     {
         public ScriptableViewBinder(ScriptableView target, BindMode mode = BindMode.OneWay) 
             : base(target, mode) { }

--- a/Aspid.MVVM/Assets/Plugins/Aspid/MVVM/Unity/Runtime/Binders/Impls/Views/ScriptableViewMonoBinder.cs
+++ b/Aspid.MVVM/Assets/Plugins/Aspid/MVVM/Unity/Runtime/Binders/Impls/Views/ScriptableViewMonoBinder.cs
@@ -3,7 +3,30 @@ using UnityEngine;
 // ReSharper disable once CheckNamespace
 namespace Aspid.MVVM
 {
-    [AddBinderContextMenu(typeof(MonoView))]
+    public abstract partial class ScriptableViewMonoBinder<TView> : MonoBinder, IBinder<IViewModel>
+        where TView : ScriptableObject, IView
+    {
+        [SerializeField] private TView _view;
+        
+        [BinderLog]
+        public void SetValue(IViewModel viewModel)
+        {
+            DeinitializeView();
+
+            if (viewModel is not null)
+                InitializeView(viewModel);
+        }
+
+        protected override void OnUnbound() =>
+            DeinitializeView();
+        
+        protected void InitializeView(IViewModel viewModel) => 
+            _view.Initialize(viewModel);
+        
+        protected void DeinitializeView() => 
+            _view.Deinitialize();
+    }
+    
     [AddComponentMenu("Aspid/MVVM/Binders/Views/ScriptableView Binder")]
-    public class ScriptableViewMonoBinder : MonoViewMonoBinder<ScriptableView> { }
+    public class ScriptableViewMonoBinder : ScriptableViewMonoBinder<ScriptableView> { }
 }

--- a/Aspid.MVVM/Assets/Plugins/Aspid/MVVM/Unity/Runtime/Binders/Impls/Views/ScriptableViewMonoBinder.cs.meta
+++ b/Aspid.MVVM/Assets/Plugins/Aspid/MVVM/Unity/Runtime/Binders/Impls/Views/ScriptableViewMonoBinder.cs.meta
@@ -1,3 +1,3 @@
 fileFormatVersion: 2
-guid: 53deff09ebff478ea980153f985fb96d
-timeCreated: 1770468960
+guid: 239b44c3ce404b09846a657bdf00b5bd
+timeCreated: 1770710749


### PR DESCRIPTION
Adds binder components that support the `OneWayToSource` bind mode for Unity component properties, propagating value changes from the View (e.g., driven by Unity physics or animation) back to the ViewModel.