### PR TITLE
Add AudioSource Binders

### DIFF
--- a/Aspid.MVVM/Assets/Plugins/Aspid/MVVM/StarterKit/Unity/Runtime/Binders/AudioSources.meta
+++ b/Aspid.MVVM/Assets/Plugins/Aspid/MVVM/StarterKit/Unity/Runtime/Binders/AudioSources.meta
@@ -1,0 +1,3 @@
+fileFormatVersion: 2
+guid: 07b66b13c3eb461d99cf013f885d8d4c
+timeCreated: 1770129996

--- a/Aspid.MVVM/Assets/Plugins/Aspid/MVVM/StarterKit/Unity/Runtime/Binders/AudioSources/AudioClip.meta
+++ b/Aspid.MVVM/Assets/Plugins/Aspid/MVVM/StarterKit/Unity/Runtime/Binders/AudioSources/AudioClip.meta
@@ -1,0 +1,3 @@
+fileFormatVersion: 2
+guid: e60e3c0658b144b2abc06d41cc0d60f8
+timeCreated: 1770891913

--- a/Aspid.MVVM/Assets/Plugins/Aspid/MVVM/StarterKit/Unity/Runtime/Binders/AudioSources/AudioClip/AudioSourceClipBinder.cs
+++ b/Aspid.MVVM/Assets/Plugins/Aspid/MVVM/StarterKit/Unity/Runtime/Binders/AudioSources/AudioClip/AudioSourceClipBinder.cs
@@ -1,0 +1,29 @@
+#nullable enable
+using System;
+using UnityEngine;
+
+// ReSharper disable once CheckNamespace
+namespace Aspid.MVVM.StarterKit
+{
+    [Serializable]
+    [BindModeOverride(BindMode.OneWay, BindMode.OneTime, BindMode.OneWayToSource)]
+    public class AudioSourceClipBinder : TargetBinder<AudioSource>, IBinder<AudioClip?>, IReverseBinder<AudioClip>
+    {
+        public event Action<AudioClip?>? ValueChanged;
+        
+        public AudioSourceClipBinder(AudioSource target, BindMode mode = BindMode.OneWay)
+            : base(target, mode)
+        {
+            mode.ThrowExceptionIfTwo();
+        }
+
+        public void SetValue(AudioClip? value) =>
+            Target.clip = value;
+        
+        protected override void OnBound()
+        {
+            if (Mode is BindMode.OneWayToSource)
+                ValueChanged?.Invoke(Target.clip);
+        }
+    }
+}

--- a/Aspid.MVVM/Assets/Plugins/Aspid/MVVM/StarterKit/Unity/Runtime/Binders/AudioSources/AudioClip/AudioSourceClipBinder.cs.meta
+++ b/Aspid.MVVM/Assets/Plugins/Aspid/MVVM/StarterKit/Unity/Runtime/Binders/AudioSources/AudioClip/AudioSourceClipBinder.cs.meta
@@ -1,0 +1,3 @@
+fileFormatVersion: 2
+guid: 66c0040799564ee5851deaabe346933d
+timeCreated: 1770880400

--- a/Aspid.MVVM/Assets/Plugins/Aspid/MVVM/StarterKit/Unity/Runtime/Binders/AudioSources/AudioClip/AudioSourceClipSwitcherBinder.cs
+++ b/Aspid.MVVM/Assets/Plugins/Aspid/MVVM/StarterKit/Unity/Runtime/Binders/AudioSources/AudioClip/AudioSourceClipSwitcherBinder.cs
@@ -1,0 +1,21 @@
+#nullable enable
+using System;
+using UnityEngine;
+
+// ReSharper disable once CheckNamespace
+namespace Aspid.MVVM.StarterKit
+{
+    [Serializable]
+    public sealed class AudioSourceClipSwitcherBinder : SwitcherBinder<AudioSource, AudioClip?>
+    {
+        public AudioSourceClipSwitcherBinder(
+            AudioSource target,
+            AudioClip? trueValue, 
+            AudioClip? falseValue,
+            BindMode mode = BindMode.OneWay)
+            : base(target, trueValue, falseValue, mode) { }
+
+        protected override void SetValue(AudioClip? value) =>
+            Target.clip = value;
+    }
+}

--- a/Aspid.MVVM/Assets/Plugins/Aspid/MVVM/StarterKit/Unity/Runtime/Binders/AudioSources/AudioClip/AudioSourceClipSwitcherBinder.cs.meta
+++ b/Aspid.MVVM/Assets/Plugins/Aspid/MVVM/StarterKit/Unity/Runtime/Binders/AudioSources/AudioClip/AudioSourceClipSwitcherBinder.cs.meta
@@ -1,0 +1,3 @@
+fileFormatVersion: 2
+guid: 54a3ca18b27e4d5f8de692b0875fecf7
+timeCreated: 1770880400

--- a/Aspid.MVVM/Assets/Plugins/Aspid/MVVM/StarterKit/Unity/Runtime/Binders/AudioSources/AudioClip/Mono.meta
+++ b/Aspid.MVVM/Assets/Plugins/Aspid/MVVM/StarterKit/Unity/Runtime/Binders/AudioSources/AudioClip/Mono.meta
@@ -1,0 +1,3 @@
+fileFormatVersion: 2
+guid: 370bd6b6eda9427ca8e4477255e53f72
+timeCreated: 1770892855

--- a/Aspid.MVVM/Assets/Plugins/Aspid/MVVM/StarterKit/Unity/Runtime/Binders/AudioSources/AudioClip/Mono/AudioSourceClipEnumGroupMonoBinder.cs
+++ b/Aspid.MVVM/Assets/Plugins/Aspid/MVVM/StarterKit/Unity/Runtime/Binders/AudioSources/AudioClip/Mono/AudioSourceClipEnumGroupMonoBinder.cs
@@ -1,0 +1,13 @@
+using UnityEngine;
+
+// ReSharper disable once CheckNamespace
+namespace Aspid.MVVM.StarterKit
+{
+    [AddBinderContextMenu(typeof(AudioSource), SubPath = "EnumGroup")]
+    [AddComponentMenu("Aspid/MVVM/Binders/Audio/AudioSource/AudioSource Binder – Clip EnumGroup")]
+    public sealed class AudioSourceClipEnumGroupMonoBinder : EnumGroupMonoBinder<AudioSource, AudioClip>
+    {
+        protected override void SetValue(AudioSource element, AudioClip value) =>
+            element.clip = value;
+    }
+}

--- a/Aspid.MVVM/Assets/Plugins/Aspid/MVVM/StarterKit/Unity/Runtime/Binders/AudioSources/AudioClip/Mono/AudioSourceClipEnumGroupMonoBinder.cs.meta
+++ b/Aspid.MVVM/Assets/Plugins/Aspid/MVVM/StarterKit/Unity/Runtime/Binders/AudioSources/AudioClip/Mono/AudioSourceClipEnumGroupMonoBinder.cs.meta
@@ -1,0 +1,3 @@
+fileFormatVersion: 2
+guid: 263f88028e13430abd3f00a091137e4d
+timeCreated: 1770460238

--- a/Aspid.MVVM/Assets/Plugins/Aspid/MVVM/StarterKit/Unity/Runtime/Binders/AudioSources/AudioClip/Mono/AudioSourceClipEnumMonoBinder.cs
+++ b/Aspid.MVVM/Assets/Plugins/Aspid/MVVM/StarterKit/Unity/Runtime/Binders/AudioSources/AudioClip/Mono/AudioSourceClipEnumMonoBinder.cs
@@ -1,0 +1,13 @@
+using UnityEngine;
+
+// ReSharper disable once CheckNamespace
+namespace Aspid.MVVM.StarterKit
+{
+    [AddBinderContextMenu(typeof(AudioSource), SubPath = "Enum")]
+    [AddComponentMenu("Aspid/MVVM/Binders/Audio/AudioSource/AudioSource Binder – Clip Enum")]
+    public sealed class AudioSourceClipEnumMonoBinder : EnumMonoBinder<AudioSource, AudioClip>
+    {
+        protected override void SetValue(AudioClip value) =>
+            CachedComponent.clip = value;
+    }
+}

--- a/Aspid.MVVM/Assets/Plugins/Aspid/MVVM/StarterKit/Unity/Runtime/Binders/AudioSources/AudioClip/Mono/AudioSourceClipEnumMonoBinder.cs.meta
+++ b/Aspid.MVVM/Assets/Plugins/Aspid/MVVM/StarterKit/Unity/Runtime/Binders/AudioSources/AudioClip/Mono/AudioSourceClipEnumMonoBinder.cs.meta
@@ -1,0 +1,3 @@
+fileFormatVersion: 2
+guid: a9c1753429d34430bf9e01717c9185b7
+timeCreated: 1770460257

--- a/Aspid.MVVM/Assets/Plugins/Aspid/MVVM/StarterKit/Unity/Runtime/Binders/AudioSources/AudioClip/Mono/AudioSourceClipMonoBinder.cs
+++ b/Aspid.MVVM/Assets/Plugins/Aspid/MVVM/StarterKit/Unity/Runtime/Binders/AudioSources/AudioClip/Mono/AudioSourceClipMonoBinder.cs
@@ -1,0 +1,24 @@
+using System;
+using UnityEngine;
+
+// ReSharper disable once CheckNamespace
+namespace Aspid.MVVM.StarterKit
+{
+    [AddBinderContextMenu(typeof(AudioSource))]
+    [AddComponentMenu("Aspid/MVVM/Binders/Audio/AudioSource/AudioSource Binder – Clip")]
+    [BindModeOverride(BindMode.OneWay, BindMode.OneTime, BindMode.OneWayToSource)]
+    public partial class AudioSourceClipMonoBinder : ComponentMonoBinder<AudioSource>, IBinder<AudioClip>, IReverseBinder<AudioClip>
+    {
+        public event Action<AudioClip> ValueChanged;
+        
+        [BinderLog]
+        public void SetValue(AudioClip value) =>
+            CachedComponent.clip = value;
+
+        protected override void OnBound()
+        {
+            if (Mode is BindMode.OneWayToSource)
+                ValueChanged?.Invoke(CachedComponent.clip);
+        }
+    }
+}

--- a/Aspid.MVVM/Assets/Plugins/Aspid/MVVM/StarterKit/Unity/Runtime/Binders/AudioSources/AudioClip/Mono/AudioSourceClipMonoBinder.cs.meta
+++ b/Aspid.MVVM/Assets/Plugins/Aspid/MVVM/StarterKit/Unity/Runtime/Binders/AudioSources/AudioClip/Mono/AudioSourceClipMonoBinder.cs.meta
@@ -1,0 +1,3 @@
+fileFormatVersion: 2
+guid: 6d9ead53a98d44b4969c74751b3b2015
+timeCreated: 1770130057

--- a/Aspid.MVVM/Assets/Plugins/Aspid/MVVM/StarterKit/Unity/Runtime/Binders/AudioSources/AudioClip/Mono/AudioSourceClipSwitcherMonoBinder.cs
+++ b/Aspid.MVVM/Assets/Plugins/Aspid/MVVM/StarterKit/Unity/Runtime/Binders/AudioSources/AudioClip/Mono/AudioSourceClipSwitcherMonoBinder.cs
@@ -1,0 +1,13 @@
+using UnityEngine;
+
+// ReSharper disable once CheckNamespace
+namespace Aspid.MVVM.StarterKit
+{
+    [AddBinderContextMenu(typeof(AudioSource), SubPath = "Switcher")]
+    [AddComponentMenu("Aspid/MVVM/Binders/Audio/AudioSource/AudioSource Binder – Clip Switcher")]
+    public sealed class AudioSourceClipSwitcherMonoBinder : SwitcherMonoBinder<AudioSource, AudioClip>
+    {
+        protected override void SetValue(AudioClip value) =>
+            CachedComponent.clip = value;
+    }
+}

--- a/Aspid.MVVM/Assets/Plugins/Aspid/MVVM/StarterKit/Unity/Runtime/Binders/AudioSources/AudioClip/Mono/AudioSourceClipSwitcherMonoBinder.cs.meta
+++ b/Aspid.MVVM/Assets/Plugins/Aspid/MVVM/StarterKit/Unity/Runtime/Binders/AudioSources/AudioClip/Mono/AudioSourceClipSwitcherMonoBinder.cs.meta
@@ -1,0 +1,3 @@
+fileFormatVersion: 2
+guid: 90a75eef84d14dd5baf752b1cc05e186
+timeCreated: 1770460272

--- a/Aspid.MVVM/Assets/Plugins/Aspid/MVVM/StarterKit/Unity/Runtime/Binders/AudioSources/AudioSourceDistanceMode.cs
+++ b/Aspid.MVVM/Assets/Plugins/Aspid/MVVM/StarterKit/Unity/Runtime/Binders/AudioSources/AudioSourceDistanceMode.cs
@@ -1,0 +1,10 @@
+// ReSharper disable once CheckNamespace
+namespace Aspid.MVVM.StarterKit
+{
+    public enum AudioSourceDistanceMode
+    {
+        Min,
+        Max,
+        Range
+    }
+}

--- a/Aspid.MVVM/Assets/Plugins/Aspid/MVVM/StarterKit/Unity/Runtime/Binders/AudioSources/AudioSourceDistanceMode.cs.meta
+++ b/Aspid.MVVM/Assets/Plugins/Aspid/MVVM/StarterKit/Unity/Runtime/Binders/AudioSources/AudioSourceDistanceMode.cs.meta
@@ -1,0 +1,3 @@
+fileFormatVersion: 2
+guid: bc5e8aa38f0044df8aa00552d82976f8
+timeCreated: 1770882911

--- a/Aspid.MVVM/Assets/Plugins/Aspid/MVVM/StarterKit/Unity/Runtime/Binders/AudioSources/BypassEffects.meta
+++ b/Aspid.MVVM/Assets/Plugins/Aspid/MVVM/StarterKit/Unity/Runtime/Binders/AudioSources/BypassEffects.meta
@@ -1,0 +1,3 @@
+fileFormatVersion: 2
+guid: d213ad4f1c9f4c48990c610bdf9a1a3c
+timeCreated: 1770891857

--- a/Aspid.MVVM/Assets/Plugins/Aspid/MVVM/StarterKit/Unity/Runtime/Binders/AudioSources/BypassEffects/AudioSourceBypassEffectsBinder.cs
+++ b/Aspid.MVVM/Assets/Plugins/Aspid/MVVM/StarterKit/Unity/Runtime/Binders/AudioSources/BypassEffects/AudioSourceBypassEffectsBinder.cs
@@ -1,0 +1,38 @@
+#nullable enable
+using System;
+using UnityEngine;
+
+// ReSharper disable once CheckNamespace
+namespace Aspid.MVVM.StarterKit
+{
+    [Serializable]
+    [BindModeOverride(BindMode.OneWay, BindMode.OneTime, BindMode.OneWayToSource)]
+    public class AudioSourceBypassEffectsBinder : TargetBinder<AudioSource>, IBinder<bool>, IReverseBinder<bool>
+    {
+        public event Action<bool>? ValueChanged;
+        
+        [SerializeField] private bool _isInvert;
+        
+        public AudioSourceBypassEffectsBinder(AudioSource target, BindMode mode)
+            : this(target, isInvert: false, mode) { }
+        
+        public AudioSourceBypassEffectsBinder(AudioSource target, bool isInvert = false, BindMode mode = BindMode.OneWay)
+            : base(target, mode)
+        {
+            mode.ThrowExceptionIfTwo();
+            _isInvert = isInvert;
+        }
+
+        public void SetValue(bool value) =>
+            Target.bypassEffects = GetConvertedValue(value);
+        
+        protected override void OnBound()
+        {
+            if (Mode is BindMode.OneWayToSource)
+                ValueChanged?.Invoke(GetConvertedValue(Target.bypassEffects));
+        }
+        
+        private bool GetConvertedValue(bool value) =>
+            _isInvert ? !value : value;
+    }
+}

--- a/Aspid.MVVM/Assets/Plugins/Aspid/MVVM/StarterKit/Unity/Runtime/Binders/AudioSources/BypassEffects/AudioSourceBypassEffectsBinder.cs.meta
+++ b/Aspid.MVVM/Assets/Plugins/Aspid/MVVM/StarterKit/Unity/Runtime/Binders/AudioSources/BypassEffects/AudioSourceBypassEffectsBinder.cs.meta
@@ -1,0 +1,3 @@
+fileFormatVersion: 2
+guid: 0ec974da3a66400ea5cb60c35dbaa77f
+timeCreated: 1770880452

--- a/Aspid.MVVM/Assets/Plugins/Aspid/MVVM/StarterKit/Unity/Runtime/Binders/AudioSources/BypassEffects/Mono.meta
+++ b/Aspid.MVVM/Assets/Plugins/Aspid/MVVM/StarterKit/Unity/Runtime/Binders/AudioSources/BypassEffects/Mono.meta
@@ -1,0 +1,3 @@
+fileFormatVersion: 2
+guid: f2269918626842b8b92a5d733aeebd87
+timeCreated: 1770892864

--- a/Aspid.MVVM/Assets/Plugins/Aspid/MVVM/StarterKit/Unity/Runtime/Binders/AudioSources/BypassEffects/Mono/AudioSourceBypassEffectsEnumGroupMonoBinder.cs
+++ b/Aspid.MVVM/Assets/Plugins/Aspid/MVVM/StarterKit/Unity/Runtime/Binders/AudioSources/BypassEffects/Mono/AudioSourceBypassEffectsEnumGroupMonoBinder.cs
@@ -1,0 +1,13 @@
+using UnityEngine;
+
+// ReSharper disable once CheckNamespace
+namespace Aspid.MVVM.StarterKit
+{
+    [AddBinderContextMenu(typeof(AudioSource), SubPath = "EnumGroup")]
+    [AddComponentMenu("Aspid/MVVM/Binders/Audio/AudioSource/AudioSource Binder – BypassEffects EnumGroup")]
+    public sealed class AudioSourceBypassEffectsEnumGroupMonoBinder : EnumGroupMonoBinder<AudioSource, bool>
+    {
+        protected override void SetValue(AudioSource element, bool value) =>
+            element.bypassEffects = value;
+    }
+}

--- a/Aspid.MVVM/Assets/Plugins/Aspid/MVVM/StarterKit/Unity/Runtime/Binders/AudioSources/BypassEffects/Mono/AudioSourceBypassEffectsEnumGroupMonoBinder.cs.meta
+++ b/Aspid.MVVM/Assets/Plugins/Aspid/MVVM/StarterKit/Unity/Runtime/Binders/AudioSources/BypassEffects/Mono/AudioSourceBypassEffectsEnumGroupMonoBinder.cs.meta
@@ -1,0 +1,3 @@
+fileFormatVersion: 2
+guid: 151eb81a15144d76b212b77c319b1c79
+timeCreated: 1770880726

--- a/Aspid.MVVM/Assets/Plugins/Aspid/MVVM/StarterKit/Unity/Runtime/Binders/AudioSources/BypassEffects/Mono/AudioSourceBypassEffectsEnumMonoBinder.cs
+++ b/Aspid.MVVM/Assets/Plugins/Aspid/MVVM/StarterKit/Unity/Runtime/Binders/AudioSources/BypassEffects/Mono/AudioSourceBypassEffectsEnumMonoBinder.cs
@@ -1,0 +1,13 @@
+using UnityEngine;
+
+// ReSharper disable once CheckNamespace
+namespace Aspid.MVVM.StarterKit
+{
+    [AddBinderContextMenu(typeof(AudioSource), SubPath = "Enum")]
+    [AddComponentMenu("Aspid/MVVM/Binders/Audio/AudioSource/AudioSource Binder – BypassEffects Enum")]
+    public sealed class AudioSourceBypassEffectsEnumMonoBinder : EnumMonoBinder<AudioSource, bool>
+    {
+        protected override void SetValue(bool value) =>
+            CachedComponent.bypassEffects = value;
+    }
+}

--- a/Aspid.MVVM/Assets/Plugins/Aspid/MVVM/StarterKit/Unity/Runtime/Binders/AudioSources/BypassEffects/Mono/AudioSourceBypassEffectsEnumMonoBinder.cs.meta
+++ b/Aspid.MVVM/Assets/Plugins/Aspid/MVVM/StarterKit/Unity/Runtime/Binders/AudioSources/BypassEffects/Mono/AudioSourceBypassEffectsEnumMonoBinder.cs.meta
@@ -1,0 +1,3 @@
+fileFormatVersion: 2
+guid: 608665baaa26404f9f427d7599fb86d5
+timeCreated: 1770880726

--- a/Aspid.MVVM/Assets/Plugins/Aspid/MVVM/StarterKit/Unity/Runtime/Binders/AudioSources/BypassEffects/Mono/AudioSourceBypassEffectsMonoBinder.cs
+++ b/Aspid.MVVM/Assets/Plugins/Aspid/MVVM/StarterKit/Unity/Runtime/Binders/AudioSources/BypassEffects/Mono/AudioSourceBypassEffectsMonoBinder.cs
@@ -1,0 +1,29 @@
+using System;
+using UnityEngine;
+
+// ReSharper disable once CheckNamespace
+namespace Aspid.MVVM.StarterKit
+{
+    [AddBinderContextMenu(typeof(AudioSource))]
+    [AddComponentMenu("Aspid/MVVM/Binders/Audio/AudioSource/AudioSource Binder – BypassEffects")]
+    [BindModeOverride(BindMode.OneWay, BindMode.OneTime, BindMode.OneWayToSource)]
+    public partial class AudioSourceBypassEffectsMonoBinder : ComponentMonoBinder<AudioSource>, IBinder<bool>, IReverseBinder<bool>
+    {
+        public event Action<bool> ValueChanged;
+        
+        [SerializeField] private bool _isInvert;
+        
+        [BinderLog]
+        public void SetValue(bool value) =>
+            CachedComponent.bypassEffects = GetConvertedValue(value);
+        
+        protected override void OnBound()
+        {
+            if (Mode is BindMode.OneWayToSource)
+                ValueChanged?.Invoke(GetConvertedValue(CachedComponent.bypassEffects));
+        }
+        
+        private bool GetConvertedValue(bool value) =>
+            _isInvert ? !value : value;
+    }
+}

--- a/Aspid.MVVM/Assets/Plugins/Aspid/MVVM/StarterKit/Unity/Runtime/Binders/AudioSources/BypassEffects/Mono/AudioSourceBypassEffectsMonoBinder.cs.meta
+++ b/Aspid.MVVM/Assets/Plugins/Aspid/MVVM/StarterKit/Unity/Runtime/Binders/AudioSources/BypassEffects/Mono/AudioSourceBypassEffectsMonoBinder.cs.meta
@@ -1,0 +1,3 @@
+fileFormatVersion: 2
+guid: 49cc99f66dcf4652a4924d675ad144bd
+timeCreated: 1770880351

--- a/Aspid.MVVM/Assets/Plugins/Aspid/MVVM/StarterKit/Unity/Runtime/Binders/AudioSources/BypassListenerEffects.meta
+++ b/Aspid.MVVM/Assets/Plugins/Aspid/MVVM/StarterKit/Unity/Runtime/Binders/AudioSources/BypassListenerEffects.meta
@@ -1,0 +1,3 @@
+fileFormatVersion: 2
+guid: 0fb4a403098746bd87b97b1ba7c3cd1a
+timeCreated: 1770891886

--- a/Aspid.MVVM/Assets/Plugins/Aspid/MVVM/StarterKit/Unity/Runtime/Binders/AudioSources/BypassListenerEffects/AudioSourceBypassListenerEffectsBinder.cs
+++ b/Aspid.MVVM/Assets/Plugins/Aspid/MVVM/StarterKit/Unity/Runtime/Binders/AudioSources/BypassListenerEffects/AudioSourceBypassListenerEffectsBinder.cs
@@ -1,0 +1,38 @@
+#nullable enable
+using System;
+using UnityEngine;
+
+// ReSharper disable once CheckNamespace
+namespace Aspid.MVVM.StarterKit
+{
+    [Serializable]
+    [BindModeOverride(BindMode.OneWay, BindMode.OneTime, BindMode.OneWayToSource)]
+    public class AudioSourceBypassListenerEffectsBinder : TargetBinder<AudioSource>, IBinder<bool>, IReverseBinder<bool>
+    {
+        public event Action<bool>? ValueChanged;
+        
+        [SerializeField] private bool _isInvert;
+        
+        public AudioSourceBypassListenerEffectsBinder(AudioSource target, BindMode mode)
+            : this(target, isInvert: false, mode) { }
+        
+        public AudioSourceBypassListenerEffectsBinder(AudioSource target, bool isInvert = false, BindMode mode = BindMode.OneWay)
+            : base(target, mode)
+        {
+            mode.ThrowExceptionIfTwo();
+            _isInvert = isInvert;
+        }
+
+        public void SetValue(bool value) =>
+            Target.bypassListenerEffects = _isInvert ? !value : value;
+        
+        protected override void OnBound()
+        {
+            if (Mode is BindMode.OneWayToSource)
+                ValueChanged?.Invoke(GetConvertedValue(Target.bypassListenerEffects));
+        }
+        
+        private bool GetConvertedValue(bool value) =>
+            _isInvert ? !value : value;
+    }
+}

--- a/Aspid.MVVM/Assets/Plugins/Aspid/MVVM/StarterKit/Unity/Runtime/Binders/AudioSources/BypassListenerEffects/AudioSourceBypassListenerEffectsBinder.cs.meta
+++ b/Aspid.MVVM/Assets/Plugins/Aspid/MVVM/StarterKit/Unity/Runtime/Binders/AudioSources/BypassListenerEffects/AudioSourceBypassListenerEffectsBinder.cs.meta
@@ -1,0 +1,3 @@
+fileFormatVersion: 2
+guid: c5b68eda68c94389a4bc292645b498e6
+timeCreated: 1770880452

--- a/Aspid.MVVM/Assets/Plugins/Aspid/MVVM/StarterKit/Unity/Runtime/Binders/AudioSources/BypassListenerEffects/Mono.meta
+++ b/Aspid.MVVM/Assets/Plugins/Aspid/MVVM/StarterKit/Unity/Runtime/Binders/AudioSources/BypassListenerEffects/Mono.meta
@@ -1,0 +1,3 @@
+fileFormatVersion: 2
+guid: c1ca78538d6c4a8bac90c082884f1606
+timeCreated: 1770892868

--- a/Aspid.MVVM/Assets/Plugins/Aspid/MVVM/StarterKit/Unity/Runtime/Binders/AudioSources/BypassListenerEffects/Mono/AudioSourceBypassListenerEffectsEnumGroupMonoBinder.cs
+++ b/Aspid.MVVM/Assets/Plugins/Aspid/MVVM/StarterKit/Unity/Runtime/Binders/AudioSources/BypassListenerEffects/Mono/AudioSourceBypassListenerEffectsEnumGroupMonoBinder.cs
@@ -1,0 +1,13 @@
+using UnityEngine;
+
+// ReSharper disable once CheckNamespace
+namespace Aspid.MVVM.StarterKit
+{
+    [AddBinderContextMenu(typeof(AudioSource), SubPath = "EnumGroup")]
+    [AddComponentMenu("Aspid/MVVM/Binders/Audio/AudioSource/AudioSource Binder – BypassListenerEffects EnumGroup")]
+    public sealed class AudioSourceBypassListenerEffectsEnumGroupMonoBinder : EnumGroupMonoBinder<AudioSource, bool>
+    {
+        protected override void SetValue(AudioSource element, bool value) =>
+            element.bypassListenerEffects = value;
+    }
+}

--- a/Aspid.MVVM/Assets/Plugins/Aspid/MVVM/StarterKit/Unity/Runtime/Binders/AudioSources/BypassListenerEffects/Mono/AudioSourceBypassListenerEffectsEnumGroupMonoBinder.cs.meta
+++ b/Aspid.MVVM/Assets/Plugins/Aspid/MVVM/StarterKit/Unity/Runtime/Binders/AudioSources/BypassListenerEffects/Mono/AudioSourceBypassListenerEffectsEnumGroupMonoBinder.cs.meta
@@ -1,0 +1,3 @@
+fileFormatVersion: 2
+guid: a839b5eac83447148302bc77019371a8
+timeCreated: 1770880726

--- a/Aspid.MVVM/Assets/Plugins/Aspid/MVVM/StarterKit/Unity/Runtime/Binders/AudioSources/BypassListenerEffects/Mono/AudioSourceBypassListenerEffectsEnumMonoBinder.cs
+++ b/Aspid.MVVM/Assets/Plugins/Aspid/MVVM/StarterKit/Unity/Runtime/Binders/AudioSources/BypassListenerEffects/Mono/AudioSourceBypassListenerEffectsEnumMonoBinder.cs
@@ -1,0 +1,13 @@
+using UnityEngine;
+
+// ReSharper disable once CheckNamespace
+namespace Aspid.MVVM.StarterKit
+{
+    [AddBinderContextMenu(typeof(AudioSource), SubPath = "Enum")]
+    [AddComponentMenu("Aspid/MVVM/Binders/Audio/AudioSource/AudioSource Binder – BypassListenerEffects Enum")]
+    public sealed class AudioSourceBypassListenerEffectsEnumMonoBinder : EnumMonoBinder<AudioSource, bool>
+    {
+        protected override void SetValue(bool value) =>
+            CachedComponent.bypassListenerEffects = value;
+    }
+}

--- a/Aspid.MVVM/Assets/Plugins/Aspid/MVVM/StarterKit/Unity/Runtime/Binders/AudioSources/BypassListenerEffects/Mono/AudioSourceBypassListenerEffectsEnumMonoBinder.cs.meta
+++ b/Aspid.MVVM/Assets/Plugins/Aspid/MVVM/StarterKit/Unity/Runtime/Binders/AudioSources/BypassListenerEffects/Mono/AudioSourceBypassListenerEffectsEnumMonoBinder.cs.meta
@@ -1,0 +1,3 @@
+fileFormatVersion: 2
+guid: 8e35fde1209f4f90a1002e6bbf2c0714
+timeCreated: 1770880726

--- a/Aspid.MVVM/Assets/Plugins/Aspid/MVVM/StarterKit/Unity/Runtime/Binders/AudioSources/BypassListenerEffects/Mono/AudioSourceBypassListenerEffectsMonoBinder.cs
+++ b/Aspid.MVVM/Assets/Plugins/Aspid/MVVM/StarterKit/Unity/Runtime/Binders/AudioSources/BypassListenerEffects/Mono/AudioSourceBypassListenerEffectsMonoBinder.cs
@@ -1,0 +1,29 @@
+using System;
+using UnityEngine;
+
+// ReSharper disable once CheckNamespace
+namespace Aspid.MVVM.StarterKit
+{
+    [AddBinderContextMenu(typeof(AudioSource))]
+    [AddComponentMenu("Aspid/MVVM/Binders/Audio/AudioSource/AudioSource Binder – BypassListenerEffects")]
+    [BindModeOverride(BindMode.OneWay, BindMode.OneTime, BindMode.OneWayToSource)]
+    public partial class AudioSourceBypassListenerEffectsMonoBinder : ComponentMonoBinder<AudioSource>, IBinder<bool>, IReverseBinder<bool>
+    {
+        public event Action<bool> ValueChanged;
+        
+        [SerializeField] private bool _isInvert;
+        
+        [BinderLog]
+        public void SetValue(bool value) =>
+            CachedComponent.bypassListenerEffects = GetConvertedValue(value);
+        
+        protected override void OnBound()
+        {
+            if (Mode is BindMode.OneWayToSource)
+                ValueChanged?.Invoke(GetConvertedValue(CachedComponent.bypassListenerEffects));
+        }
+        
+        private bool GetConvertedValue(bool value) =>
+            _isInvert ? !value : value;
+    }
+}

--- a/Aspid.MVVM/Assets/Plugins/Aspid/MVVM/StarterKit/Unity/Runtime/Binders/AudioSources/BypassListenerEffects/Mono/AudioSourceBypassListenerEffectsMonoBinder.cs.meta
+++ b/Aspid.MVVM/Assets/Plugins/Aspid/MVVM/StarterKit/Unity/Runtime/Binders/AudioSources/BypassListenerEffects/Mono/AudioSourceBypassListenerEffectsMonoBinder.cs.meta
@@ -1,0 +1,3 @@
+fileFormatVersion: 2
+guid: d0ed6eabadd4462c9715f07137d2be5b
+timeCreated: 1770880352

--- a/Aspid.MVVM/Assets/Plugins/Aspid/MVVM/StarterKit/Unity/Runtime/Binders/AudioSources/BypassReverbZones.meta
+++ b/Aspid.MVVM/Assets/Plugins/Aspid/MVVM/StarterKit/Unity/Runtime/Binders/AudioSources/BypassReverbZones.meta
@@ -1,0 +1,3 @@
+fileFormatVersion: 2
+guid: b0965367372644d6813d45a67a96d377
+timeCreated: 1770891900

--- a/Aspid.MVVM/Assets/Plugins/Aspid/MVVM/StarterKit/Unity/Runtime/Binders/AudioSources/BypassReverbZones/AudioSourceBypassReverbZonesBinder.cs
+++ b/Aspid.MVVM/Assets/Plugins/Aspid/MVVM/StarterKit/Unity/Runtime/Binders/AudioSources/BypassReverbZones/AudioSourceBypassReverbZonesBinder.cs
@@ -1,0 +1,35 @@
+#nullable enable
+using System;
+using UnityEngine;
+
+// ReSharper disable once CheckNamespace
+namespace Aspid.MVVM.StarterKit
+{
+    [Serializable]
+    [BindModeOverride(BindMode.OneWay, BindMode.OneTime, BindMode.OneWayToSource)]
+    public class AudioSourceBypassReverbZonesBinder : TargetBinder<AudioSource>, IBinder<bool>, IReverseBinder<bool>
+    {
+        public event Action<bool>? ValueChanged;
+        
+        [SerializeField] private bool _isInvert;
+        
+        public AudioSourceBypassReverbZonesBinder(AudioSource target, BindMode mode)
+            : this(target, isInvert: false, mode) { }
+        
+        public AudioSourceBypassReverbZonesBinder(AudioSource target, bool isInvert = false, BindMode mode = BindMode.OneWay)
+            : base(target, mode)
+        {
+            mode.ThrowExceptionIfTwo();
+            _isInvert = isInvert;
+        }
+
+        public void SetValue(bool value) =>
+            Target.bypassReverbZones = _isInvert ? !value : value;
+        
+        protected override void OnBound()
+        {
+            if (Mode is BindMode.OneWayToSource)
+                ValueChanged?.Invoke(Target.bypassReverbZones);
+        }
+    }
+}

--- a/Aspid.MVVM/Assets/Plugins/Aspid/MVVM/StarterKit/Unity/Runtime/Binders/AudioSources/BypassReverbZones/AudioSourceBypassReverbZonesBinder.cs.meta
+++ b/Aspid.MVVM/Assets/Plugins/Aspid/MVVM/StarterKit/Unity/Runtime/Binders/AudioSources/BypassReverbZones/AudioSourceBypassReverbZonesBinder.cs.meta
@@ -1,0 +1,3 @@
+fileFormatVersion: 2
+guid: 516389a0b5b64756b8eb489ef1e4afa1
+timeCreated: 1770880452

--- a/Aspid.MVVM/Assets/Plugins/Aspid/MVVM/StarterKit/Unity/Runtime/Binders/AudioSources/BypassReverbZones/Mono.meta
+++ b/Aspid.MVVM/Assets/Plugins/Aspid/MVVM/StarterKit/Unity/Runtime/Binders/AudioSources/BypassReverbZones/Mono.meta
@@ -1,0 +1,3 @@
+fileFormatVersion: 2
+guid: 6c8855896aa44f10a47c36f48f8bdfa4
+timeCreated: 1770892873

--- a/Aspid.MVVM/Assets/Plugins/Aspid/MVVM/StarterKit/Unity/Runtime/Binders/AudioSources/BypassReverbZones/Mono/AudioSourceBypassReverbZonesEnumGroupMonoBinder.cs
+++ b/Aspid.MVVM/Assets/Plugins/Aspid/MVVM/StarterKit/Unity/Runtime/Binders/AudioSources/BypassReverbZones/Mono/AudioSourceBypassReverbZonesEnumGroupMonoBinder.cs
@@ -1,0 +1,13 @@
+using UnityEngine;
+
+// ReSharper disable once CheckNamespace
+namespace Aspid.MVVM.StarterKit
+{
+    [AddBinderContextMenu(typeof(AudioSource), SubPath = "EnumGroup")]
+    [AddComponentMenu("Aspid/MVVM/Binders/Audio/AudioSource/AudioSource Binder – BypassReverbZones EnumGroup")]
+    public sealed class AudioSourceBypassReverbZonesEnumGroupMonoBinder : EnumGroupMonoBinder<AudioSource, bool>
+    {
+        protected override void SetValue(AudioSource element, bool value) =>
+            element.bypassReverbZones = value;
+    }
+}

--- a/Aspid.MVVM/Assets/Plugins/Aspid/MVVM/StarterKit/Unity/Runtime/Binders/AudioSources/BypassReverbZones/Mono/AudioSourceBypassReverbZonesEnumGroupMonoBinder.cs.meta
+++ b/Aspid.MVVM/Assets/Plugins/Aspid/MVVM/StarterKit/Unity/Runtime/Binders/AudioSources/BypassReverbZones/Mono/AudioSourceBypassReverbZonesEnumGroupMonoBinder.cs.meta
@@ -1,0 +1,3 @@
+fileFormatVersion: 2
+guid: 626c196954cb45beafdda40e283d32ba
+timeCreated: 1770880727

--- a/Aspid.MVVM/Assets/Plugins/Aspid/MVVM/StarterKit/Unity/Runtime/Binders/AudioSources/BypassReverbZones/Mono/AudioSourceBypassReverbZonesEnumMonoBinder.cs
+++ b/Aspid.MVVM/Assets/Plugins/Aspid/MVVM/StarterKit/Unity/Runtime/Binders/AudioSources/BypassReverbZones/Mono/AudioSourceBypassReverbZonesEnumMonoBinder.cs
@@ -1,0 +1,13 @@
+using UnityEngine;
+
+// ReSharper disable once CheckNamespace
+namespace Aspid.MVVM.StarterKit
+{
+    [AddBinderContextMenu(typeof(AudioSource), SubPath = "Enum")]
+    [AddComponentMenu("Aspid/MVVM/Binders/Audio/AudioSource/AudioSource Binder – BypassReverbZones Enum")]
+    public sealed class AudioSourceBypassReverbZonesEnumMonoBinder : EnumMonoBinder<AudioSource, bool>
+    {
+        protected override void SetValue(bool value) =>
+            CachedComponent.bypassReverbZones = value;
+    }
+}

--- a/Aspid.MVVM/Assets/Plugins/Aspid/MVVM/StarterKit/Unity/Runtime/Binders/AudioSources/BypassReverbZones/Mono/AudioSourceBypassReverbZonesEnumMonoBinder.cs.meta
+++ b/Aspid.MVVM/Assets/Plugins/Aspid/MVVM/StarterKit/Unity/Runtime/Binders/AudioSources/BypassReverbZones/Mono/AudioSourceBypassReverbZonesEnumMonoBinder.cs.meta
@@ -1,0 +1,3 @@
+fileFormatVersion: 2
+guid: 019a7f920f664b8581e4709551caf5d9
+timeCreated: 1770880726

--- a/Aspid.MVVM/Assets/Plugins/Aspid/MVVM/StarterKit/Unity/Runtime/Binders/AudioSources/BypassReverbZones/Mono/AudioSourceBypassReverbZonesMonoBinder.cs
+++ b/Aspid.MVVM/Assets/Plugins/Aspid/MVVM/StarterKit/Unity/Runtime/Binders/AudioSources/BypassReverbZones/Mono/AudioSourceBypassReverbZonesMonoBinder.cs
@@ -1,0 +1,26 @@
+using System;
+using UnityEngine;
+
+// ReSharper disable once CheckNamespace
+namespace Aspid.MVVM.StarterKit
+{
+    [AddBinderContextMenu(typeof(AudioSource))]
+    [AddComponentMenu("Aspid/MVVM/Binders/Audio/AudioSource/AudioSource Binder – BypassReverbZones")]
+    [BindModeOverride(BindMode.OneWay, BindMode.OneTime, BindMode.OneWayToSource)]
+    public partial class AudioSourceBypassReverbZonesMonoBinder : ComponentMonoBinder<AudioSource>, IBinder<bool>, IReverseBinder<bool>
+    {
+        public event Action<bool> ValueChanged;
+        
+        [SerializeField] private bool _isInvert;
+        
+        [BinderLog]
+        public void SetValue(bool value) =>
+            CachedComponent.bypassReverbZones = _isInvert ? !value : value;
+        
+        protected override void OnBound()
+        {
+            if (Mode is BindMode.OneWayToSource)
+                ValueChanged?.Invoke(CachedComponent.bypassReverbZones);
+        }
+    }
+}

--- a/Aspid.MVVM/Assets/Plugins/Aspid/MVVM/StarterKit/Unity/Runtime/Binders/AudioSources/BypassReverbZones/Mono/AudioSourceBypassReverbZonesMonoBinder.cs.meta
+++ b/Aspid.MVVM/Assets/Plugins/Aspid/MVVM/StarterKit/Unity/Runtime/Binders/AudioSources/BypassReverbZones/Mono/AudioSourceBypassReverbZonesMonoBinder.cs.meta
@@ -1,0 +1,3 @@
+fileFormatVersion: 2
+guid: 03ffb58598b8488aa605c1fa01a50652
+timeCreated: 1770880352

--- a/Aspid.MVVM/Assets/Plugins/Aspid/MVVM/StarterKit/Unity/Runtime/Binders/AudioSources/DopplerLevel.meta
+++ b/Aspid.MVVM/Assets/Plugins/Aspid/MVVM/StarterKit/Unity/Runtime/Binders/AudioSources/DopplerLevel.meta
@@ -1,0 +1,3 @@
+fileFormatVersion: 2
+guid: fe7cd961ca4e4ffeb3aaf38f3719595a
+timeCreated: 1770891996

--- a/Aspid.MVVM/Assets/Plugins/Aspid/MVVM/StarterKit/Unity/Runtime/Binders/AudioSources/DopplerLevel/AudioSourceDopplerLevelBinder.cs
+++ b/Aspid.MVVM/Assets/Plugins/Aspid/MVVM/StarterKit/Unity/Runtime/Binders/AudioSources/DopplerLevel/AudioSourceDopplerLevelBinder.cs
@@ -1,0 +1,63 @@
+#nullable enable
+using System;
+using UnityEngine;
+#if UNITY_2023_1_OR_NEWER
+using Converter = Aspid.MVVM.StarterKit.IConverter<float, float>;
+#else
+using Converter = Aspid.MVVM.StarterKit.IConverterFloat;
+#endif
+
+// ReSharper disable once CheckNamespace
+namespace Aspid.MVVM.StarterKit
+{
+    [Serializable]
+    [BindModeOverride(BindMode.OneWay, BindMode.OneTime, BindMode.OneWayToSource)]
+    public class AudioSourceDopplerLevelBinder : TargetBinder<AudioSource>, INumberBinder
+    {
+        public event Action<int> IntValueChanged;
+        public event Action<long> LongValueChanged;
+        public event Action<float> FloatValueChanged;
+        public event Action<double> DoubleValueChanged;
+        
+        [SerializeReferenceDropdown]
+        [SerializeReference] private Converter? _converter;
+        
+        public AudioSourceDopplerLevelBinder(AudioSource target, BindMode mode)
+            : this(target, converter: null, mode) { }
+        
+        public AudioSourceDopplerLevelBinder(AudioSource target, Converter? converter = null, BindMode mode = BindMode.OneWay)
+            : base(target, mode)
+        {
+            mode.ThrowExceptionIfTwo();
+            _converter = converter;
+        }
+
+        public void SetValue(int value) =>
+            SetValue((float)value);
+
+        public void SetValue(long value) =>
+            SetValue((float)value);
+        
+        public void SetValue(float value) =>
+            Target.dopplerLevel =  GetConvertedValue(value);
+
+        public void SetValue(double value) => 
+            SetValue((float)value);
+        
+        protected override void OnBound()
+        {
+            if (Mode is BindMode.OneWayToSource)
+            {
+                var value = GetConvertedValue(Target.dopplerLevel);
+                
+                IntValueChanged?.Invoke((int)value);
+                LongValueChanged?.Invoke((long)value);
+                FloatValueChanged?.Invoke(value);
+                DoubleValueChanged?.Invoke(value);
+            }
+        }
+        
+        private float GetConvertedValue(float value) =>
+            _converter?.Convert(value) ?? value;
+    }
+}

--- a/Aspid.MVVM/Assets/Plugins/Aspid/MVVM/StarterKit/Unity/Runtime/Binders/AudioSources/DopplerLevel/AudioSourceDopplerLevelBinder.cs.meta
+++ b/Aspid.MVVM/Assets/Plugins/Aspid/MVVM/StarterKit/Unity/Runtime/Binders/AudioSources/DopplerLevel/AudioSourceDopplerLevelBinder.cs.meta
@@ -1,0 +1,3 @@
+fileFormatVersion: 2
+guid: 62db5f140e37445a84404d41c0b9c28d
+timeCreated: 1770880452

--- a/Aspid.MVVM/Assets/Plugins/Aspid/MVVM/StarterKit/Unity/Runtime/Binders/AudioSources/DopplerLevel/AudioSourceDopplerLevelSwitcherBinder.cs
+++ b/Aspid.MVVM/Assets/Plugins/Aspid/MVVM/StarterKit/Unity/Runtime/Binders/AudioSources/DopplerLevel/AudioSourceDopplerLevelSwitcherBinder.cs
@@ -1,0 +1,40 @@
+#nullable enable
+using System;
+using UnityEngine;
+#if UNITY_2023_1_OR_NEWER
+using Converter = Aspid.MVVM.StarterKit.IConverter<float, float>;
+#else
+using Converter = Aspid.MVVM.StarterKit.IConverterFloat;
+#endif
+
+// ReSharper disable once CheckNamespace
+namespace Aspid.MVVM.StarterKit
+{
+    [Serializable]
+    public sealed class AudioSourceDopplerLevelSwitcherBinder : SwitcherBinder<AudioSource, float>
+    {
+        [SerializeReferenceDropdown]
+        [SerializeReference] private Converter? _converter;
+        
+        public AudioSourceDopplerLevelSwitcherBinder(
+            AudioSource target,
+            float trueValue, 
+            float falseValue,
+            BindMode mode)
+            : this(target, trueValue, falseValue, converter: null, mode) { }
+        
+        public AudioSourceDopplerLevelSwitcherBinder(
+            AudioSource target,
+            float trueValue, 
+            float falseValue,
+            Converter? converter = null,
+            BindMode mode = BindMode.OneWay)
+            : base(target, trueValue, falseValue, mode)
+        {
+            _converter = converter;
+        }
+
+        protected override void SetValue(float value) =>
+            Target.dopplerLevel = _converter?.Convert(value) ?? value;
+    }
+}

--- a/Aspid.MVVM/Assets/Plugins/Aspid/MVVM/StarterKit/Unity/Runtime/Binders/AudioSources/DopplerLevel/AudioSourceDopplerLevelSwitcherBinder.cs.meta
+++ b/Aspid.MVVM/Assets/Plugins/Aspid/MVVM/StarterKit/Unity/Runtime/Binders/AudioSources/DopplerLevel/AudioSourceDopplerLevelSwitcherBinder.cs.meta
@@ -1,0 +1,3 @@
+fileFormatVersion: 2
+guid: 41c43956b77f42a5a6dcba1d1310fc10
+timeCreated: 1770881429

--- a/Aspid.MVVM/Assets/Plugins/Aspid/MVVM/StarterKit/Unity/Runtime/Binders/AudioSources/DopplerLevel/Mono.meta
+++ b/Aspid.MVVM/Assets/Plugins/Aspid/MVVM/StarterKit/Unity/Runtime/Binders/AudioSources/DopplerLevel/Mono.meta
@@ -1,0 +1,3 @@
+fileFormatVersion: 2
+guid: 197112cfc54344468294a0269f846fb8
+timeCreated: 1770892874

--- a/Aspid.MVVM/Assets/Plugins/Aspid/MVVM/StarterKit/Unity/Runtime/Binders/AudioSources/DopplerLevel/Mono/AudioSourceDopplerLevelEnumGroupMonoBinder.cs
+++ b/Aspid.MVVM/Assets/Plugins/Aspid/MVVM/StarterKit/Unity/Runtime/Binders/AudioSources/DopplerLevel/Mono/AudioSourceDopplerLevelEnumGroupMonoBinder.cs
@@ -1,0 +1,30 @@
+using UnityEngine;
+#if UNITY_2023_1_OR_NEWER
+using Converter = Aspid.MVVM.StarterKit.IConverter<float, float>;
+#else
+using Converter = Aspid.MVVM.StarterKit.IConverterFloat;
+#endif
+
+// ReSharper disable once CheckNamespace
+namespace Aspid.MVVM.StarterKit
+{
+    [AddBinderContextMenu(typeof(AudioSource), SubPath = "EnumGroup")]
+    [AddComponentMenu("Aspid/MVVM/Binders/Audio/AudioSource/AudioSource Binder – DopplerLevel EnumGroup")]
+    public sealed class AudioSourceDopplerLevelEnumGroupMonoBinder : EnumGroupMonoBinder<AudioSource>
+    {
+        [SerializeField] private float _defaultValue;
+        [SerializeField] private float _selectedValue;
+        
+        [SerializeReferenceDropdown]
+        [SerializeReference] private Converter _defaultConverter;
+        
+        [SerializeReferenceDropdown]
+        [SerializeReference] private Converter _selectedConverter;
+        
+        protected override void SetDefaultValue(AudioSource element) =>
+            element.dopplerLevel = _defaultConverter?.Convert(_defaultValue) ?? _defaultValue;
+
+        protected override void SetSelectedValue(AudioSource element) =>
+            element.dopplerLevel = _selectedConverter?.Convert(_selectedValue) ?? _selectedValue;
+    }
+}

--- a/Aspid.MVVM/Assets/Plugins/Aspid/MVVM/StarterKit/Unity/Runtime/Binders/AudioSources/DopplerLevel/Mono/AudioSourceDopplerLevelEnumGroupMonoBinder.cs.meta
+++ b/Aspid.MVVM/Assets/Plugins/Aspid/MVVM/StarterKit/Unity/Runtime/Binders/AudioSources/DopplerLevel/Mono/AudioSourceDopplerLevelEnumGroupMonoBinder.cs.meta
@@ -1,0 +1,3 @@
+fileFormatVersion: 2
+guid: 73792eadc8704623ad88d67ddfce61bb
+timeCreated: 1770880784

--- a/Aspid.MVVM/Assets/Plugins/Aspid/MVVM/StarterKit/Unity/Runtime/Binders/AudioSources/DopplerLevel/Mono/AudioSourceDopplerLevelEnumMonoBinder.cs
+++ b/Aspid.MVVM/Assets/Plugins/Aspid/MVVM/StarterKit/Unity/Runtime/Binders/AudioSources/DopplerLevel/Mono/AudioSourceDopplerLevelEnumMonoBinder.cs
@@ -1,0 +1,21 @@
+#if UNITY_2023_1_OR_NEWER
+using Converter = Aspid.MVVM.StarterKit.IConverter<float, float>;
+#else
+using Converter = Aspid.MVVM.StarterKit.IConverterFloat;
+#endif
+using UnityEngine;
+
+// ReSharper disable once CheckNamespace
+namespace Aspid.MVVM.StarterKit
+{
+    [AddBinderContextMenu(typeof(AudioSource), SubPath = "Enum")]
+    [AddComponentMenu("Aspid/MVVM/Binders/Audio/AudioSource/AudioSource Binder – DopplerLevel Enum")]
+    public sealed class AudioSourceDopplerLevelEnumMonoBinder : EnumMonoBinder<AudioSource, float>
+    {
+        [SerializeReferenceDropdown]
+        [SerializeReference] private Converter _converter;
+        
+        protected override void SetValue(float value) =>
+            CachedComponent.dopplerLevel = _converter?.Convert(value) ?? value;
+    }
+}

--- a/Aspid.MVVM/Assets/Plugins/Aspid/MVVM/StarterKit/Unity/Runtime/Binders/AudioSources/DopplerLevel/Mono/AudioSourceDopplerLevelEnumMonoBinder.cs.meta
+++ b/Aspid.MVVM/Assets/Plugins/Aspid/MVVM/StarterKit/Unity/Runtime/Binders/AudioSources/DopplerLevel/Mono/AudioSourceDopplerLevelEnumMonoBinder.cs.meta
@@ -1,0 +1,3 @@
+fileFormatVersion: 2
+guid: 75a7628996ee4c55abcbb85310ca4a3e
+timeCreated: 1770881429

--- a/Aspid.MVVM/Assets/Plugins/Aspid/MVVM/StarterKit/Unity/Runtime/Binders/AudioSources/DopplerLevel/Mono/AudioSourceDopplerLevelMonoBinder.cs
+++ b/Aspid.MVVM/Assets/Plugins/Aspid/MVVM/StarterKit/Unity/Runtime/Binders/AudioSources/DopplerLevel/Mono/AudioSourceDopplerLevelMonoBinder.cs
@@ -1,0 +1,57 @@
+using System;
+using UnityEngine;
+#if UNITY_2023_1_OR_NEWER
+using Converter = Aspid.MVVM.StarterKit.IConverter<float, float>;
+#else
+using Converter = Aspid.MVVM.StarterKit.IConverterFloat;
+#endif
+
+// ReSharper disable once CheckNamespace
+namespace Aspid.MVVM.StarterKit
+{
+    [AddBinderContextMenu(typeof(AudioSource))]
+    [AddComponentMenu("Aspid/MVVM/Binders/Audio/AudioSource/AudioSource Binder – DopplerLevel")]
+    [BindModeOverride(BindMode.OneWay, BindMode.OneTime, BindMode.OneWayToSource)]
+    public partial class AudioSourceDopplerLevelMonoBinder : ComponentMonoBinder<AudioSource>, INumberBinder, INumberReverseBinder
+    {
+        public event Action<int> IntValueChanged;
+        public event Action<long> LongValueChanged;
+        public event Action<float> FloatValueChanged;
+        public event Action<double> DoubleValueChanged;
+        
+        [SerializeReferenceDropdown]
+        [SerializeReference] private Converter _converter;
+
+        [BinderLog]
+        public void SetValue(float value) =>
+            CachedComponent.dopplerLevel = GetConvertedValue(value);
+
+        [BinderLog]
+        public void SetValue(int value) =>
+            SetValue((float)value);
+
+        [BinderLog]
+        public void SetValue(long value) =>
+            SetValue((float)value);
+
+        [BinderLog]
+        public void SetValue(double value) =>
+            SetValue((float)value);
+        
+        protected override void OnBound()
+        {
+            if (Mode is BindMode.OneWayToSource)
+            {
+                var value = GetConvertedValue(CachedComponent.dopplerLevel);
+                
+                IntValueChanged?.Invoke((int)value);
+                LongValueChanged?.Invoke((long)value);
+                FloatValueChanged?.Invoke(value);
+                DoubleValueChanged?.Invoke(value);
+            }
+        }
+        
+        private float GetConvertedValue(float value) =>
+            _converter?.Convert(value) ?? value;
+    }
+}

--- a/Aspid.MVVM/Assets/Plugins/Aspid/MVVM/StarterKit/Unity/Runtime/Binders/AudioSources/DopplerLevel/Mono/AudioSourceDopplerLevelMonoBinder.cs.meta
+++ b/Aspid.MVVM/Assets/Plugins/Aspid/MVVM/StarterKit/Unity/Runtime/Binders/AudioSources/DopplerLevel/Mono/AudioSourceDopplerLevelMonoBinder.cs.meta
@@ -1,0 +1,3 @@
+fileFormatVersion: 2
+guid: ba77c42e662446acadae49ca1a947ec5
+timeCreated: 1770880352

--- a/Aspid.MVVM/Assets/Plugins/Aspid/MVVM/StarterKit/Unity/Runtime/Binders/AudioSources/DopplerLevel/Mono/AudioSourceDopplerLevelSwitcherMonoBinder.cs
+++ b/Aspid.MVVM/Assets/Plugins/Aspid/MVVM/StarterKit/Unity/Runtime/Binders/AudioSources/DopplerLevel/Mono/AudioSourceDopplerLevelSwitcherMonoBinder.cs
@@ -1,0 +1,21 @@
+using UnityEngine;
+#if UNITY_2023_1_OR_NEWER
+using Converter = Aspid.MVVM.StarterKit.IConverter<float, float>;
+#else
+using Converter = Aspid.MVVM.StarterKit.IConverterFloat;
+#endif
+
+// ReSharper disable once CheckNamespace
+namespace Aspid.MVVM.StarterKit
+{
+    [AddBinderContextMenu(typeof(AudioSource), SubPath = "Switcher")]
+    [AddComponentMenu("Aspid/MVVM/Binders/Audio/AudioSource/AudioSource Binder – DopplerLevel Switcher")]
+    public sealed class AudioSourceDopplerLevelSwitcherMonoBinder : SwitcherMonoBinder<AudioSource, float>
+    {
+        [SerializeReferenceDropdown]
+        [SerializeReference] private Converter _converter;
+        
+        protected override void SetValue(float value) =>
+            CachedComponent.dopplerLevel = _converter?.Convert(value) ?? value;
+    }
+}

--- a/Aspid.MVVM/Assets/Plugins/Aspid/MVVM/StarterKit/Unity/Runtime/Binders/AudioSources/DopplerLevel/Mono/AudioSourceDopplerLevelSwitcherMonoBinder.cs.meta
+++ b/Aspid.MVVM/Assets/Plugins/Aspid/MVVM/StarterKit/Unity/Runtime/Binders/AudioSources/DopplerLevel/Mono/AudioSourceDopplerLevelSwitcherMonoBinder.cs.meta
@@ -1,0 +1,3 @@
+fileFormatVersion: 2
+guid: 800fbcff424e40d5a4c5d30d9d38b571
+timeCreated: 1770880784

--- a/Aspid.MVVM/Assets/Plugins/Aspid/MVVM/StarterKit/Unity/Runtime/Binders/AudioSources/Extensions.meta
+++ b/Aspid.MVVM/Assets/Plugins/Aspid/MVVM/StarterKit/Unity/Runtime/Binders/AudioSources/Extensions.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: baf7d1dbc47bd4ab2adc10daf22c438c
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Aspid.MVVM/Assets/Plugins/Aspid/MVVM/StarterKit/Unity/Runtime/Binders/AudioSources/Extensions/AudioSourceSetters.cs
+++ b/Aspid.MVVM/Assets/Plugins/Aspid/MVVM/StarterKit/Unity/Runtime/Binders/AudioSources/Extensions/AudioSourceSetters.cs
@@ -1,0 +1,26 @@
+using System;
+using UnityEngine;
+using System.Runtime.CompilerServices;
+
+// ReSharper disable once CheckNamespace
+namespace Aspid.MVVM.StarterKit
+{
+    public static class AudioSourceSetters
+    {
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static void SetMinMaxDistance(this AudioSource audioSource, Vector2 value, AudioSourceDistanceMode mode)
+        {
+            value = mode switch
+            {
+                AudioSourceDistanceMode.Min => new Vector2(value.x, audioSource.maxDistance),
+                AudioSourceDistanceMode.Max => new Vector2(audioSource.minDistance, value.y),
+                AudioSourceDistanceMode.Range => new Vector2(value.x, value.y),
+                _ => throw new ArgumentOutOfRangeException()
+            };
+            
+            audioSource.minDistance = value.x;
+            audioSource.maxDistance = value.y;
+        }
+    }
+}
+

--- a/Aspid.MVVM/Assets/Plugins/Aspid/MVVM/StarterKit/Unity/Runtime/Binders/AudioSources/Extensions/AudioSourceSetters.cs.meta
+++ b/Aspid.MVVM/Assets/Plugins/Aspid/MVVM/StarterKit/Unity/Runtime/Binders/AudioSources/Extensions/AudioSourceSetters.cs.meta
@@ -1,0 +1,3 @@
+fileFormatVersion: 2
+guid: 479d76f4c4934ceb8777b6870e5988e8
+timeCreated: 1770882659

--- a/Aspid.MVVM/Assets/Plugins/Aspid/MVVM/StarterKit/Unity/Runtime/Binders/AudioSources/Loop.meta
+++ b/Aspid.MVVM/Assets/Plugins/Aspid/MVVM/StarterKit/Unity/Runtime/Binders/AudioSources/Loop.meta
@@ -1,0 +1,3 @@
+fileFormatVersion: 2
+guid: b98c4551b25f45a6928d387b34c9066b
+timeCreated: 1770892006

--- a/Aspid.MVVM/Assets/Plugins/Aspid/MVVM/StarterKit/Unity/Runtime/Binders/AudioSources/Loop/AudioSourceLoopBinder.cs
+++ b/Aspid.MVVM/Assets/Plugins/Aspid/MVVM/StarterKit/Unity/Runtime/Binders/AudioSources/Loop/AudioSourceLoopBinder.cs
@@ -1,0 +1,38 @@
+#nullable enable
+using System;
+using UnityEngine;
+
+// ReSharper disable once CheckNamespace
+namespace Aspid.MVVM.StarterKit
+{
+    [Serializable]
+    [BindModeOverride(BindMode.OneWay, BindMode.OneTime, BindMode.OneWayToSource)]
+    public class AudioSourceLoopBinder : TargetBinder<AudioSource>, IBinder<bool>, IReverseBinder<bool>
+    {
+        public event Action<bool>? ValueChanged;
+        
+        [SerializeField] private bool _isInvert;
+        
+        public AudioSourceLoopBinder(AudioSource target, BindMode mode)
+            : this(target, isInvert: false, mode) { }
+        
+        public AudioSourceLoopBinder(AudioSource target, bool isInvert = false, BindMode mode = BindMode.OneWay)
+            : base(target, mode)
+        {
+            mode.ThrowExceptionIfTwo();
+            _isInvert = isInvert;
+        }
+
+        public void SetValue(bool value) =>
+            Target.loop = GetConvertedValue(value);
+        
+        protected override void OnBound()
+        {
+            if (Mode is BindMode.OneWayToSource)
+                ValueChanged?.Invoke(GetConvertedValue(Target.loop));
+        }
+        
+        private bool GetConvertedValue(bool value) =>
+            _isInvert ? !value : value;
+    }
+}

--- a/Aspid.MVVM/Assets/Plugins/Aspid/MVVM/StarterKit/Unity/Runtime/Binders/AudioSources/Loop/AudioSourceLoopBinder.cs.meta
+++ b/Aspid.MVVM/Assets/Plugins/Aspid/MVVM/StarterKit/Unity/Runtime/Binders/AudioSources/Loop/AudioSourceLoopBinder.cs.meta
@@ -1,0 +1,3 @@
+fileFormatVersion: 2
+guid: defd41ed3315407a92715e0d3673a0e6
+timeCreated: 1770880401

--- a/Aspid.MVVM/Assets/Plugins/Aspid/MVVM/StarterKit/Unity/Runtime/Binders/AudioSources/Loop/Mono.meta
+++ b/Aspid.MVVM/Assets/Plugins/Aspid/MVVM/StarterKit/Unity/Runtime/Binders/AudioSources/Loop/Mono.meta
@@ -1,0 +1,3 @@
+fileFormatVersion: 2
+guid: 851e6df2bf704270873f7448e2e05f62
+timeCreated: 1770892876

--- a/Aspid.MVVM/Assets/Plugins/Aspid/MVVM/StarterKit/Unity/Runtime/Binders/AudioSources/Loop/Mono/AudioSourceLoopEnumGroupMonoBinder.cs
+++ b/Aspid.MVVM/Assets/Plugins/Aspid/MVVM/StarterKit/Unity/Runtime/Binders/AudioSources/Loop/Mono/AudioSourceLoopEnumGroupMonoBinder.cs
@@ -1,0 +1,13 @@
+using UnityEngine;
+
+// ReSharper disable once CheckNamespace
+namespace Aspid.MVVM.StarterKit
+{
+    [AddBinderContextMenu(typeof(AudioSource), SubPath = "EnumGroup")]
+    [AddComponentMenu("Aspid/MVVM/Binders/Audio/AudioSource/AudioSource Binder – Loop EnumGroup")]
+    public sealed class AudioSourceLoopEnumGroupMonoBinder : EnumGroupMonoBinder<AudioSource, bool>
+    {
+        protected override void SetValue(AudioSource element, bool value) =>
+            element.loop = value;
+    }
+}

--- a/Aspid.MVVM/Assets/Plugins/Aspid/MVVM/StarterKit/Unity/Runtime/Binders/AudioSources/Loop/Mono/AudioSourceLoopEnumGroupMonoBinder.cs.meta
+++ b/Aspid.MVVM/Assets/Plugins/Aspid/MVVM/StarterKit/Unity/Runtime/Binders/AudioSources/Loop/Mono/AudioSourceLoopEnumGroupMonoBinder.cs.meta
@@ -1,0 +1,3 @@
+fileFormatVersion: 2
+guid: 1687523db091434e8769b3d75bce065b
+timeCreated: 1770577010

--- a/Aspid.MVVM/Assets/Plugins/Aspid/MVVM/StarterKit/Unity/Runtime/Binders/AudioSources/Loop/Mono/AudioSourceLoopEnumMonoBinder.cs
+++ b/Aspid.MVVM/Assets/Plugins/Aspid/MVVM/StarterKit/Unity/Runtime/Binders/AudioSources/Loop/Mono/AudioSourceLoopEnumMonoBinder.cs
@@ -1,0 +1,13 @@
+using UnityEngine;
+
+// ReSharper disable once CheckNamespace
+namespace Aspid.MVVM.StarterKit
+{
+    [AddBinderContextMenu(typeof(AudioSource), SubPath = "Enum")]
+    [AddComponentMenu("Aspid/MVVM/Binders/Audio/AudioSource/AudioSource Binder – Loop Enum")]
+    public sealed class AudioSourceLoopEnumMonoBinder : EnumMonoBinder<AudioSource, bool>
+    {
+        protected override void SetValue(bool value) =>
+            CachedComponent.loop = value;
+    }
+}

--- a/Aspid.MVVM/Assets/Plugins/Aspid/MVVM/StarterKit/Unity/Runtime/Binders/AudioSources/Loop/Mono/AudioSourceLoopEnumMonoBinder.cs.meta
+++ b/Aspid.MVVM/Assets/Plugins/Aspid/MVVM/StarterKit/Unity/Runtime/Binders/AudioSources/Loop/Mono/AudioSourceLoopEnumMonoBinder.cs.meta
@@ -1,0 +1,3 @@
+fileFormatVersion: 2
+guid: ade8955acfa140119fa57bd74854016f
+timeCreated: 1770577010

--- a/Aspid.MVVM/Assets/Plugins/Aspid/MVVM/StarterKit/Unity/Runtime/Binders/AudioSources/Loop/Mono/AudioSourceLoopMonoBinder.cs
+++ b/Aspid.MVVM/Assets/Plugins/Aspid/MVVM/StarterKit/Unity/Runtime/Binders/AudioSources/Loop/Mono/AudioSourceLoopMonoBinder.cs
@@ -1,0 +1,29 @@
+using System;
+using UnityEngine;
+
+// ReSharper disable once CheckNamespace
+namespace Aspid.MVVM.StarterKit
+{
+    [AddBinderContextMenu(typeof(AudioSource))]
+    [AddComponentMenu("Aspid/MVVM/Binders/Audio/AudioSource/AudioSource Binder – Loop")]
+    [BindModeOverride(BindMode.OneWay, BindMode.OneTime, BindMode.OneWayToSource)]
+    public partial class AudioSourceLoopMonoBinder : ComponentMonoBinder<AudioSource>, IBinder<bool>, IReverseBinder<bool>
+    {
+        public event Action<bool> ValueChanged;
+        
+        [SerializeField] private bool _isInvert;
+
+        [BinderLog]
+        public void SetValue(bool value) =>
+            CachedComponent.loop = GetConvertedValue(value);
+        
+        protected override void OnBound()
+        {
+            if (Mode is BindMode.OneWayToSource)
+                ValueChanged?.Invoke(GetConvertedValue(CachedComponent.loop));
+        }
+        
+        private bool GetConvertedValue(bool value) =>
+            _isInvert ? !value : value;
+    }
+}

--- a/Aspid.MVVM/Assets/Plugins/Aspid/MVVM/StarterKit/Unity/Runtime/Binders/AudioSources/Loop/Mono/AudioSourceLoopMonoBinder.cs.meta
+++ b/Aspid.MVVM/Assets/Plugins/Aspid/MVVM/StarterKit/Unity/Runtime/Binders/AudioSources/Loop/Mono/AudioSourceLoopMonoBinder.cs.meta
@@ -1,0 +1,3 @@
+fileFormatVersion: 2
+guid: a0e18a7de7e045d4a8012e96f565207e
+timeCreated: 1770577010

--- a/Aspid.MVVM/Assets/Plugins/Aspid/MVVM/StarterKit/Unity/Runtime/Binders/AudioSources/MinMaxDistance.meta
+++ b/Aspid.MVVM/Assets/Plugins/Aspid/MVVM/StarterKit/Unity/Runtime/Binders/AudioSources/MinMaxDistance.meta
@@ -1,0 +1,3 @@
+fileFormatVersion: 2
+guid: 3c9326824711462cb2dbf7e9571d8b4b
+timeCreated: 1770892015

--- a/Aspid.MVVM/Assets/Plugins/Aspid/MVVM/StarterKit/Unity/Runtime/Binders/AudioSources/MinMaxDistance/AudioSourceMinMaxDistanceBinder.cs
+++ b/Aspid.MVVM/Assets/Plugins/Aspid/MVVM/StarterKit/Unity/Runtime/Binders/AudioSources/MinMaxDistance/AudioSourceMinMaxDistanceBinder.cs
@@ -1,0 +1,69 @@
+#nullable enable
+using System;
+using UnityEngine;
+#if UNITY_2023_1_OR_NEWER
+using Converter = Aspid.MVVM.StarterKit.IConverter<UnityEngine.Vector2, UnityEngine.Vector2>;
+#else
+using Converter = Aspid.MVVM.StarterKit.IConverterVector2;
+#endif
+
+// ReSharper disable once CheckNamespace
+namespace Aspid.MVVM.StarterKit
+{
+    [Serializable]
+    [BindModeOverride(BindMode.OneWay, BindMode.OneTime, BindMode.OneWayToSource)]
+    public class AudioSourceMinMaxDistanceBinder : TargetBinder<AudioSource>, IBinder<Vector2>, INumberBinder
+    {
+        [SerializeField] private AudioSourceDistanceMode _distanceMode = AudioSourceDistanceMode.Range;
+        
+        [SerializeReferenceDropdown]
+        [SerializeReference] private Converter? _converter;
+        
+        public AudioSourceMinMaxDistanceBinder(
+            AudioSource target, 
+            BindMode mode)
+            : this(target, AudioSourceDistanceMode.Range, converter: null, mode) { }
+        
+        public AudioSourceMinMaxDistanceBinder(
+            AudioSource target, 
+            AudioSourceDistanceMode distanceMode, 
+            BindMode mode)
+            : this(target, distanceMode, converter: null, mode) { }
+        
+        public AudioSourceMinMaxDistanceBinder(
+            AudioSource target, 
+            Converter? converter,
+            BindMode mode = BindMode.OneWay)
+            : this(target, AudioSourceDistanceMode.Range, converter, mode) { }
+        
+        public AudioSourceMinMaxDistanceBinder(
+            AudioSource target, 
+            AudioSourceDistanceMode distanceMode = AudioSourceDistanceMode.Range, 
+            Converter? converter = null,
+            BindMode mode = BindMode.OneWay)
+            : base(target, mode)
+        {
+            mode.ThrowExceptionIfTwo();
+            _distanceMode = distanceMode;
+            _converter = converter; 
+        }
+        
+        public void SetValue(Vector2 value)
+        {
+            value = _converter?.Convert(value) ?? value;
+            Target.SetMinMaxDistance(value, _distanceMode);
+        }
+        
+        public void SetValue(float value) =>
+            SetValue(new Vector2(value, value));
+
+        public void SetValue(int value) =>
+            SetValue((float)value);
+
+        public void SetValue(long value) =>
+            SetValue((float)value);
+
+        public void SetValue(double value) =>
+            SetValue((float)value);
+    }
+}

--- a/Aspid.MVVM/Assets/Plugins/Aspid/MVVM/StarterKit/Unity/Runtime/Binders/AudioSources/MinMaxDistance/AudioSourceMinMaxDistanceBinder.cs.meta
+++ b/Aspid.MVVM/Assets/Plugins/Aspid/MVVM/StarterKit/Unity/Runtime/Binders/AudioSources/MinMaxDistance/AudioSourceMinMaxDistanceBinder.cs.meta
@@ -1,0 +1,3 @@
+fileFormatVersion: 2
+guid: 446b06c1dc6243d99d88f4f50aa67d64
+timeCreated: 1770884734

--- a/Aspid.MVVM/Assets/Plugins/Aspid/MVVM/StarterKit/Unity/Runtime/Binders/AudioSources/MinMaxDistance/AudioSourceMinMaxDistanceSwitcherBinder.cs
+++ b/Aspid.MVVM/Assets/Plugins/Aspid/MVVM/StarterKit/Unity/Runtime/Binders/AudioSources/MinMaxDistance/AudioSourceMinMaxDistanceSwitcherBinder.cs
@@ -1,0 +1,63 @@
+#nullable enable
+using System;
+using UnityEngine;
+#if UNITY_2023_1_OR_NEWER
+using Converter = Aspid.MVVM.StarterKit.IConverter<UnityEngine.Vector2, UnityEngine.Vector2>;
+#else
+using Converter = Aspid.MVVM.StarterKit.IConverterVector2;
+#endif
+
+// ReSharper disable once CheckNamespace
+namespace Aspid.MVVM.StarterKit
+{
+    [Serializable]
+    public sealed class AudioSourceMinMaxDistanceSwitcherBinder : SwitcherBinder<AudioSource, Vector2>
+    {
+        [SerializeField] private AudioSourceDistanceMode _distanceMode = AudioSourceDistanceMode.Range;
+        
+        [SerializeReferenceDropdown]
+        [SerializeReference] private Converter? _converter;
+        
+        public AudioSourceMinMaxDistanceSwitcherBinder(
+            AudioSource target,
+            Vector2 trueValue, 
+            Vector2 falseValue,
+            BindMode mode)
+            : this(target, trueValue, falseValue, AudioSourceDistanceMode.Range, converter: null, mode) { }
+        
+        public AudioSourceMinMaxDistanceSwitcherBinder(
+            AudioSource target,
+            Vector2 trueValue, 
+            Vector2 falseValue,
+            AudioSourceDistanceMode distanceMode,
+            BindMode mode)
+            : this(target, trueValue, falseValue, distanceMode, converter: null, mode) { }
+        
+        public AudioSourceMinMaxDistanceSwitcherBinder(
+            AudioSource target,
+            Vector2 trueValue, 
+            Vector2 falseValue,
+            Converter? converter,
+            BindMode mode = BindMode.OneWay)
+            : this(target, trueValue, falseValue, AudioSourceDistanceMode.Range, converter, mode) { }
+        
+        public AudioSourceMinMaxDistanceSwitcherBinder(
+            AudioSource target,
+            Vector2 trueValue, 
+            Vector2 falseValue,
+            AudioSourceDistanceMode distanceMode = AudioSourceDistanceMode.Range,
+            Converter? converter = null,
+            BindMode mode = BindMode.OneWay)
+            : base(target, trueValue, falseValue, mode)
+        {
+            _distanceMode = distanceMode;
+            _converter = converter;
+        }
+
+        protected override void SetValue(Vector2 value)
+        {
+            value = _converter?.Convert(value) ?? value;
+            Target.SetMinMaxDistance(value, _distanceMode);
+        }
+    }
+}

--- a/Aspid.MVVM/Assets/Plugins/Aspid/MVVM/StarterKit/Unity/Runtime/Binders/AudioSources/MinMaxDistance/AudioSourceMinMaxDistanceSwitcherBinder.cs.meta
+++ b/Aspid.MVVM/Assets/Plugins/Aspid/MVVM/StarterKit/Unity/Runtime/Binders/AudioSources/MinMaxDistance/AudioSourceMinMaxDistanceSwitcherBinder.cs.meta
@@ -1,0 +1,3 @@
+fileFormatVersion: 2
+guid: 6b6d07a6491e422dbfa05572cbba55ec
+timeCreated: 1770882684

--- a/Aspid.MVVM/Assets/Plugins/Aspid/MVVM/StarterKit/Unity/Runtime/Binders/AudioSources/MinMaxDistance/Mono.meta
+++ b/Aspid.MVVM/Assets/Plugins/Aspid/MVVM/StarterKit/Unity/Runtime/Binders/AudioSources/MinMaxDistance/Mono.meta
@@ -1,0 +1,3 @@
+fileFormatVersion: 2
+guid: d7e6706144994af8b08b563bccd94e58
+timeCreated: 1770892878

--- a/Aspid.MVVM/Assets/Plugins/Aspid/MVVM/StarterKit/Unity/Runtime/Binders/AudioSources/MinMaxDistance/Mono/AudioSourceMinMaxDistanceEnumGroupMonoBinder.cs
+++ b/Aspid.MVVM/Assets/Plugins/Aspid/MVVM/StarterKit/Unity/Runtime/Binders/AudioSources/MinMaxDistance/Mono/AudioSourceMinMaxDistanceEnumGroupMonoBinder.cs
@@ -1,0 +1,38 @@
+using UnityEngine;
+#if UNITY_2023_1_OR_NEWER
+using Converter = Aspid.MVVM.StarterKit.IConverter<UnityEngine.Vector2, UnityEngine.Vector2>;
+#else
+using Converter = Aspid.MVVM.StarterKit.IConverterVector2;
+#endif
+
+// ReSharper disable once CheckNamespace
+namespace Aspid.MVVM.StarterKit
+{
+    [AddBinderContextMenu(typeof(AudioSource), SubPath = "EnumGroup")]
+    [AddComponentMenu("Aspid/MVVM/Binders/Audio/AudioSource/AudioSource Binder – MinMaxDistance EnumGroup")]
+    public sealed class AudioSourceMinMaxDistanceEnumGroupMonoBinder : EnumGroupMonoBinder<AudioSource>
+    {
+        [SerializeField] private Vector2 _defaultValue;
+        [SerializeField] private Vector2 _selectedValue;
+        
+        [SerializeField] private AudioSourceDistanceMode _distanceMode = AudioSourceDistanceMode.Range;
+        
+        [SerializeReferenceDropdown]
+        [SerializeReference] private Converter _defaultConverter;
+        
+        [SerializeReferenceDropdown]
+        [SerializeReference] private Converter _selectedConverter;
+        
+        protected override void SetDefaultValue(AudioSource element)
+        {
+            var value = _defaultConverter?.Convert(_defaultValue) ?? _defaultValue;
+            element.SetMinMaxDistance(value, _distanceMode);
+        }
+
+        protected override void SetSelectedValue(AudioSource element)
+        {
+            var value = _selectedConverter?.Convert(_selectedValue) ?? _selectedValue;
+            element.SetMinMaxDistance(value, _distanceMode);
+        }
+    }
+}

--- a/Aspid.MVVM/Assets/Plugins/Aspid/MVVM/StarterKit/Unity/Runtime/Binders/AudioSources/MinMaxDistance/Mono/AudioSourceMinMaxDistanceEnumGroupMonoBinder.cs.meta
+++ b/Aspid.MVVM/Assets/Plugins/Aspid/MVVM/StarterKit/Unity/Runtime/Binders/AudioSources/MinMaxDistance/Mono/AudioSourceMinMaxDistanceEnumGroupMonoBinder.cs.meta
@@ -1,0 +1,3 @@
+fileFormatVersion: 2
+guid: 9ea20f60539d43308357eb6cbd2e8dd9
+timeCreated: 1770882749

--- a/Aspid.MVVM/Assets/Plugins/Aspid/MVVM/StarterKit/Unity/Runtime/Binders/AudioSources/MinMaxDistance/Mono/AudioSourceMinMaxDistanceEnumMonoBinder.cs
+++ b/Aspid.MVVM/Assets/Plugins/Aspid/MVVM/StarterKit/Unity/Runtime/Binders/AudioSources/MinMaxDistance/Mono/AudioSourceMinMaxDistanceEnumMonoBinder.cs
@@ -1,0 +1,26 @@
+using UnityEngine;
+#if UNITY_2023_1_OR_NEWER
+using Converter = Aspid.MVVM.StarterKit.IConverter<UnityEngine.Vector2, UnityEngine.Vector2>;
+#else
+using Converter = Aspid.MVVM.StarterKit.IConverterVector2;
+#endif
+
+// ReSharper disable once CheckNamespace
+namespace Aspid.MVVM.StarterKit
+{
+    [AddBinderContextMenu(typeof(AudioSource), SubPath = "Enum")]
+    [AddComponentMenu("Aspid/MVVM/Binders/Audio/AudioSource/AudioSource Binder – MinMaxDistance Enum")]
+    public sealed class AudioSourceMinMaxDistanceEnumMonoBinder : EnumMonoBinder<AudioSource, Vector2>
+    {
+        [SerializeField] private AudioSourceDistanceMode _distanceMode = AudioSourceDistanceMode.Range;
+        
+        [SerializeReferenceDropdown]
+        [SerializeReference] private Converter _converter;
+        
+        protected override void SetValue(Vector2 value)
+        {
+            value = _converter?.Convert(value) ?? value;
+            CachedComponent.SetMinMaxDistance(value, _distanceMode);
+        }
+    }
+}

--- a/Aspid.MVVM/Assets/Plugins/Aspid/MVVM/StarterKit/Unity/Runtime/Binders/AudioSources/MinMaxDistance/Mono/AudioSourceMinMaxDistanceEnumMonoBinder.cs.meta
+++ b/Aspid.MVVM/Assets/Plugins/Aspid/MVVM/StarterKit/Unity/Runtime/Binders/AudioSources/MinMaxDistance/Mono/AudioSourceMinMaxDistanceEnumMonoBinder.cs.meta
@@ -1,0 +1,3 @@
+fileFormatVersion: 2
+guid: 004c90bfde484f57a4d035a5ec375673
+timeCreated: 1770882749

--- a/Aspid.MVVM/Assets/Plugins/Aspid/MVVM/StarterKit/Unity/Runtime/Binders/AudioSources/MinMaxDistance/Mono/AudioSourceMinMaxDistanceMonoBinder.cs
+++ b/Aspid.MVVM/Assets/Plugins/Aspid/MVVM/StarterKit/Unity/Runtime/Binders/AudioSources/MinMaxDistance/Mono/AudioSourceMinMaxDistanceMonoBinder.cs
@@ -1,0 +1,44 @@
+using UnityEngine;
+#if UNITY_2023_1_OR_NEWER
+using Converter = Aspid.MVVM.StarterKit.IConverter<UnityEngine.Vector2, UnityEngine.Vector2>;
+#else
+using Converter = Aspid.MVVM.StarterKit.IConverterVector2;
+#endif
+
+// ReSharper disable once CheckNamespace
+namespace Aspid.MVVM.StarterKit
+{
+    [AddBinderContextMenu(typeof(AudioSource))]
+    [AddComponentMenu("Aspid/MVVM/Binders/Audio/AudioSource/AudioSource Binder – MinMaxDistance")]
+    [BindModeOverride(BindMode.OneWay, BindMode.OneTime, BindMode.OneWayToSource)]
+    public partial class AudioSourceMinMaxDistanceMonoBinder : ComponentMonoBinder<AudioSource>, IBinder<Vector2>, INumberBinder
+    {
+        [SerializeField] private AudioSourceDistanceMode _distanceMode = AudioSourceDistanceMode.Range;
+        
+        [SerializeReferenceDropdown]
+        [SerializeReference] private Converter _converter;
+        
+        [BinderLog]
+        public void SetValue(Vector2 value)
+        {
+            value = _converter?.Convert(value) ?? value;
+            CachedComponent.SetMinMaxDistance(value, _distanceMode);
+        }
+        
+        [BinderLog]
+        public void SetValue(float value) =>
+            SetValue(new Vector2(value, value));
+
+        [BinderLog]
+        public void SetValue(int value) =>
+            SetValue((float)value);
+
+        [BinderLog]
+        public void SetValue(long value) =>
+            SetValue((float)value);
+
+        [BinderLog]
+        public void SetValue(double value) =>
+            SetValue((float)value);
+    }
+}

--- a/Aspid.MVVM/Assets/Plugins/Aspid/MVVM/StarterKit/Unity/Runtime/Binders/AudioSources/MinMaxDistance/Mono/AudioSourceMinMaxDistanceMonoBinder.cs.meta
+++ b/Aspid.MVVM/Assets/Plugins/Aspid/MVVM/StarterKit/Unity/Runtime/Binders/AudioSources/MinMaxDistance/Mono/AudioSourceMinMaxDistanceMonoBinder.cs.meta
@@ -1,0 +1,3 @@
+fileFormatVersion: 2
+guid: e7acbd23a25a410796b813a7fe8fcb64
+timeCreated: 1770885169

--- a/Aspid.MVVM/Assets/Plugins/Aspid/MVVM/StarterKit/Unity/Runtime/Binders/AudioSources/MinMaxDistance/Mono/AudioSourceMinMaxDistanceSwitcherMonoBinder.cs
+++ b/Aspid.MVVM/Assets/Plugins/Aspid/MVVM/StarterKit/Unity/Runtime/Binders/AudioSources/MinMaxDistance/Mono/AudioSourceMinMaxDistanceSwitcherMonoBinder.cs
@@ -1,0 +1,26 @@
+using UnityEngine;
+#if UNITY_2023_1_OR_NEWER
+using Converter = Aspid.MVVM.StarterKit.IConverter<UnityEngine.Vector2, UnityEngine.Vector2>;
+#else
+using Converter = Aspid.MVVM.StarterKit.IConverterVector2;
+#endif
+
+// ReSharper disable once CheckNamespace
+namespace Aspid.MVVM.StarterKit
+{
+    [AddBinderContextMenu(typeof(AudioSource), SubPath = "Switcher")]
+    [AddComponentMenu("Aspid/MVVM/Binders/Audio/AudioSource/AudioSource Binder – MinMaxDistance Switcher")]
+    public sealed class AudioSourceMinMaxDistanceSwitcherMonoBinder : SwitcherMonoBinder<AudioSource, Vector2>
+    {
+        [SerializeField] private AudioSourceDistanceMode _distanceMode = AudioSourceDistanceMode.Range;
+        
+        [SerializeReferenceDropdown]
+        [SerializeReference] private Converter _converter;
+        
+        protected override void SetValue(Vector2 value)
+        {
+            value = _converter?.Convert(value) ?? value;
+            CachedComponent.SetMinMaxDistance(value, _distanceMode);
+        }
+    }
+}

--- a/Aspid.MVVM/Assets/Plugins/Aspid/MVVM/StarterKit/Unity/Runtime/Binders/AudioSources/MinMaxDistance/Mono/AudioSourceMinMaxDistanceSwitcherMonoBinder.cs.meta
+++ b/Aspid.MVVM/Assets/Plugins/Aspid/MVVM/StarterKit/Unity/Runtime/Binders/AudioSources/MinMaxDistance/Mono/AudioSourceMinMaxDistanceSwitcherMonoBinder.cs.meta
@@ -1,0 +1,3 @@
+fileFormatVersion: 2
+guid: ffe7c1ac82b147318bf5fa422a6d981e
+timeCreated: 1770882748

--- a/Aspid.MVVM/Assets/Plugins/Aspid/MVVM/StarterKit/Unity/Runtime/Binders/AudioSources/Mute.meta
+++ b/Aspid.MVVM/Assets/Plugins/Aspid/MVVM/StarterKit/Unity/Runtime/Binders/AudioSources/Mute.meta
@@ -1,0 +1,3 @@
+fileFormatVersion: 2
+guid: 57e1612232c34ff7b034a81d44c94a38
+timeCreated: 1770892025

--- a/Aspid.MVVM/Assets/Plugins/Aspid/MVVM/StarterKit/Unity/Runtime/Binders/AudioSources/Mute/AudioSourceMuteBinder.cs
+++ b/Aspid.MVVM/Assets/Plugins/Aspid/MVVM/StarterKit/Unity/Runtime/Binders/AudioSources/Mute/AudioSourceMuteBinder.cs
@@ -1,0 +1,38 @@
+#nullable enable
+using System;
+using UnityEngine;
+
+// ReSharper disable once CheckNamespace
+namespace Aspid.MVVM.StarterKit
+{
+    [Serializable]
+    [BindModeOverride(BindMode.OneWay, BindMode.OneTime, BindMode.OneWayToSource)]
+    public class AudioSourceMuteBinder : TargetBinder<AudioSource>, IBinder<bool>, IReverseBinder<bool>
+    {
+        public event Action<bool>? ValueChanged;
+        
+        [SerializeField] private bool _isInvert;
+        
+        public AudioSourceMuteBinder(AudioSource target, BindMode mode)
+            : this(target, isInvert: false, mode) { }
+        
+        public AudioSourceMuteBinder(AudioSource target, bool isInvert = false, BindMode mode = BindMode.OneWay)
+            : base(target, mode)
+        {
+            mode.ThrowExceptionIfTwo();
+            _isInvert = isInvert;
+        }
+
+        public void SetValue(bool value) =>
+            Target.mute = GetConvertedValue(value);
+        
+        protected override void OnBound()
+        {
+            if (Mode is BindMode.OneWayToSource)
+                ValueChanged?.Invoke(GetConvertedValue(Target.mute));
+        }
+        
+        private bool GetConvertedValue(bool value) =>
+            _isInvert ? !value : value;
+    }
+}

--- a/Aspid.MVVM/Assets/Plugins/Aspid/MVVM/StarterKit/Unity/Runtime/Binders/AudioSources/Mute/AudioSourceMuteBinder.cs.meta
+++ b/Aspid.MVVM/Assets/Plugins/Aspid/MVVM/StarterKit/Unity/Runtime/Binders/AudioSources/Mute/AudioSourceMuteBinder.cs.meta
@@ -1,0 +1,3 @@
+fileFormatVersion: 2
+guid: d01940dad1a747db9d72b3fa64508454
+timeCreated: 1770880401

--- a/Aspid.MVVM/Assets/Plugins/Aspid/MVVM/StarterKit/Unity/Runtime/Binders/AudioSources/Mute/Mono.meta
+++ b/Aspid.MVVM/Assets/Plugins/Aspid/MVVM/StarterKit/Unity/Runtime/Binders/AudioSources/Mute/Mono.meta
@@ -1,0 +1,3 @@
+fileFormatVersion: 2
+guid: e54df802cbf9451289a46febdf5d7480
+timeCreated: 1770892880

--- a/Aspid.MVVM/Assets/Plugins/Aspid/MVVM/StarterKit/Unity/Runtime/Binders/AudioSources/Mute/Mono/AudioSourceMuteEnumGroupMonoBinder.cs
+++ b/Aspid.MVVM/Assets/Plugins/Aspid/MVVM/StarterKit/Unity/Runtime/Binders/AudioSources/Mute/Mono/AudioSourceMuteEnumGroupMonoBinder.cs
@@ -1,0 +1,13 @@
+using UnityEngine;
+
+// ReSharper disable once CheckNamespace
+namespace Aspid.MVVM.StarterKit
+{
+    [AddBinderContextMenu(typeof(AudioSource), SubPath = "EnumGroup")]
+    [AddComponentMenu("Aspid/MVVM/Binders/Audio/AudioSource/AudioSource Binder – Mute EnumGroup")]
+    public sealed class AudioSourceMuteEnumGroupMonoBinder : EnumGroupMonoBinder<AudioSource, bool>
+    {
+        protected override void SetValue(AudioSource element, bool value) =>
+            element.mute = value;
+    }
+}

--- a/Aspid.MVVM/Assets/Plugins/Aspid/MVVM/StarterKit/Unity/Runtime/Binders/AudioSources/Mute/Mono/AudioSourceMuteEnumGroupMonoBinder.cs.meta
+++ b/Aspid.MVVM/Assets/Plugins/Aspid/MVVM/StarterKit/Unity/Runtime/Binders/AudioSources/Mute/Mono/AudioSourceMuteEnumGroupMonoBinder.cs.meta
@@ -1,0 +1,3 @@
+fileFormatVersion: 2
+guid: 5ee4a0da3029451ebfbd82614abce0de
+timeCreated: 1770577000

--- a/Aspid.MVVM/Assets/Plugins/Aspid/MVVM/StarterKit/Unity/Runtime/Binders/AudioSources/Mute/Mono/AudioSourceMuteEnumMonoBinder.cs
+++ b/Aspid.MVVM/Assets/Plugins/Aspid/MVVM/StarterKit/Unity/Runtime/Binders/AudioSources/Mute/Mono/AudioSourceMuteEnumMonoBinder.cs
@@ -1,0 +1,13 @@
+using UnityEngine;
+
+// ReSharper disable once CheckNamespace
+namespace Aspid.MVVM.StarterKit
+{
+    [AddBinderContextMenu(typeof(AudioSource), SubPath = "Enum")]
+    [AddComponentMenu("Aspid/MVVM/Binders/Audio/AudioSource/AudioSource Binder – Mute Enum")]
+    public sealed class AudioSourceMuteEnumMonoBinder : EnumMonoBinder<AudioSource, bool>
+    {
+        protected override void SetValue(bool value) =>
+            CachedComponent.mute = value;
+    }
+}

--- a/Aspid.MVVM/Assets/Plugins/Aspid/MVVM/StarterKit/Unity/Runtime/Binders/AudioSources/Mute/Mono/AudioSourceMuteEnumMonoBinder.cs.meta
+++ b/Aspid.MVVM/Assets/Plugins/Aspid/MVVM/StarterKit/Unity/Runtime/Binders/AudioSources/Mute/Mono/AudioSourceMuteEnumMonoBinder.cs.meta
@@ -1,0 +1,3 @@
+fileFormatVersion: 2
+guid: 3d03ffec8ee04bfabb49dcfd1a1500eb
+timeCreated: 1770577000

--- a/Aspid.MVVM/Assets/Plugins/Aspid/MVVM/StarterKit/Unity/Runtime/Binders/AudioSources/Mute/Mono/AudioSourceMuteMonoBinder.cs
+++ b/Aspid.MVVM/Assets/Plugins/Aspid/MVVM/StarterKit/Unity/Runtime/Binders/AudioSources/Mute/Mono/AudioSourceMuteMonoBinder.cs
@@ -1,0 +1,29 @@
+using System;
+using UnityEngine;
+
+// ReSharper disable once CheckNamespace
+namespace Aspid.MVVM.StarterKit
+{
+    [AddBinderContextMenu(typeof(AudioSource))]
+    [AddComponentMenu("Aspid/MVVM/Binders/Audio/AudioSource/AudioSource Binder – Mute")]
+    [BindModeOverride(BindMode.OneWay, BindMode.OneTime, BindMode.OneWayToSource)]
+    public partial class AudioSourceMuteMonoBinder : ComponentMonoBinder<AudioSource>, IBinder<bool>, IReverseBinder<bool>
+    {
+        public event Action<bool> ValueChanged;
+        
+        [SerializeField] private bool _isInvert;
+
+        [BinderLog]
+        public void SetValue(bool value) =>
+            CachedComponent.mute = GetConvertedValue(value);
+        
+        protected override void OnBound()
+        {
+            if (Mode is BindMode.OneWayToSource)
+                ValueChanged?.Invoke(GetConvertedValue(CachedComponent.mute));
+        }
+        
+        private bool GetConvertedValue(bool value) =>
+            _isInvert ? !value : value;
+    }
+}

--- a/Aspid.MVVM/Assets/Plugins/Aspid/MVVM/StarterKit/Unity/Runtime/Binders/AudioSources/Mute/Mono/AudioSourceMuteMonoBinder.cs.meta
+++ b/Aspid.MVVM/Assets/Plugins/Aspid/MVVM/StarterKit/Unity/Runtime/Binders/AudioSources/Mute/Mono/AudioSourceMuteMonoBinder.cs.meta
@@ -1,0 +1,3 @@
+fileFormatVersion: 2
+guid: 0df7a0f304d84c819fd61700e603b4f5
+timeCreated: 1770577000

--- a/Aspid.MVVM/Assets/Plugins/Aspid/MVVM/StarterKit/Unity/Runtime/Binders/AudioSources/OneWayToSource.meta
+++ b/Aspid.MVVM/Assets/Plugins/Aspid/MVVM/StarterKit/Unity/Runtime/Binders/AudioSources/OneWayToSource.meta
@@ -1,0 +1,3 @@
+fileFormatVersion: 2
+guid: f43caac99b4a499eb475e85e1a93f5e9
+timeCreated: 1770893028

--- a/Aspid.MVVM/Assets/Plugins/Aspid/MVVM/StarterKit/Unity/Runtime/Binders/AudioSources/OneWayToSource/Mono.meta
+++ b/Aspid.MVVM/Assets/Plugins/Aspid/MVVM/StarterKit/Unity/Runtime/Binders/AudioSources/OneWayToSource/Mono.meta
@@ -1,0 +1,3 @@
+fileFormatVersion: 2
+guid: 6dfeab820a7d49ddab7001fd2e9b3412
+timeCreated: 1770893121

--- a/Aspid.MVVM/Assets/Plugins/Aspid/MVVM/StarterKit/Unity/Runtime/Binders/AudioSources/OneWayToSource/Mono/AudioSourceToSourceMonoBinder.cs
+++ b/Aspid.MVVM/Assets/Plugins/Aspid/MVVM/StarterKit/Unity/Runtime/Binders/AudioSources/OneWayToSource/Mono/AudioSourceToSourceMonoBinder.cs
@@ -1,0 +1,9 @@
+using UnityEngine;
+
+// ReSharper disable once CheckNamespace
+namespace Aspid.MVVM.StarterKit
+{
+    [AddBinderContextMenu(typeof(AudioSource))]
+    [AddComponentMenu("Aspid/MVVM/Binders/Audio/AudioSource/AudioSource To Source Binder")]
+    public sealed class AudioSourceToSourceMonoBinder : ComponentToSourceMonoBinder<AudioSource> { }
+}

--- a/Aspid.MVVM/Assets/Plugins/Aspid/MVVM/StarterKit/Unity/Runtime/Binders/AudioSources/OneWayToSource/Mono/AudioSourceToSourceMonoBinder.cs.meta
+++ b/Aspid.MVVM/Assets/Plugins/Aspid/MVVM/StarterKit/Unity/Runtime/Binders/AudioSources/OneWayToSource/Mono/AudioSourceToSourceMonoBinder.cs.meta
@@ -1,0 +1,3 @@
+fileFormatVersion: 2
+guid: e5ec16fb9c4142a4a791e6ac909d7274
+timeCreated: 1770631208

--- a/Aspid.MVVM/Assets/Plugins/Aspid/MVVM/StarterKit/Unity/Runtime/Binders/AudioSources/OutputAudioMixerGroup.meta
+++ b/Aspid.MVVM/Assets/Plugins/Aspid/MVVM/StarterKit/Unity/Runtime/Binders/AudioSources/OutputAudioMixerGroup.meta
@@ -1,0 +1,3 @@
+fileFormatVersion: 2
+guid: 7b304779d54948029053a8e457350dc9
+timeCreated: 1770892837

--- a/Aspid.MVVM/Assets/Plugins/Aspid/MVVM/StarterKit/Unity/Runtime/Binders/AudioSources/OutputAudioMixerGroup/AudioSourceOutputAudioMixerGroupBinder.cs
+++ b/Aspid.MVVM/Assets/Plugins/Aspid/MVVM/StarterKit/Unity/Runtime/Binders/AudioSources/OutputAudioMixerGroup/AudioSourceOutputAudioMixerGroupBinder.cs
@@ -1,0 +1,30 @@
+#nullable enable
+using System;
+using UnityEngine;
+using UnityEngine.Audio;
+
+// ReSharper disable once CheckNamespace
+namespace Aspid.MVVM.StarterKit
+{
+    [Serializable]
+    [BindModeOverride(BindMode.OneWay, BindMode.OneTime, BindMode.OneWayToSource)]
+    public class AudioSourceOutputAudioMixerGroupBinder : TargetBinder<AudioSource>, IBinder<AudioMixerGroup?>, IReverseBinder<AudioMixerGroup?>
+    {
+        public event Action<AudioMixerGroup?>? ValueChanged;
+        
+        public AudioSourceOutputAudioMixerGroupBinder(AudioSource target, BindMode mode = BindMode.OneWay)
+            : base(target, mode)
+        {
+            mode.ThrowExceptionIfTwo();
+        }
+
+        public void SetValue(AudioMixerGroup? value) =>
+            Target.outputAudioMixerGroup = value;
+        
+        protected override void OnBound()
+        {
+            if (Mode is BindMode.OneWayToSource)
+                ValueChanged?.Invoke(Target.outputAudioMixerGroup);
+        }
+    }
+}

--- a/Aspid.MVVM/Assets/Plugins/Aspid/MVVM/StarterKit/Unity/Runtime/Binders/AudioSources/OutputAudioMixerGroup/AudioSourceOutputAudioMixerGroupBinder.cs.meta
+++ b/Aspid.MVVM/Assets/Plugins/Aspid/MVVM/StarterKit/Unity/Runtime/Binders/AudioSources/OutputAudioMixerGroup/AudioSourceOutputAudioMixerGroupBinder.cs.meta
@@ -1,0 +1,3 @@
+fileFormatVersion: 2
+guid: 7798e4f8f0a44fbda9dcd579565bff5f
+timeCreated: 1770880454

--- a/Aspid.MVVM/Assets/Plugins/Aspid/MVVM/StarterKit/Unity/Runtime/Binders/AudioSources/OutputAudioMixerGroup/AudioSourceOutputAudioMixerGroupSwitcherBinder.cs
+++ b/Aspid.MVVM/Assets/Plugins/Aspid/MVVM/StarterKit/Unity/Runtime/Binders/AudioSources/OutputAudioMixerGroup/AudioSourceOutputAudioMixerGroupSwitcherBinder.cs
@@ -1,0 +1,23 @@
+#nullable enable
+using System;
+using UnityEngine;
+using UnityEngine.Audio;
+
+// ReSharper disable once CheckNamespace
+namespace Aspid.MVVM.StarterKit
+{
+    [Serializable]
+    public sealed class AudioSourceOutputAudioMixerGroupSwitcherBinder : SwitcherBinder<AudioSource, AudioMixerGroup?>
+    {
+        public AudioSourceOutputAudioMixerGroupSwitcherBinder(
+            AudioSource target,
+            AudioMixerGroup? trueValue, 
+            AudioMixerGroup? falseValue,
+            BindMode mode = BindMode.OneWay)
+            : base(target, trueValue, falseValue, mode) { }
+
+        protected override void SetValue(AudioMixerGroup? value) =>
+            Target.outputAudioMixerGroup = value;
+    }
+}
+

--- a/Aspid.MVVM/Assets/Plugins/Aspid/MVVM/StarterKit/Unity/Runtime/Binders/AudioSources/OutputAudioMixerGroup/AudioSourceOutputAudioMixerGroupSwitcherBinder.cs.meta
+++ b/Aspid.MVVM/Assets/Plugins/Aspid/MVVM/StarterKit/Unity/Runtime/Binders/AudioSources/OutputAudioMixerGroup/AudioSourceOutputAudioMixerGroupSwitcherBinder.cs.meta
@@ -1,0 +1,3 @@
+fileFormatVersion: 2
+guid: b3bfc4e8d6794267ae44c63eda02eaaf
+timeCreated: 1770892276

--- a/Aspid.MVVM/Assets/Plugins/Aspid/MVVM/StarterKit/Unity/Runtime/Binders/AudioSources/OutputAudioMixerGroup/Mono.meta
+++ b/Aspid.MVVM/Assets/Plugins/Aspid/MVVM/StarterKit/Unity/Runtime/Binders/AudioSources/OutputAudioMixerGroup/Mono.meta
@@ -1,0 +1,3 @@
+fileFormatVersion: 2
+guid: e2c43e62a0a94eaa99a58ac32f2aeaf2
+timeCreated: 1770892881

--- a/Aspid.MVVM/Assets/Plugins/Aspid/MVVM/StarterKit/Unity/Runtime/Binders/AudioSources/OutputAudioMixerGroup/Mono/AudioSourceOutputAudioMixerGroupEnumGroupMonoBinder.cs
+++ b/Aspid.MVVM/Assets/Plugins/Aspid/MVVM/StarterKit/Unity/Runtime/Binders/AudioSources/OutputAudioMixerGroup/Mono/AudioSourceOutputAudioMixerGroupEnumGroupMonoBinder.cs
@@ -1,0 +1,14 @@
+using UnityEngine;
+using UnityEngine.Audio;
+
+// ReSharper disable once CheckNamespace
+namespace Aspid.MVVM.StarterKit
+{
+    [AddBinderContextMenu(typeof(AudioSource), SubPath = "EnumGroup")]
+    [AddComponentMenu("Aspid/MVVM/Binders/Audio/AudioSource/AudioSource Binder – OutputAudioMixerGroup EnumGroup")]
+    public sealed class AudioSourceOutputAudioMixerGroupEnumGroupMonoBinder : EnumGroupMonoBinder<AudioSource, AudioMixerGroup>
+    {
+        protected override void SetValue(AudioSource element, AudioMixerGroup value) =>
+            element.outputAudioMixerGroup = value;
+    }
+}

--- a/Aspid.MVVM/Assets/Plugins/Aspid/MVVM/StarterKit/Unity/Runtime/Binders/AudioSources/OutputAudioMixerGroup/Mono/AudioSourceOutputAudioMixerGroupEnumGroupMonoBinder.cs.meta
+++ b/Aspid.MVVM/Assets/Plugins/Aspid/MVVM/StarterKit/Unity/Runtime/Binders/AudioSources/OutputAudioMixerGroup/Mono/AudioSourceOutputAudioMixerGroupEnumGroupMonoBinder.cs.meta
@@ -1,0 +1,3 @@
+fileFormatVersion: 2
+guid: 9b8c285c3db9482c91004d1b270b3289
+timeCreated: 1770892276

--- a/Aspid.MVVM/Assets/Plugins/Aspid/MVVM/StarterKit/Unity/Runtime/Binders/AudioSources/OutputAudioMixerGroup/Mono/AudioSourceOutputAudioMixerGroupEnumMonoBinder.cs
+++ b/Aspid.MVVM/Assets/Plugins/Aspid/MVVM/StarterKit/Unity/Runtime/Binders/AudioSources/OutputAudioMixerGroup/Mono/AudioSourceOutputAudioMixerGroupEnumMonoBinder.cs
@@ -1,0 +1,14 @@
+using UnityEngine;
+using UnityEngine.Audio;
+
+// ReSharper disable once CheckNamespace
+namespace Aspid.MVVM.StarterKit
+{
+    [AddBinderContextMenu(typeof(AudioSource), SubPath = "Enum")]
+    [AddComponentMenu("Aspid/MVVM/Binders/Audio/AudioSource/AudioSource Binder – OutputAudioMixerGroup Enum")]
+    public sealed class AudioSourceOutputAudioMixerGroupEnumMonoBinder : EnumMonoBinder<AudioSource, AudioMixerGroup>
+    {
+        protected override void SetValue(AudioMixerGroup value) =>
+            CachedComponent.outputAudioMixerGroup = value;
+    }
+}

--- a/Aspid.MVVM/Assets/Plugins/Aspid/MVVM/StarterKit/Unity/Runtime/Binders/AudioSources/OutputAudioMixerGroup/Mono/AudioSourceOutputAudioMixerGroupEnumMonoBinder.cs.meta
+++ b/Aspid.MVVM/Assets/Plugins/Aspid/MVVM/StarterKit/Unity/Runtime/Binders/AudioSources/OutputAudioMixerGroup/Mono/AudioSourceOutputAudioMixerGroupEnumMonoBinder.cs.meta
@@ -1,0 +1,3 @@
+fileFormatVersion: 2
+guid: caa22b157d5c47a8a8921716aff0eb0c
+timeCreated: 1770892275

--- a/Aspid.MVVM/Assets/Plugins/Aspid/MVVM/StarterKit/Unity/Runtime/Binders/AudioSources/OutputAudioMixerGroup/Mono/AudioSourceOutputAudioMixerGroupMonoBinder.cs
+++ b/Aspid.MVVM/Assets/Plugins/Aspid/MVVM/StarterKit/Unity/Runtime/Binders/AudioSources/OutputAudioMixerGroup/Mono/AudioSourceOutputAudioMixerGroupMonoBinder.cs
@@ -1,0 +1,25 @@
+using System;
+using UnityEngine;
+using UnityEngine.Audio;
+
+// ReSharper disable once CheckNamespace
+namespace Aspid.MVVM.StarterKit
+{
+    [AddBinderContextMenu(typeof(AudioSource))]
+    [AddComponentMenu("Aspid/MVVM/Binders/Audio/AudioSource/AudioSource Binder – OutputAudioMixerGroup")]
+    [BindModeOverride(BindMode.OneWay, BindMode.OneTime, BindMode.OneWayToSource)]
+    public partial class AudioSourceOutputAudioMixerGroupMonoBinder : ComponentMonoBinder<AudioSource>, IBinder<AudioMixerGroup>, IReverseBinder<AudioMixerGroup>
+    {
+        public event Action<AudioMixerGroup> ValueChanged;
+        
+        [BinderLog]
+        public void SetValue(AudioMixerGroup value) =>
+            CachedComponent.outputAudioMixerGroup = value;
+        
+        protected override void OnBound()
+        {
+            if (Mode is BindMode.OneWayToSource)
+                ValueChanged?.Invoke(CachedComponent.outputAudioMixerGroup);
+        }
+    }
+}

--- a/Aspid.MVVM/Assets/Plugins/Aspid/MVVM/StarterKit/Unity/Runtime/Binders/AudioSources/OutputAudioMixerGroup/Mono/AudioSourceOutputAudioMixerGroupMonoBinder.cs.meta
+++ b/Aspid.MVVM/Assets/Plugins/Aspid/MVVM/StarterKit/Unity/Runtime/Binders/AudioSources/OutputAudioMixerGroup/Mono/AudioSourceOutputAudioMixerGroupMonoBinder.cs.meta
@@ -1,0 +1,3 @@
+fileFormatVersion: 2
+guid: cffe73c79a3f49538035685ebe3b7726
+timeCreated: 1770880353

--- a/Aspid.MVVM/Assets/Plugins/Aspid/MVVM/StarterKit/Unity/Runtime/Binders/AudioSources/OutputAudioMixerGroup/Mono/AudioSourceOutputAudioMixerGroupSwitcherMonoBinder.cs
+++ b/Aspid.MVVM/Assets/Plugins/Aspid/MVVM/StarterKit/Unity/Runtime/Binders/AudioSources/OutputAudioMixerGroup/Mono/AudioSourceOutputAudioMixerGroupSwitcherMonoBinder.cs
@@ -1,0 +1,14 @@
+using UnityEngine;
+using UnityEngine.Audio;
+
+// ReSharper disable once CheckNamespace
+namespace Aspid.MVVM.StarterKit
+{
+    [AddBinderContextMenu(typeof(AudioSource), SubPath = "Switcher")]
+    [AddComponentMenu("Aspid/MVVM/Binders/Audio/AudioSource/AudioSource Binder – OutputAudioMixerGroup Switcher")]
+    public sealed class AudioSourceOutputAudioMixerGroupSwitcherMonoBinder : SwitcherMonoBinder<AudioSource, AudioMixerGroup>
+    {
+        protected override void SetValue(AudioMixerGroup value) =>
+            CachedComponent.outputAudioMixerGroup = value;
+    }
+}

--- a/Aspid.MVVM/Assets/Plugins/Aspid/MVVM/StarterKit/Unity/Runtime/Binders/AudioSources/OutputAudioMixerGroup/Mono/AudioSourceOutputAudioMixerGroupSwitcherMonoBinder.cs.meta
+++ b/Aspid.MVVM/Assets/Plugins/Aspid/MVVM/StarterKit/Unity/Runtime/Binders/AudioSources/OutputAudioMixerGroup/Mono/AudioSourceOutputAudioMixerGroupSwitcherMonoBinder.cs.meta
@@ -1,0 +1,3 @@
+fileFormatVersion: 2
+guid: 9eeb43f3d1fb491d87c8b2be91558c2d
+timeCreated: 1770892275

--- a/Aspid.MVVM/Assets/Plugins/Aspid/MVVM/StarterKit/Unity/Runtime/Binders/AudioSources/PanStereo.meta
+++ b/Aspid.MVVM/Assets/Plugins/Aspid/MVVM/StarterKit/Unity/Runtime/Binders/AudioSources/PanStereo.meta
@@ -1,0 +1,3 @@
+fileFormatVersion: 2
+guid: 1d824a15b133498dba76b91c117a8333
+timeCreated: 1770892037

--- a/Aspid.MVVM/Assets/Plugins/Aspid/MVVM/StarterKit/Unity/Runtime/Binders/AudioSources/PanStereo/AudioSourcePanStereoBinder.cs
+++ b/Aspid.MVVM/Assets/Plugins/Aspid/MVVM/StarterKit/Unity/Runtime/Binders/AudioSources/PanStereo/AudioSourcePanStereoBinder.cs
@@ -1,0 +1,60 @@
+#nullable enable
+using System;
+using UnityEngine;
+#if UNITY_2023_1_OR_NEWER
+using Converter = Aspid.MVVM.StarterKit.IConverter<float, float>;
+#else
+using Converter = Aspid.MVVM.StarterKit.IConverterFloat;
+#endif
+
+// ReSharper disable once CheckNamespace
+namespace Aspid.MVVM.StarterKit
+{
+    [Serializable]
+    [BindModeOverride(BindMode.OneWay, BindMode.OneTime, BindMode.OneWayToSource)]
+    public class AudioSourcePanStereoBinder : TargetBinder<AudioSource>, INumberBinder, INumberReverseBinder
+    {
+        public event Action<int>? IntValueChanged;
+        public event Action<long>? LongValueChanged;
+        public event Action<float>? FloatValueChanged;
+        public event Action<double>? DoubleValueChanged;
+        
+        [SerializeReferenceDropdown]
+        [SerializeReference] private Converter? _converter;
+        
+        public AudioSourcePanStereoBinder(AudioSource target, BindMode mode)
+            : this(target, converter: null, mode) { }
+        
+        public AudioSourcePanStereoBinder(AudioSource target, Converter? converter = null, BindMode mode = BindMode.OneWay)
+            : base(target, mode)
+        {
+            mode.ThrowExceptionIfTwo();
+            _converter = converter;
+        }
+
+        public void SetValue(int value) => SetValue((float)value);
+
+        public void SetValue(long value) => SetValue((float)value);
+
+        public void SetValue(float value) =>
+            Target.panStereo = GetConvertedValue(value);
+
+        public void SetValue(double value) => SetValue((float)value);
+        
+        protected override void OnBound()
+        {
+            if (Mode is BindMode.OneWayToSource)
+            {
+                var value = GetConvertedValue(Target.panStereo);
+                
+                IntValueChanged?.Invoke((int)value);
+                LongValueChanged?.Invoke((long)value);
+                FloatValueChanged?.Invoke(value);
+                DoubleValueChanged?.Invoke(value);
+            }
+        }
+        
+        private float GetConvertedValue(float value) =>
+            _converter?.Convert(value) ?? value;
+    }
+}

--- a/Aspid.MVVM/Assets/Plugins/Aspid/MVVM/StarterKit/Unity/Runtime/Binders/AudioSources/PanStereo/AudioSourcePanStereoBinder.cs.meta
+++ b/Aspid.MVVM/Assets/Plugins/Aspid/MVVM/StarterKit/Unity/Runtime/Binders/AudioSources/PanStereo/AudioSourcePanStereoBinder.cs.meta
@@ -1,0 +1,3 @@
+fileFormatVersion: 2
+guid: 847f160d35664a17b1080d7fb82e75ef
+timeCreated: 1770880453

--- a/Aspid.MVVM/Assets/Plugins/Aspid/MVVM/StarterKit/Unity/Runtime/Binders/AudioSources/PanStereo/AudioSourcePanStereoSwitcherBinder.cs
+++ b/Aspid.MVVM/Assets/Plugins/Aspid/MVVM/StarterKit/Unity/Runtime/Binders/AudioSources/PanStereo/AudioSourcePanStereoSwitcherBinder.cs
@@ -1,0 +1,40 @@
+#nullable enable
+using System;
+using UnityEngine;
+#if UNITY_2023_1_OR_NEWER
+using Converter = Aspid.MVVM.StarterKit.IConverter<float, float>;
+#else
+using Converter = Aspid.MVVM.StarterKit.IConverterFloat;
+#endif
+
+// ReSharper disable once CheckNamespace
+namespace Aspid.MVVM.StarterKit
+{
+    [Serializable]
+    public sealed class AudioSourcePanStereoSwitcherBinder : SwitcherBinder<AudioSource, float>
+    {
+        [SerializeReferenceDropdown]
+        [SerializeReference] private Converter? _converter;
+        
+        public AudioSourcePanStereoSwitcherBinder(
+            AudioSource target,
+            float trueValue, 
+            float falseValue,
+            BindMode mode)
+            : this(target, trueValue, falseValue, converter: null, mode) { }
+        
+        public AudioSourcePanStereoSwitcherBinder(
+            AudioSource target,
+            float trueValue, 
+            float falseValue,
+            Converter? converter = null,
+            BindMode mode = BindMode.OneWay)
+            : base(target, trueValue, falseValue, mode)
+        {
+            _converter = converter;
+        }
+
+        protected override void SetValue(float value) =>
+            Target.panStereo = _converter?.Convert(value) ?? value;
+    }
+}

--- a/Aspid.MVVM/Assets/Plugins/Aspid/MVVM/StarterKit/Unity/Runtime/Binders/AudioSources/PanStereo/AudioSourcePanStereoSwitcherBinder.cs.meta
+++ b/Aspid.MVVM/Assets/Plugins/Aspid/MVVM/StarterKit/Unity/Runtime/Binders/AudioSources/PanStereo/AudioSourcePanStereoSwitcherBinder.cs.meta
@@ -1,0 +1,3 @@
+fileFormatVersion: 2
+guid: 889e7098d31147af85d0b363e63e4dc2
+timeCreated: 1770880887

--- a/Aspid.MVVM/Assets/Plugins/Aspid/MVVM/StarterKit/Unity/Runtime/Binders/AudioSources/PanStereo/Mono.meta
+++ b/Aspid.MVVM/Assets/Plugins/Aspid/MVVM/StarterKit/Unity/Runtime/Binders/AudioSources/PanStereo/Mono.meta
@@ -1,0 +1,3 @@
+fileFormatVersion: 2
+guid: 7e8affb896f6403983a97c82d93e6368
+timeCreated: 1770892893

--- a/Aspid.MVVM/Assets/Plugins/Aspid/MVVM/StarterKit/Unity/Runtime/Binders/AudioSources/PanStereo/Mono/AudioSourcePanStereoEnumGroupMonoBinder.cs
+++ b/Aspid.MVVM/Assets/Plugins/Aspid/MVVM/StarterKit/Unity/Runtime/Binders/AudioSources/PanStereo/Mono/AudioSourcePanStereoEnumGroupMonoBinder.cs
@@ -1,0 +1,30 @@
+using UnityEngine;
+#if UNITY_2023_1_OR_NEWER
+using Converter = Aspid.MVVM.StarterKit.IConverter<float, float>;
+#else
+using Converter = Aspid.MVVM.StarterKit.IConverterFloat;
+#endif
+
+// ReSharper disable once CheckNamespace
+namespace Aspid.MVVM.StarterKit
+{
+    [AddBinderContextMenu(typeof(AudioSource), SubPath = "EnumGroup")]
+    [AddComponentMenu("Aspid/MVVM/Binders/Audio/AudioSource/AudioSource Binder – PanStereo EnumGroup")]
+    public sealed class AudioSourcePanStereoEnumGroupMonoBinder : EnumGroupMonoBinder<AudioSource>
+    {
+        [SerializeField] [Range(-1, 1)] private float _defaultValue;
+        [SerializeField] [Range(-1, 1)] private float _selectedValue;
+        
+        [SerializeReferenceDropdown]
+        [SerializeReference] private Converter _defaultConverter;
+        
+        [SerializeReferenceDropdown]
+        [SerializeReference] private Converter _selectedConverter;
+        
+        protected override void SetDefaultValue(AudioSource element) =>
+            element.panStereo = _defaultConverter?.Convert(_defaultValue) ?? _defaultValue;
+
+        protected override void SetSelectedValue(AudioSource element) =>
+            element.panStereo = _selectedConverter?.Convert(_selectedValue) ?? _selectedValue;
+    }
+}

--- a/Aspid.MVVM/Assets/Plugins/Aspid/MVVM/StarterKit/Unity/Runtime/Binders/AudioSources/PanStereo/Mono/AudioSourcePanStereoEnumGroupMonoBinder.cs.meta
+++ b/Aspid.MVVM/Assets/Plugins/Aspid/MVVM/StarterKit/Unity/Runtime/Binders/AudioSources/PanStereo/Mono/AudioSourcePanStereoEnumGroupMonoBinder.cs.meta
@@ -1,0 +1,3 @@
+fileFormatVersion: 2
+guid: 509b1562397840f6ad3b9df289e60506
+timeCreated: 1770880834

--- a/Aspid.MVVM/Assets/Plugins/Aspid/MVVM/StarterKit/Unity/Runtime/Binders/AudioSources/PanStereo/Mono/AudioSourcePanStereoEnumMonoBinder.cs
+++ b/Aspid.MVVM/Assets/Plugins/Aspid/MVVM/StarterKit/Unity/Runtime/Binders/AudioSources/PanStereo/Mono/AudioSourcePanStereoEnumMonoBinder.cs
@@ -1,0 +1,22 @@
+using UnityEngine;
+#if UNITY_2023_1_OR_NEWER
+using Converter = Aspid.MVVM.StarterKit.IConverter<float, float>;
+#else
+using Converter = Aspid.MVVM.StarterKit.IConverterFloat;
+#endif
+
+// ReSharper disable once CheckNamespace
+namespace Aspid.MVVM.StarterKit
+{
+    [AddBinderContextMenu(typeof(AudioSource), SubPath = "Enum")]
+    [AddComponentMenu("Aspid/MVVM/Binders/Audio/AudioSource/AudioSource Binder – PanStereo Enum")]
+    public sealed class AudioSourcePanStereoEnumMonoBinder : EnumMonoBinder<AudioSource, float>
+    {
+        [SerializeReferenceDropdown]
+        [SerializeReference] private Converter _converter;
+        
+        protected override void SetValue(float value) =>
+            CachedComponent.panStereo = _converter?.Convert(value) ?? value;
+    }
+}
+

--- a/Aspid.MVVM/Assets/Plugins/Aspid/MVVM/StarterKit/Unity/Runtime/Binders/AudioSources/PanStereo/Mono/AudioSourcePanStereoEnumMonoBinder.cs.meta
+++ b/Aspid.MVVM/Assets/Plugins/Aspid/MVVM/StarterKit/Unity/Runtime/Binders/AudioSources/PanStereo/Mono/AudioSourcePanStereoEnumMonoBinder.cs.meta
@@ -1,0 +1,3 @@
+fileFormatVersion: 2
+guid: 9dde4b715e2147c5b8c5278693059907
+timeCreated: 1770881429

--- a/Aspid.MVVM/Assets/Plugins/Aspid/MVVM/StarterKit/Unity/Runtime/Binders/AudioSources/PanStereo/Mono/AudioSourcePanStereoMonoBinder.cs
+++ b/Aspid.MVVM/Assets/Plugins/Aspid/MVVM/StarterKit/Unity/Runtime/Binders/AudioSources/PanStereo/Mono/AudioSourcePanStereoMonoBinder.cs
@@ -1,0 +1,57 @@
+using System;
+using UnityEngine;
+#if UNITY_2023_1_OR_NEWER
+using Converter = Aspid.MVVM.StarterKit.IConverter<float, float>;
+#else
+using Converter = Aspid.MVVM.StarterKit.IConverterFloat;
+#endif
+
+// ReSharper disable once CheckNamespace
+namespace Aspid.MVVM.StarterKit
+{
+    [AddBinderContextMenu(typeof(AudioSource))]
+    [AddComponentMenu("Aspid/MVVM/Binders/Audio/AudioSource/AudioSource Binder – PanStereo")]
+    [BindModeOverride(BindMode.OneWay, BindMode.OneTime, BindMode.OneWayToSource)]
+    public partial class AudioSourcePanStereoMonoBinder : ComponentMonoBinder<AudioSource>, INumberBinder, INumberReverseBinder
+    {
+        public event Action<int> IntValueChanged;
+        public event Action<long> LongValueChanged;
+        public event Action<float> FloatValueChanged;
+        public event Action<double> DoubleValueChanged;
+        
+        [SerializeReferenceDropdown]
+        [SerializeReference] private Converter _converter;
+
+        [BinderLog]
+        public void SetValue(float value) =>
+            CachedComponent.panStereo = GetConvertedValue(value);
+
+        [BinderLog]
+        public void SetValue(int value) =>
+            SetValue((float)value);
+
+        [BinderLog]
+        public void SetValue(long value) =>
+            SetValue((float)value);
+
+        [BinderLog]
+        public void SetValue(double value) =>
+            SetValue((float)value);
+        
+        protected override void OnBound()
+        {
+            if (Mode is BindMode.OneWayToSource)
+            {
+                var value = GetConvertedValue(CachedComponent.panStereo);
+                
+                IntValueChanged?.Invoke((int)value);
+                LongValueChanged?.Invoke((long)value);
+                FloatValueChanged?.Invoke(value);
+                DoubleValueChanged?.Invoke(value);
+            }
+        }
+        
+        private float GetConvertedValue(float value) =>
+            _converter?.Convert(value) ?? value;
+    }
+}

--- a/Aspid.MVVM/Assets/Plugins/Aspid/MVVM/StarterKit/Unity/Runtime/Binders/AudioSources/PanStereo/Mono/AudioSourcePanStereoMonoBinder.cs.meta
+++ b/Aspid.MVVM/Assets/Plugins/Aspid/MVVM/StarterKit/Unity/Runtime/Binders/AudioSources/PanStereo/Mono/AudioSourcePanStereoMonoBinder.cs.meta
@@ -1,0 +1,3 @@
+fileFormatVersion: 2
+guid: c6e72599249e49e281b9287efcd923bc
+timeCreated: 1770880353

--- a/Aspid.MVVM/Assets/Plugins/Aspid/MVVM/StarterKit/Unity/Runtime/Binders/AudioSources/PanStereo/Mono/AudioSourcePanStereoSwitcherMonoBinder.cs
+++ b/Aspid.MVVM/Assets/Plugins/Aspid/MVVM/StarterKit/Unity/Runtime/Binders/AudioSources/PanStereo/Mono/AudioSourcePanStereoSwitcherMonoBinder.cs
@@ -1,0 +1,21 @@
+using UnityEngine;
+#if UNITY_2023_1_OR_NEWER
+using Converter = Aspid.MVVM.StarterKit.IConverter<float, float>;
+#else
+using Converter = Aspid.MVVM.StarterKit.IConverterFloat;
+#endif
+
+// ReSharper disable once CheckNamespace
+namespace Aspid.MVVM.StarterKit
+{
+    [AddBinderContextMenu(typeof(AudioSource), SubPath = "Switcher")]
+    [AddComponentMenu("Aspid/MVVM/Binders/Audio/AudioSource/AudioSource Binder – PanStereo Switcher")]
+    public sealed class AudioSourcePanStereoSwitcherMonoBinder : SwitcherMonoBinder<AudioSource, float>
+    {
+        [SerializeReferenceDropdown]
+        [SerializeReference] private Converter _converter;
+        
+        protected override void SetValue(float value) =>
+            CachedComponent.panStereo = _converter?.Convert(value) ?? value;
+    }
+}

--- a/Aspid.MVVM/Assets/Plugins/Aspid/MVVM/StarterKit/Unity/Runtime/Binders/AudioSources/PanStereo/Mono/AudioSourcePanStereoSwitcherMonoBinder.cs.meta
+++ b/Aspid.MVVM/Assets/Plugins/Aspid/MVVM/StarterKit/Unity/Runtime/Binders/AudioSources/PanStereo/Mono/AudioSourcePanStereoSwitcherMonoBinder.cs.meta
@@ -1,0 +1,3 @@
+fileFormatVersion: 2
+guid: cfc69f6cbe5d42af81942e6077385029
+timeCreated: 1770880834

--- a/Aspid.MVVM/Assets/Plugins/Aspid/MVVM/StarterKit/Unity/Runtime/Binders/AudioSources/Pitch.meta
+++ b/Aspid.MVVM/Assets/Plugins/Aspid/MVVM/StarterKit/Unity/Runtime/Binders/AudioSources/Pitch.meta
@@ -1,0 +1,3 @@
+fileFormatVersion: 2
+guid: 66405da8bce04f4b866cfcf12b4448d6
+timeCreated: 1770892051

--- a/Aspid.MVVM/Assets/Plugins/Aspid/MVVM/StarterKit/Unity/Runtime/Binders/AudioSources/Pitch/AudioSourcePitchBinder.cs
+++ b/Aspid.MVVM/Assets/Plugins/Aspid/MVVM/StarterKit/Unity/Runtime/Binders/AudioSources/Pitch/AudioSourcePitchBinder.cs
@@ -1,0 +1,63 @@
+#nullable enable
+using System;
+using UnityEngine;
+#if UNITY_2023_1_OR_NEWER
+using Converter = Aspid.MVVM.StarterKit.IConverter<float, float>;
+#else
+using Converter = Aspid.MVVM.StarterKit.IConverterFloat;
+#endif
+
+// ReSharper disable once CheckNamespace
+namespace Aspid.MVVM.StarterKit
+{
+    [Serializable]
+    [BindModeOverride(BindMode.OneWay, BindMode.OneTime, BindMode.OneWayToSource)]
+    public class AudioSourcePitchBinder : TargetBinder<AudioSource>, INumberBinder, INumberReverseBinder
+    {
+        public event Action<int>? IntValueChanged;
+        public event Action<long>? LongValueChanged;
+        public event Action<float>? FloatValueChanged;
+        public event Action<double>? DoubleValueChanged;
+        
+        [SerializeReferenceDropdown]
+        [SerializeReference] private Converter? _converter;
+        
+        public AudioSourcePitchBinder(AudioSource target, BindMode mode)
+            : this(target, converter: null, mode) { }
+        
+        public AudioSourcePitchBinder(AudioSource target, Converter? converter = null, BindMode mode = BindMode.OneWay)
+            : base(target, mode)
+        {
+            mode.ThrowExceptionIfTwo();
+            _converter = converter;
+        }
+
+        public void SetValue(int value) => 
+            SetValue((float)value);
+
+        public void SetValue(long value) => 
+            SetValue((float)value);
+
+        public void SetValue(float value) =>
+            Target.pitch = GetConvertedValue(value);
+
+        public void SetValue(double value) => 
+            SetValue((float)value);
+        
+        protected override void OnBound()
+        {
+            if (Mode is BindMode.OneWayToSource)
+            {
+                var value = GetConvertedValue(Target.pitch);
+                
+                IntValueChanged?.Invoke((int)value);
+                LongValueChanged?.Invoke((long)value);
+                FloatValueChanged?.Invoke(value);
+                DoubleValueChanged?.Invoke(value);
+            }
+        }
+        
+        private float GetConvertedValue(float value) =>
+            _converter?.Convert(value) ?? value;
+    }
+}

--- a/Aspid.MVVM/Assets/Plugins/Aspid/MVVM/StarterKit/Unity/Runtime/Binders/AudioSources/Pitch/AudioSourcePitchBinder.cs.meta
+++ b/Aspid.MVVM/Assets/Plugins/Aspid/MVVM/StarterKit/Unity/Runtime/Binders/AudioSources/Pitch/AudioSourcePitchBinder.cs.meta
@@ -1,0 +1,3 @@
+fileFormatVersion: 2
+guid: 292bc7f4cb124fc79815c8d15ab6d6a1
+timeCreated: 1770880401

--- a/Aspid.MVVM/Assets/Plugins/Aspid/MVVM/StarterKit/Unity/Runtime/Binders/AudioSources/Pitch/AudioSourcePitchSwitcherBinder.cs
+++ b/Aspid.MVVM/Assets/Plugins/Aspid/MVVM/StarterKit/Unity/Runtime/Binders/AudioSources/Pitch/AudioSourcePitchSwitcherBinder.cs
@@ -1,0 +1,40 @@
+#nullable enable
+using System;
+using UnityEngine;
+#if UNITY_2023_1_OR_NEWER
+using Converter = Aspid.MVVM.StarterKit.IConverter<float, float>;
+#else
+using Converter = Aspid.MVVM.StarterKit.IConverterFloat;
+#endif
+
+// ReSharper disable once CheckNamespace
+namespace Aspid.MVVM.StarterKit
+{
+    [Serializable]
+    public sealed class AudioSourcePitchSwitcherBinder : SwitcherBinder<AudioSource, float>
+    {
+        [SerializeReferenceDropdown]
+        [SerializeReference] private Converter? _converter;
+        
+        public AudioSourcePitchSwitcherBinder(
+            AudioSource target,
+            float trueValue, 
+            float falseValue,
+            BindMode mode)
+            : this(target, trueValue, falseValue, converter: null, mode) { }
+        
+        public AudioSourcePitchSwitcherBinder(
+            AudioSource target,
+            float trueValue, 
+            float falseValue,
+            Converter? converter = null,
+            BindMode mode = BindMode.OneWay)
+            : base(target, trueValue, falseValue, mode)
+        {
+            _converter = converter;
+        }
+
+        protected override void SetValue(float value) =>
+            Target.pitch = _converter?.Convert(value) ?? value;
+    }
+}

--- a/Aspid.MVVM/Assets/Plugins/Aspid/MVVM/StarterKit/Unity/Runtime/Binders/AudioSources/Pitch/AudioSourcePitchSwitcherBinder.cs.meta
+++ b/Aspid.MVVM/Assets/Plugins/Aspid/MVVM/StarterKit/Unity/Runtime/Binders/AudioSources/Pitch/AudioSourcePitchSwitcherBinder.cs.meta
@@ -1,0 +1,3 @@
+fileFormatVersion: 2
+guid: 1268ca85140147faa1894701888db37d
+timeCreated: 1770880401

--- a/Aspid.MVVM/Assets/Plugins/Aspid/MVVM/StarterKit/Unity/Runtime/Binders/AudioSources/Pitch/Mono.meta
+++ b/Aspid.MVVM/Assets/Plugins/Aspid/MVVM/StarterKit/Unity/Runtime/Binders/AudioSources/Pitch/Mono.meta
@@ -1,0 +1,3 @@
+fileFormatVersion: 2
+guid: a13ceb9481974e6da359bbe81c4bf93e
+timeCreated: 1770892892

--- a/Aspid.MVVM/Assets/Plugins/Aspid/MVVM/StarterKit/Unity/Runtime/Binders/AudioSources/Pitch/Mono/AudioSourcePitchEnumGroupMonoBinder.cs
+++ b/Aspid.MVVM/Assets/Plugins/Aspid/MVVM/StarterKit/Unity/Runtime/Binders/AudioSources/Pitch/Mono/AudioSourcePitchEnumGroupMonoBinder.cs
@@ -1,0 +1,30 @@
+using UnityEngine;
+#if UNITY_2023_1_OR_NEWER
+using Converter = Aspid.MVVM.StarterKit.IConverter<float, float>;
+#else
+using Converter = Aspid.MVVM.StarterKit.IConverterFloat;
+#endif
+
+// ReSharper disable once CheckNamespace
+namespace Aspid.MVVM.StarterKit
+{
+    [AddBinderContextMenu(typeof(AudioSource), SubPath = "EnumGroup")]
+    [AddComponentMenu("Aspid/MVVM/Binders/Audio/AudioSource/AudioSource Binder – Pitch EnumGroup")]
+    public sealed class AudioSourcePitchEnumGroupMonoBinder : EnumGroupMonoBinder<AudioSource>
+    {
+        [SerializeField] [Range(-3f, 3)] private float _defaultValue;
+        [SerializeField] [Range(-3f, 3)] private float _selectedValue;
+        
+        [SerializeReferenceDropdown]
+        [SerializeReference] private Converter _defaultConverter;
+        
+        [SerializeReferenceDropdown]
+        [SerializeReference] private Converter _selectedConverter;
+
+        protected override void SetDefaultValue(AudioSource element) =>
+            element.pitch = _defaultConverter?.Convert(_defaultValue) ?? _defaultValue;
+
+        protected override void SetSelectedValue(AudioSource element) =>
+            element.pitch = _selectedConverter?.Convert(_selectedValue) ?? _selectedValue;
+    }
+}

--- a/Aspid.MVVM/Assets/Plugins/Aspid/MVVM/StarterKit/Unity/Runtime/Binders/AudioSources/Pitch/Mono/AudioSourcePitchEnumGroupMonoBinder.cs.meta
+++ b/Aspid.MVVM/Assets/Plugins/Aspid/MVVM/StarterKit/Unity/Runtime/Binders/AudioSources/Pitch/Mono/AudioSourcePitchEnumGroupMonoBinder.cs.meta
@@ -1,0 +1,3 @@
+fileFormatVersion: 2
+guid: a594c0b5199d4ca8ac3bbac7a1983ce5
+timeCreated: 1770576989

--- a/Aspid.MVVM/Assets/Plugins/Aspid/MVVM/StarterKit/Unity/Runtime/Binders/AudioSources/Pitch/Mono/AudioSourcePitchEnumMonoBinder.cs
+++ b/Aspid.MVVM/Assets/Plugins/Aspid/MVVM/StarterKit/Unity/Runtime/Binders/AudioSources/Pitch/Mono/AudioSourcePitchEnumMonoBinder.cs
@@ -1,0 +1,21 @@
+using UnityEngine;
+#if UNITY_2023_1_OR_NEWER
+using Converter = Aspid.MVVM.StarterKit.IConverter<float, float>;
+#else
+using Converter = Aspid.MVVM.StarterKit.IConverterFloat;
+#endif
+
+// ReSharper disable once CheckNamespace
+namespace Aspid.MVVM.StarterKit
+{
+    [AddBinderContextMenu(typeof(AudioSource), SubPath = "Enum")]
+    [AddComponentMenu("Aspid/MVVM/Binders/Audio/AudioSource/AudioSource Binder – Pitch Enum")]
+    public sealed class AudioSourcePitchEnumMonoBinder : EnumMonoBinder<AudioSource, float>
+    {
+        [SerializeReferenceDropdown]
+        [SerializeReference] private Converter _converter;
+        
+        protected override void SetValue(float value) =>
+            CachedComponent.pitch = _converter?.Convert(value) ?? value;
+    }
+}

--- a/Aspid.MVVM/Assets/Plugins/Aspid/MVVM/StarterKit/Unity/Runtime/Binders/AudioSources/Pitch/Mono/AudioSourcePitchEnumMonoBinder.cs.meta
+++ b/Aspid.MVVM/Assets/Plugins/Aspid/MVVM/StarterKit/Unity/Runtime/Binders/AudioSources/Pitch/Mono/AudioSourcePitchEnumMonoBinder.cs.meta
@@ -1,0 +1,3 @@
+fileFormatVersion: 2
+guid: b9d3ab3ce8d44b469e1549309fafe154
+timeCreated: 1770576989

--- a/Aspid.MVVM/Assets/Plugins/Aspid/MVVM/StarterKit/Unity/Runtime/Binders/AudioSources/Pitch/Mono/AudioSourcePitchMonoBinder.cs
+++ b/Aspid.MVVM/Assets/Plugins/Aspid/MVVM/StarterKit/Unity/Runtime/Binders/AudioSources/Pitch/Mono/AudioSourcePitchMonoBinder.cs
@@ -1,0 +1,57 @@
+using System;
+using UnityEngine;
+#if UNITY_2023_1_OR_NEWER
+using Converter = Aspid.MVVM.StarterKit.IConverter<float, float>;
+#else
+using Converter = Aspid.MVVM.StarterKit.IConverterFloat;
+#endif
+
+// ReSharper disable once CheckNamespace
+namespace Aspid.MVVM.StarterKit
+{
+    [AddBinderContextMenu(typeof(AudioSource))]
+    [AddComponentMenu("Aspid/MVVM/Binders/Audio/AudioSource/AudioSource Binder – Pitch")]
+    [BindModeOverride(BindMode.OneWay, BindMode.OneTime, BindMode.OneWayToSource)]
+    public partial class AudioSourcePitchMonoBinder : ComponentMonoBinder<AudioSource>, INumberBinder, INumberReverseBinder
+    {
+        public event Action<int> IntValueChanged;
+        public event Action<long> LongValueChanged;
+        public event Action<float> FloatValueChanged;
+        public event Action<double> DoubleValueChanged;
+        
+        [SerializeReferenceDropdown]
+        [SerializeReference] private Converter _converter;
+
+        [BinderLog]
+        public void SetValue(float value) =>
+            CachedComponent.pitch = GetConvertedValue(value);
+
+        [BinderLog]
+        public void SetValue(int value) =>
+            SetValue((float)value);
+
+        [BinderLog]
+        public void SetValue(long value) =>
+            SetValue((float)value);
+
+        [BinderLog]
+        public void SetValue(double value) =>
+            SetValue((float)value);
+        
+        protected override void OnBound()
+        {
+            if (Mode is BindMode.OneWayToSource)
+            {
+                var value = GetConvertedValue(CachedComponent.pitch);
+                
+                IntValueChanged?.Invoke((int)value);
+                LongValueChanged?.Invoke((long)value);
+                FloatValueChanged?.Invoke(value);
+                DoubleValueChanged?.Invoke(value);
+            }
+        }
+        
+        private float GetConvertedValue(float value) =>
+            _converter?.Convert(value) ?? value;
+    }
+}

--- a/Aspid.MVVM/Assets/Plugins/Aspid/MVVM/StarterKit/Unity/Runtime/Binders/AudioSources/Pitch/Mono/AudioSourcePitchMonoBinder.cs.meta
+++ b/Aspid.MVVM/Assets/Plugins/Aspid/MVVM/StarterKit/Unity/Runtime/Binders/AudioSources/Pitch/Mono/AudioSourcePitchMonoBinder.cs.meta
@@ -1,0 +1,3 @@
+fileFormatVersion: 2
+guid: 5b8d523cf1f142c58928727af3357907
+timeCreated: 1770576989

--- a/Aspid.MVVM/Assets/Plugins/Aspid/MVVM/StarterKit/Unity/Runtime/Binders/AudioSources/Pitch/Mono/AudioSourcePitchSwitcherMonoBinder.cs
+++ b/Aspid.MVVM/Assets/Plugins/Aspid/MVVM/StarterKit/Unity/Runtime/Binders/AudioSources/Pitch/Mono/AudioSourcePitchSwitcherMonoBinder.cs
@@ -1,0 +1,21 @@
+using UnityEngine;
+#if UNITY_2023_1_OR_NEWER
+using Converter = Aspid.MVVM.StarterKit.IConverter<float, float>;
+#else
+using Converter = Aspid.MVVM.StarterKit.IConverterFloat;
+#endif
+
+// ReSharper disable once CheckNamespace
+namespace Aspid.MVVM.StarterKit
+{
+    [AddBinderContextMenu(typeof(AudioSource), SubPath = "Switcher")]
+    [AddComponentMenu("Aspid/MVVM/Binders/Audio/AudioSource/AudioSource Binder – Pitch Switcher")]
+    public sealed class AudioSourcePitchSwitcherMonoBinder : SwitcherMonoBinder<AudioSource, float>
+    {     
+        [SerializeReferenceDropdown]
+        [SerializeReference] private Converter _converter;
+
+        protected override void SetValue(float value) =>
+            CachedComponent.pitch = _converter?.Convert(value) ?? value;
+    }
+}

--- a/Aspid.MVVM/Assets/Plugins/Aspid/MVVM/StarterKit/Unity/Runtime/Binders/AudioSources/Pitch/Mono/AudioSourcePitchSwitcherMonoBinder.cs.meta
+++ b/Aspid.MVVM/Assets/Plugins/Aspid/MVVM/StarterKit/Unity/Runtime/Binders/AudioSources/Pitch/Mono/AudioSourcePitchSwitcherMonoBinder.cs.meta
@@ -1,0 +1,3 @@
+fileFormatVersion: 2
+guid: 1fadda757f684cdb960bdf37b02c297f
+timeCreated: 1770576989

--- a/Aspid.MVVM/Assets/Plugins/Aspid/MVVM/StarterKit/Unity/Runtime/Binders/AudioSources/Priority.meta
+++ b/Aspid.MVVM/Assets/Plugins/Aspid/MVVM/StarterKit/Unity/Runtime/Binders/AudioSources/Priority.meta
@@ -1,0 +1,3 @@
+fileFormatVersion: 2
+guid: 4aebad54135d4df79d9070f8ce3a51d2
+timeCreated: 1770892123

--- a/Aspid.MVVM/Assets/Plugins/Aspid/MVVM/StarterKit/Unity/Runtime/Binders/AudioSources/Priority/AudioSourcePriorityBinder.cs
+++ b/Aspid.MVVM/Assets/Plugins/Aspid/MVVM/StarterKit/Unity/Runtime/Binders/AudioSources/Priority/AudioSourcePriorityBinder.cs
@@ -1,0 +1,63 @@
+#nullable enable
+using System;
+using UnityEngine;
+#if UNITY_2023_1_OR_NEWER
+using Converter = Aspid.MVVM.StarterKit.IConverter<int, int>;
+#else
+using Converter = Aspid.MVVM.StarterKit.IConverterInt;
+#endif
+
+// ReSharper disable once CheckNamespace
+namespace Aspid.MVVM.StarterKit
+{
+    [Serializable]
+    [BindModeOverride(BindMode.OneWay, BindMode.OneTime, BindMode.OneWayToSource)]
+    public class AudioSourcePriorityBinder : TargetBinder<AudioSource>, INumberBinder, INumberReverseBinder
+    {
+        public event Action<int>? IntValueChanged;
+        public event Action<long>? LongValueChanged;
+        public event Action<float>? FloatValueChanged;
+        public event Action<double>? DoubleValueChanged;
+        
+        [SerializeReferenceDropdown]
+        [SerializeReference] private Converter? _converter;
+        
+        public AudioSourcePriorityBinder(AudioSource target, BindMode mode)
+            : this(target, converter: null, mode) { }
+        
+        public AudioSourcePriorityBinder(AudioSource target, Converter? converter = null, BindMode mode = BindMode.OneWay)
+            : base(target, mode)
+        {
+            mode.ThrowExceptionIfTwo();
+            _converter = converter;
+        }
+
+        public void SetValue(int value) =>
+            Target.priority = GetConvertedValue(value);
+
+        public void SetValue(float value) =>
+            SetValue((int)value);
+
+        public void SetValue(long value) =>
+            SetValue((int)value);
+
+        public void SetValue(double value) => 
+            SetValue((int)value);
+        
+        protected override void OnBound()
+        {
+            if (Mode is BindMode.OneWayToSource)
+            {
+                var value = GetConvertedValue(Target.priority);
+                
+                IntValueChanged?.Invoke(value);
+                LongValueChanged?.Invoke(value);
+                FloatValueChanged?.Invoke(value);
+                DoubleValueChanged?.Invoke(value);
+            }
+        }
+        
+        private int GetConvertedValue(int value) =>
+            _converter?.Convert(value) ?? value;
+    }
+}

--- a/Aspid.MVVM/Assets/Plugins/Aspid/MVVM/StarterKit/Unity/Runtime/Binders/AudioSources/Priority/AudioSourcePriorityBinder.cs.meta
+++ b/Aspid.MVVM/Assets/Plugins/Aspid/MVVM/StarterKit/Unity/Runtime/Binders/AudioSources/Priority/AudioSourcePriorityBinder.cs.meta
@@ -1,0 +1,3 @@
+fileFormatVersion: 2
+guid: b9da4764312a48958ebeb8b6b3ea176c
+timeCreated: 1770880402

--- a/Aspid.MVVM/Assets/Plugins/Aspid/MVVM/StarterKit/Unity/Runtime/Binders/AudioSources/Priority/AudioSourcePrioritySwitcherBinder.cs
+++ b/Aspid.MVVM/Assets/Plugins/Aspid/MVVM/StarterKit/Unity/Runtime/Binders/AudioSources/Priority/AudioSourcePrioritySwitcherBinder.cs
@@ -1,0 +1,40 @@
+#nullable enable
+using System;
+using UnityEngine;
+#if UNITY_2023_1_OR_NEWER
+using Converter = Aspid.MVVM.StarterKit.IConverter<int, int>;
+#else
+using Converter = Aspid.MVVM.StarterKit.IConverterInt;
+#endif
+
+// ReSharper disable once CheckNamespace
+namespace Aspid.MVVM.StarterKit
+{
+    [Serializable]
+    public sealed class AudioSourcePrioritySwitcherBinder : SwitcherBinder<AudioSource, int>
+    {
+        [SerializeReferenceDropdown]
+        [SerializeReference] private Converter? _converter;
+        
+        public AudioSourcePrioritySwitcherBinder(
+            AudioSource target,
+            int trueValue, 
+            int falseValue,
+            BindMode mode)
+            : this(target, trueValue, falseValue, converter: null, mode) { }
+        
+        public AudioSourcePrioritySwitcherBinder(
+            AudioSource target,
+            int trueValue, 
+            int falseValue,
+            Converter? converter = null,
+            BindMode mode = BindMode.OneWay)
+            : base(target, trueValue, falseValue, mode)
+        {
+            _converter = converter;
+        }
+
+        protected override void SetValue(int value) =>
+            Target.priority = _converter?.Convert(value) ?? value;
+    }
+}

--- a/Aspid.MVVM/Assets/Plugins/Aspid/MVVM/StarterKit/Unity/Runtime/Binders/AudioSources/Priority/AudioSourcePrioritySwitcherBinder.cs.meta
+++ b/Aspid.MVVM/Assets/Plugins/Aspid/MVVM/StarterKit/Unity/Runtime/Binders/AudioSources/Priority/AudioSourcePrioritySwitcherBinder.cs.meta
@@ -1,0 +1,3 @@
+fileFormatVersion: 2
+guid: 24a0e364bc884a8d8ddfcba6c4162e97
+timeCreated: 1770880402

--- a/Aspid.MVVM/Assets/Plugins/Aspid/MVVM/StarterKit/Unity/Runtime/Binders/AudioSources/Priority/Mono.meta
+++ b/Aspid.MVVM/Assets/Plugins/Aspid/MVVM/StarterKit/Unity/Runtime/Binders/AudioSources/Priority/Mono.meta
@@ -1,0 +1,3 @@
+fileFormatVersion: 2
+guid: 0e2fb9652ab74fddb42561efb7124399
+timeCreated: 1770892891

--- a/Aspid.MVVM/Assets/Plugins/Aspid/MVVM/StarterKit/Unity/Runtime/Binders/AudioSources/Priority/Mono/AudioSourcePriorityEnumGroupMonoBinder.cs
+++ b/Aspid.MVVM/Assets/Plugins/Aspid/MVVM/StarterKit/Unity/Runtime/Binders/AudioSources/Priority/Mono/AudioSourcePriorityEnumGroupMonoBinder.cs
@@ -1,0 +1,30 @@
+using UnityEngine;
+#if UNITY_2023_1_OR_NEWER
+using Converter = Aspid.MVVM.StarterKit.IConverter<int, int>;
+#else
+using Converter = Aspid.MVVM.StarterKit.IConverterInt;
+#endif
+
+// ReSharper disable once CheckNamespace
+namespace Aspid.MVVM.StarterKit
+{
+    [AddBinderContextMenu(typeof(AudioSource), SubPath = "EnumGroup")]
+    [AddComponentMenu("Aspid/MVVM/Binders/Audio/AudioSource/AudioSource Binder – Priority EnumGroup")]
+    public sealed class AudioSourcePriorityEnumGroupMonoBinder : EnumGroupMonoBinder<AudioSource>
+    {
+        [SerializeField] [Range(0, 256)] private int _defaultValue;
+        [SerializeField] [Range(0, 256)] private int _selectedValue;
+        
+        [SerializeReferenceDropdown]
+        [SerializeReference] private Converter _defaultConverter;
+        
+        [SerializeReferenceDropdown]
+        [SerializeReference] private Converter _selectedConverter;
+
+        protected override void SetDefaultValue(AudioSource element) =>
+            element.priority = _defaultConverter?.Convert(_defaultValue) ?? _defaultValue;
+
+        protected override void SetSelectedValue(AudioSource element) =>
+            element.priority = _selectedConverter?.Convert(_selectedValue) ?? _selectedValue;
+    }
+}

--- a/Aspid.MVVM/Assets/Plugins/Aspid/MVVM/StarterKit/Unity/Runtime/Binders/AudioSources/Priority/Mono/AudioSourcePriorityEnumGroupMonoBinder.cs.meta
+++ b/Aspid.MVVM/Assets/Plugins/Aspid/MVVM/StarterKit/Unity/Runtime/Binders/AudioSources/Priority/Mono/AudioSourcePriorityEnumGroupMonoBinder.cs.meta
@@ -1,0 +1,3 @@
+fileFormatVersion: 2
+guid: e64f1d1971fd455ebc88e3bc0d11ac4f
+timeCreated: 1770577045

--- a/Aspid.MVVM/Assets/Plugins/Aspid/MVVM/StarterKit/Unity/Runtime/Binders/AudioSources/Priority/Mono/AudioSourcePriorityEnumMonoBinder.cs
+++ b/Aspid.MVVM/Assets/Plugins/Aspid/MVVM/StarterKit/Unity/Runtime/Binders/AudioSources/Priority/Mono/AudioSourcePriorityEnumMonoBinder.cs
@@ -1,0 +1,21 @@
+using UnityEngine;
+#if UNITY_2023_1_OR_NEWER
+using Converter = Aspid.MVVM.StarterKit.IConverter<int, int>;
+#else
+using Converter = Aspid.MVVM.StarterKit.IConverterInt;
+#endif
+
+// ReSharper disable once CheckNamespace
+namespace Aspid.MVVM.StarterKit
+{
+    [AddBinderContextMenu(typeof(AudioSource), SubPath = "Enum")]
+    [AddComponentMenu("Aspid/MVVM/Binders/Audio/AudioSource/AudioSource Binder – Priority Enum")]
+    public sealed class AudioSourcePriorityEnumMonoBinder : EnumMonoBinder<AudioSource, int>
+    {
+        [SerializeReferenceDropdown]
+        [SerializeReference] private Converter _converter;
+        
+        protected override void SetValue(int value) =>
+            CachedComponent.priority = _converter?.Convert(value) ?? value;
+    }
+}

--- a/Aspid.MVVM/Assets/Plugins/Aspid/MVVM/StarterKit/Unity/Runtime/Binders/AudioSources/Priority/Mono/AudioSourcePriorityEnumMonoBinder.cs.meta
+++ b/Aspid.MVVM/Assets/Plugins/Aspid/MVVM/StarterKit/Unity/Runtime/Binders/AudioSources/Priority/Mono/AudioSourcePriorityEnumMonoBinder.cs.meta
@@ -1,0 +1,3 @@
+fileFormatVersion: 2
+guid: a38ece8151624844b84caa2127de75fb
+timeCreated: 1770577044

--- a/Aspid.MVVM/Assets/Plugins/Aspid/MVVM/StarterKit/Unity/Runtime/Binders/AudioSources/Priority/Mono/AudioSourcePriorityMonoBinder.cs
+++ b/Aspid.MVVM/Assets/Plugins/Aspid/MVVM/StarterKit/Unity/Runtime/Binders/AudioSources/Priority/Mono/AudioSourcePriorityMonoBinder.cs
@@ -1,0 +1,57 @@
+using System;
+using UnityEngine;
+#if UNITY_2023_1_OR_NEWER
+using Converter = Aspid.MVVM.StarterKit.IConverter<int, int>;
+#else
+using Converter = Aspid.MVVM.StarterKit.IConverterInt;
+#endif
+
+// ReSharper disable once CheckNamespace
+namespace Aspid.MVVM.StarterKit
+{
+    [AddBinderContextMenu(typeof(AudioSource))]
+    [AddComponentMenu("Aspid/MVVM/Binders/Audio/AudioSource/AudioSource Binder – Priority")]
+    [BindModeOverride(BindMode.OneWay, BindMode.OneTime, BindMode.OneWayToSource)]
+    public partial class AudioSourcePriorityMonoBinder : ComponentMonoBinder<AudioSource>, INumberBinder, INumberReverseBinder
+    {
+        public event Action<int> IntValueChanged;
+        public event Action<long> LongValueChanged;
+        public event Action<float> FloatValueChanged;
+        public event Action<double> DoubleValueChanged;
+        
+        [SerializeReferenceDropdown]
+        [SerializeReference] private Converter _converter;
+
+        [BinderLog]
+        public void SetValue(int value) =>
+            CachedComponent.priority = GetConvertedValue(value);
+        
+        [BinderLog]
+        public void SetValue(float value) =>
+            SetValue((int)value);
+        
+        [BinderLog]
+        public void SetValue(long value) =>
+            SetValue((int)value);
+        
+        [BinderLog]
+        public void SetValue(double value) =>
+            SetValue((int)value);
+        
+        protected override void OnBound()
+        {
+            if (Mode is BindMode.OneWayToSource)
+            {
+                var value = GetConvertedValue(CachedComponent.priority);
+                
+                IntValueChanged?.Invoke(value);
+                LongValueChanged?.Invoke(value);
+                FloatValueChanged?.Invoke(value);
+                DoubleValueChanged?.Invoke(value);
+            }
+        }
+        
+        private int GetConvertedValue(int value) =>
+            _converter?.Convert(value) ?? value;
+    }
+}

--- a/Aspid.MVVM/Assets/Plugins/Aspid/MVVM/StarterKit/Unity/Runtime/Binders/AudioSources/Priority/Mono/AudioSourcePriorityMonoBinder.cs.meta
+++ b/Aspid.MVVM/Assets/Plugins/Aspid/MVVM/StarterKit/Unity/Runtime/Binders/AudioSources/Priority/Mono/AudioSourcePriorityMonoBinder.cs.meta
@@ -1,0 +1,3 @@
+fileFormatVersion: 2
+guid: 5b3109730c7a4dfebb131f52b285fd10
+timeCreated: 1770577044

--- a/Aspid.MVVM/Assets/Plugins/Aspid/MVVM/StarterKit/Unity/Runtime/Binders/AudioSources/Priority/Mono/AudioSourcePrioritySwitcherMonoBinder.cs
+++ b/Aspid.MVVM/Assets/Plugins/Aspid/MVVM/StarterKit/Unity/Runtime/Binders/AudioSources/Priority/Mono/AudioSourcePrioritySwitcherMonoBinder.cs
@@ -1,0 +1,21 @@
+using UnityEngine;
+#if UNITY_2023_1_OR_NEWER
+using Converter = Aspid.MVVM.StarterKit.IConverter<int, int>;
+#else
+using Converter = Aspid.MVVM.StarterKit.IConverterInt;
+#endif
+
+// ReSharper disable once CheckNamespace
+namespace Aspid.MVVM.StarterKit
+{
+    [AddComponentMenu("Aspid/MVVM/Binders/Audio/AudioSource/AudioSource Binder – Priority Switcher")]
+    [AddBinderContextMenu(typeof(AudioSource), serializePropertyNames: "m_Priority", SubPath = "Switcher")]
+    public sealed class AudioSourcePrioritySwitcherMonoBinder : SwitcherMonoBinder<AudioSource, int>
+    {
+        [SerializeReferenceDropdown]
+        [SerializeReference] private Converter _converter;
+        
+        protected override void SetValue(int value) =>
+            CachedComponent.priority = value;
+    }
+}

--- a/Aspid.MVVM/Assets/Plugins/Aspid/MVVM/StarterKit/Unity/Runtime/Binders/AudioSources/Priority/Mono/AudioSourcePrioritySwitcherMonoBinder.cs.meta
+++ b/Aspid.MVVM/Assets/Plugins/Aspid/MVVM/StarterKit/Unity/Runtime/Binders/AudioSources/Priority/Mono/AudioSourcePrioritySwitcherMonoBinder.cs.meta
@@ -1,0 +1,3 @@
+fileFormatVersion: 2
+guid: cae2c3a2fc2140d29057018d2ade4e56
+timeCreated: 1770577044

--- a/Aspid.MVVM/Assets/Plugins/Aspid/MVVM/StarterKit/Unity/Runtime/Binders/AudioSources/ReverbZoneMix.meta
+++ b/Aspid.MVVM/Assets/Plugins/Aspid/MVVM/StarterKit/Unity/Runtime/Binders/AudioSources/ReverbZoneMix.meta
@@ -1,0 +1,3 @@
+fileFormatVersion: 2
+guid: e70ffb5db05b4b2ea71c12e4702f555a
+timeCreated: 1770892135

--- a/Aspid.MVVM/Assets/Plugins/Aspid/MVVM/StarterKit/Unity/Runtime/Binders/AudioSources/ReverbZoneMix/AudioSourceReverbZoneMixBinder.cs
+++ b/Aspid.MVVM/Assets/Plugins/Aspid/MVVM/StarterKit/Unity/Runtime/Binders/AudioSources/ReverbZoneMix/AudioSourceReverbZoneMixBinder.cs
@@ -1,0 +1,63 @@
+#nullable enable
+using System;
+using UnityEngine;
+#if UNITY_2023_1_OR_NEWER
+using Converter = Aspid.MVVM.StarterKit.IConverter<float, float>;
+#else
+using Converter = Aspid.MVVM.StarterKit.IConverterFloat;
+#endif
+
+// ReSharper disable once CheckNamespace
+namespace Aspid.MVVM.StarterKit
+{
+    [Serializable]
+    [BindModeOverride(BindMode.OneWay, BindMode.OneTime, BindMode.OneWayToSource)]
+    public class AudioSourceReverbZoneMixBinder : TargetBinder<AudioSource>, INumberBinder, INumberReverseBinder
+    {
+        public event Action<int>? IntValueChanged;
+        public event Action<long>? LongValueChanged;
+        public event Action<float>? FloatValueChanged;
+        public event Action<double>? DoubleValueChanged;
+        
+        [SerializeReferenceDropdown]
+        [SerializeReference] private Converter? _converter;
+        
+        public AudioSourceReverbZoneMixBinder(AudioSource target, BindMode mode)
+            : this(target, converter: null, mode) { }
+        
+        public AudioSourceReverbZoneMixBinder(AudioSource target, Converter? converter = null, BindMode mode = BindMode.OneWay)
+            : base(target, mode)
+        {
+            mode.ThrowExceptionIfTwo();
+            _converter = converter;
+        }
+
+        public void SetValue(int value) => 
+            SetValue((float)value);
+
+        public void SetValue(long value) =>
+            SetValue((float)value);
+
+        public void SetValue(float value) =>
+            Target.reverbZoneMix = GetConvertedValue(value);
+
+        public void SetValue(double value) =>
+            SetValue((float)value);
+        
+        protected override void OnBound()
+        {
+            if (Mode is BindMode.OneWayToSource)
+            {
+                var value = GetConvertedValue(Target.reverbZoneMix);
+                
+                IntValueChanged?.Invoke((int)value);
+                LongValueChanged?.Invoke((long)value);
+                FloatValueChanged?.Invoke(value);
+                DoubleValueChanged?.Invoke(value);
+            }
+        }
+        
+        private float GetConvertedValue(float value) =>
+            _converter?.Convert(value) ?? value;
+    }
+}

--- a/Aspid.MVVM/Assets/Plugins/Aspid/MVVM/StarterKit/Unity/Runtime/Binders/AudioSources/ReverbZoneMix/AudioSourceReverbZoneMixBinder.cs.meta
+++ b/Aspid.MVVM/Assets/Plugins/Aspid/MVVM/StarterKit/Unity/Runtime/Binders/AudioSources/ReverbZoneMix/AudioSourceReverbZoneMixBinder.cs.meta
@@ -1,0 +1,3 @@
+fileFormatVersion: 2
+guid: 24cc49da3476420c80fcd90aa2e03249
+timeCreated: 1770880454

--- a/Aspid.MVVM/Assets/Plugins/Aspid/MVVM/StarterKit/Unity/Runtime/Binders/AudioSources/ReverbZoneMix/AudioSourceReverbZoneMixSwitcherBinder.cs
+++ b/Aspid.MVVM/Assets/Plugins/Aspid/MVVM/StarterKit/Unity/Runtime/Binders/AudioSources/ReverbZoneMix/AudioSourceReverbZoneMixSwitcherBinder.cs
@@ -1,0 +1,40 @@
+#nullable enable
+using System;
+using UnityEngine;
+#if UNITY_2023_1_OR_NEWER
+using Converter = Aspid.MVVM.StarterKit.IConverter<float, float>;
+#else
+using Converter = Aspid.MVVM.StarterKit.IConverterFloat;
+#endif
+
+// ReSharper disable once CheckNamespace
+namespace Aspid.MVVM.StarterKit
+{
+    [Serializable]
+    public sealed class AudioSourceReverbZoneMixSwitcherBinder : SwitcherBinder<AudioSource, float>
+    {
+        [SerializeReferenceDropdown]
+        [SerializeReference] private Converter? _converter;
+        
+        public AudioSourceReverbZoneMixSwitcherBinder(
+            AudioSource target,
+            float trueValue, 
+            float falseValue,
+            BindMode mode)
+            : this(target, trueValue, falseValue, converter: null, mode) { }
+        
+        public AudioSourceReverbZoneMixSwitcherBinder(
+            AudioSource target,
+            float trueValue, 
+            float falseValue,
+            Converter? converter = null,
+            BindMode mode = BindMode.OneWay)
+            : base(target, trueValue, falseValue, mode)
+        {
+            _converter = converter;
+        }
+
+        protected override void SetValue(float value) =>
+            Target.reverbZoneMix = _converter?.Convert(value) ?? value;
+    }
+}

--- a/Aspid.MVVM/Assets/Plugins/Aspid/MVVM/StarterKit/Unity/Runtime/Binders/AudioSources/ReverbZoneMix/AudioSourceReverbZoneMixSwitcherBinder.cs.meta
+++ b/Aspid.MVVM/Assets/Plugins/Aspid/MVVM/StarterKit/Unity/Runtime/Binders/AudioSources/ReverbZoneMix/AudioSourceReverbZoneMixSwitcherBinder.cs.meta
@@ -1,0 +1,3 @@
+fileFormatVersion: 2
+guid: 52e66bfe9b0944d79e2d3f0e8671ab7d
+timeCreated: 1770880887

--- a/Aspid.MVVM/Assets/Plugins/Aspid/MVVM/StarterKit/Unity/Runtime/Binders/AudioSources/ReverbZoneMix/Mono.meta
+++ b/Aspid.MVVM/Assets/Plugins/Aspid/MVVM/StarterKit/Unity/Runtime/Binders/AudioSources/ReverbZoneMix/Mono.meta
@@ -1,0 +1,3 @@
+fileFormatVersion: 2
+guid: 50f5b32c55ac4499ac2986c3f41d507d
+timeCreated: 1770892890

--- a/Aspid.MVVM/Assets/Plugins/Aspid/MVVM/StarterKit/Unity/Runtime/Binders/AudioSources/ReverbZoneMix/Mono/AudioSourceReverbZoneMixEnumGroupMonoBinder.cs
+++ b/Aspid.MVVM/Assets/Plugins/Aspid/MVVM/StarterKit/Unity/Runtime/Binders/AudioSources/ReverbZoneMix/Mono/AudioSourceReverbZoneMixEnumGroupMonoBinder.cs
@@ -1,0 +1,30 @@
+using UnityEngine;
+#if UNITY_2023_1_OR_NEWER
+using Converter = Aspid.MVVM.StarterKit.IConverter<float, float>;
+#else
+using Converter = Aspid.MVVM.StarterKit.IConverterFloat;
+#endif
+
+// ReSharper disable once CheckNamespace
+namespace Aspid.MVVM.StarterKit
+{
+    [AddBinderContextMenu(typeof(AudioSource), SubPath = "EnumGroup")]
+    [AddComponentMenu("Aspid/MVVM/Binders/Audio/AudioSource/AudioSource Binder – ReverbZoneMix EnumGroup")]
+    public sealed class AudioSourceReverbZoneMixEnumGroupMonoBinder : EnumGroupMonoBinder<AudioSource>
+    {
+        [SerializeField] [Range(0, 1.1f)] private float _defaultValue;
+        [SerializeField] [Range(0, 1.1f)] private float _selectedValue;
+        
+        [SerializeReferenceDropdown]
+        [SerializeReference] private Converter _defaultConverter;
+        
+        [SerializeReferenceDropdown]
+        [SerializeReference] private Converter _selectedConverter;
+        
+        protected override void SetDefaultValue(AudioSource element) =>
+            element.reverbZoneMix = _defaultConverter?.Convert(_defaultValue) ?? _defaultValue;
+
+        protected override void SetSelectedValue(AudioSource element) =>
+            element.reverbZoneMix = _selectedConverter?.Convert(_selectedValue) ?? _selectedValue;
+    }
+}

--- a/Aspid.MVVM/Assets/Plugins/Aspid/MVVM/StarterKit/Unity/Runtime/Binders/AudioSources/ReverbZoneMix/Mono/AudioSourceReverbZoneMixEnumGroupMonoBinder.cs.meta
+++ b/Aspid.MVVM/Assets/Plugins/Aspid/MVVM/StarterKit/Unity/Runtime/Binders/AudioSources/ReverbZoneMix/Mono/AudioSourceReverbZoneMixEnumGroupMonoBinder.cs.meta
@@ -1,0 +1,3 @@
+fileFormatVersion: 2
+guid: 3981741b8b3d40cb8c1ff65b2bc99f95
+timeCreated: 1770880835

--- a/Aspid.MVVM/Assets/Plugins/Aspid/MVVM/StarterKit/Unity/Runtime/Binders/AudioSources/ReverbZoneMix/Mono/AudioSourceReverbZoneMixEnumMonoBinder.cs
+++ b/Aspid.MVVM/Assets/Plugins/Aspid/MVVM/StarterKit/Unity/Runtime/Binders/AudioSources/ReverbZoneMix/Mono/AudioSourceReverbZoneMixEnumMonoBinder.cs
@@ -1,0 +1,21 @@
+using UnityEngine;
+#if UNITY_2023_1_OR_NEWER
+using Converter = Aspid.MVVM.StarterKit.IConverter<float, float>;
+#else
+using Converter = Aspid.MVVM.StarterKit.IConverterFloat;
+#endif
+
+// ReSharper disable once CheckNamespace
+namespace Aspid.MVVM.StarterKit
+{
+    [AddBinderContextMenu(typeof(AudioSource), SubPath = "Enum")]
+    [AddComponentMenu("Aspid/MVVM/Binders/Audio/AudioSource/AudioSource Binder – ReverbZoneMix Enum")]
+    public sealed class AudioSourceReverbZoneMixEnumMonoBinder : EnumMonoBinder<AudioSource, float>
+    {
+        [SerializeReferenceDropdown]
+        [SerializeReference] private Converter _converter;
+        
+        protected override void SetValue(float value) =>
+            CachedComponent.reverbZoneMix = _converter?.Convert(value) ?? value;
+    }
+}

--- a/Aspid.MVVM/Assets/Plugins/Aspid/MVVM/StarterKit/Unity/Runtime/Binders/AudioSources/ReverbZoneMix/Mono/AudioSourceReverbZoneMixEnumMonoBinder.cs.meta
+++ b/Aspid.MVVM/Assets/Plugins/Aspid/MVVM/StarterKit/Unity/Runtime/Binders/AudioSources/ReverbZoneMix/Mono/AudioSourceReverbZoneMixEnumMonoBinder.cs.meta
@@ -1,0 +1,3 @@
+fileFormatVersion: 2
+guid: 14d5a9130b8b4b869246be0c87bf4524
+timeCreated: 1770880835

--- a/Aspid.MVVM/Assets/Plugins/Aspid/MVVM/StarterKit/Unity/Runtime/Binders/AudioSources/ReverbZoneMix/Mono/AudioSourceReverbZoneMixMonoBinder.cs
+++ b/Aspid.MVVM/Assets/Plugins/Aspid/MVVM/StarterKit/Unity/Runtime/Binders/AudioSources/ReverbZoneMix/Mono/AudioSourceReverbZoneMixMonoBinder.cs
@@ -1,0 +1,57 @@
+using System;
+using UnityEngine;
+#if UNITY_2023_1_OR_NEWER
+using Converter = Aspid.MVVM.StarterKit.IConverter<float, float>;
+#else
+using Converter = Aspid.MVVM.StarterKit.IConverterFloat;
+#endif
+
+// ReSharper disable once CheckNamespace
+namespace Aspid.MVVM.StarterKit
+{
+    [AddBinderContextMenu(typeof(AudioSource))]
+    [AddComponentMenu("Aspid/MVVM/Binders/Audio/AudioSource/AudioSource Binder – ReverbZoneMix")]
+    [BindModeOverride(BindMode.OneWay, BindMode.OneTime, BindMode.OneWayToSource)]
+    public partial class AudioSourceReverbZoneMixMonoBinder : ComponentMonoBinder<AudioSource>, INumberBinder, INumberReverseBinder
+    {
+        public event Action<int> IntValueChanged;
+        public event Action<long> LongValueChanged;
+        public event Action<float> FloatValueChanged;
+        public event Action<double> DoubleValueChanged;
+        
+        [SerializeReferenceDropdown]
+        [SerializeReference] private Converter _converter;
+
+        [BinderLog]
+        public void SetValue(float value) =>
+            CachedComponent.reverbZoneMix = GetConvertedValue(value);
+
+        [BinderLog]
+        public void SetValue(int value) =>
+            SetValue((float)value);
+
+        [BinderLog]
+        public void SetValue(long value) =>
+            SetValue((float)value);
+
+        [BinderLog]
+        public void SetValue(double value) =>
+            SetValue((float)value);
+        
+        protected override void OnBound()
+        {
+            if (Mode is BindMode.OneWayToSource)
+            {
+                var value = GetConvertedValue(CachedComponent.reverbZoneMix);
+                
+                IntValueChanged?.Invoke((int)value);
+                LongValueChanged?.Invoke((long)value);
+                FloatValueChanged?.Invoke(value);
+                DoubleValueChanged?.Invoke(value);
+            }
+        }
+        
+        private float GetConvertedValue(float value) =>
+            _converter?.Convert(value) ?? value;
+    }
+}

--- a/Aspid.MVVM/Assets/Plugins/Aspid/MVVM/StarterKit/Unity/Runtime/Binders/AudioSources/ReverbZoneMix/Mono/AudioSourceReverbZoneMixMonoBinder.cs.meta
+++ b/Aspid.MVVM/Assets/Plugins/Aspid/MVVM/StarterKit/Unity/Runtime/Binders/AudioSources/ReverbZoneMix/Mono/AudioSourceReverbZoneMixMonoBinder.cs.meta
@@ -1,0 +1,3 @@
+fileFormatVersion: 2
+guid: dfa0feb48fcd4fb3af7397233f7f6b73
+timeCreated: 1770880353

--- a/Aspid.MVVM/Assets/Plugins/Aspid/MVVM/StarterKit/Unity/Runtime/Binders/AudioSources/ReverbZoneMix/Mono/AudioSourceReverbZoneMixSwitcherMonoBinder.cs
+++ b/Aspid.MVVM/Assets/Plugins/Aspid/MVVM/StarterKit/Unity/Runtime/Binders/AudioSources/ReverbZoneMix/Mono/AudioSourceReverbZoneMixSwitcherMonoBinder.cs
@@ -1,0 +1,21 @@
+using UnityEngine;
+#if UNITY_2023_1_OR_NEWER
+using Converter = Aspid.MVVM.StarterKit.IConverter<float, float>;
+#else
+using Converter = Aspid.MVVM.StarterKit.IConverterFloat;
+#endif
+
+// ReSharper disable once CheckNamespace
+namespace Aspid.MVVM.StarterKit
+{
+    [AddBinderContextMenu(typeof(AudioSource), SubPath = "Switcher")]
+    [AddComponentMenu("Aspid/MVVM/Binders/Audio/AudioSource/AudioSource Binder – ReverbZoneMix Switcher")]
+    public sealed class AudioSourceReverbZoneMixSwitcherMonoBinder : SwitcherMonoBinder<AudioSource, float>
+    {
+        [SerializeReferenceDropdown]
+        [SerializeReference] private Converter _converter;
+        
+        protected override void SetValue(float value) =>
+            CachedComponent.reverbZoneMix = _converter?.Convert(value) ?? value;
+    }
+}

--- a/Aspid.MVVM/Assets/Plugins/Aspid/MVVM/StarterKit/Unity/Runtime/Binders/AudioSources/ReverbZoneMix/Mono/AudioSourceReverbZoneMixSwitcherMonoBinder.cs.meta
+++ b/Aspid.MVVM/Assets/Plugins/Aspid/MVVM/StarterKit/Unity/Runtime/Binders/AudioSources/ReverbZoneMix/Mono/AudioSourceReverbZoneMixSwitcherMonoBinder.cs.meta
@@ -1,0 +1,3 @@
+fileFormatVersion: 2
+guid: e919dd41ea774f5a88bd35e6c9fa1e4b
+timeCreated: 1770880835

--- a/Aspid.MVVM/Assets/Plugins/Aspid/MVVM/StarterKit/Unity/Runtime/Binders/AudioSources/SpatialBlend.meta
+++ b/Aspid.MVVM/Assets/Plugins/Aspid/MVVM/StarterKit/Unity/Runtime/Binders/AudioSources/SpatialBlend.meta
@@ -1,0 +1,3 @@
+fileFormatVersion: 2
+guid: 5b1dbad6e5ab4d9cb78e5f6df5a5274c
+timeCreated: 1770892147

--- a/Aspid.MVVM/Assets/Plugins/Aspid/MVVM/StarterKit/Unity/Runtime/Binders/AudioSources/SpatialBlend/AudioSourceSpatialBlendBinder.cs
+++ b/Aspid.MVVM/Assets/Plugins/Aspid/MVVM/StarterKit/Unity/Runtime/Binders/AudioSources/SpatialBlend/AudioSourceSpatialBlendBinder.cs
@@ -1,0 +1,63 @@
+#nullable enable
+using System;
+using UnityEngine;
+#if UNITY_2023_1_OR_NEWER
+using Converter = Aspid.MVVM.StarterKit.IConverter<float, float>;
+#else
+using Converter = Aspid.MVVM.StarterKit.IConverterFloat;
+#endif
+
+// ReSharper disable once CheckNamespace
+namespace Aspid.MVVM.StarterKit
+{
+    [Serializable]
+    [BindModeOverride(BindMode.OneWay, BindMode.OneTime, BindMode.OneWayToSource)]
+    public class AudioSourceSpatialBlendBinder : TargetBinder<AudioSource>, INumberBinder, INumberReverseBinder
+    {
+        public event Action<int>? IntValueChanged;
+        public event Action<long>? LongValueChanged;
+        public event Action<float>? FloatValueChanged;
+        public event Action<double>? DoubleValueChanged;
+        
+        [SerializeReferenceDropdown]
+        [SerializeReference] private Converter? _converter;
+        
+        public AudioSourceSpatialBlendBinder(AudioSource target, BindMode mode)
+            : this(target, converter: null, mode) { }
+        
+        public AudioSourceSpatialBlendBinder(AudioSource target, Converter? converter = null, BindMode mode = BindMode.OneWay)
+            : base(target, mode)
+        {
+            mode.ThrowExceptionIfTwo();
+            _converter = converter;
+        }
+
+        public void SetValue(int value) => 
+            SetValue((float)value);
+
+        public void SetValue(long value) =>
+            SetValue((float)value);
+
+        public void SetValue(float value) =>
+            Target.spatialBlend = GetConvertedValue(value);
+
+        public void SetValue(double value) => 
+            SetValue((float)value);
+        
+        protected override void OnBound()
+        {
+            if (Mode is BindMode.OneWayToSource)
+            {
+                var value = GetConvertedValue(Target.spatialBlend);
+                
+                IntValueChanged?.Invoke((int)value);
+                LongValueChanged?.Invoke((long)value);
+                FloatValueChanged?.Invoke(value);
+                DoubleValueChanged?.Invoke(value);
+            }
+        }
+        
+        private float GetConvertedValue(float value) =>
+            _converter?.Convert(value) ?? value;
+    }
+}

--- a/Aspid.MVVM/Assets/Plugins/Aspid/MVVM/StarterKit/Unity/Runtime/Binders/AudioSources/SpatialBlend/AudioSourceSpatialBlendBinder.cs.meta
+++ b/Aspid.MVVM/Assets/Plugins/Aspid/MVVM/StarterKit/Unity/Runtime/Binders/AudioSources/SpatialBlend/AudioSourceSpatialBlendBinder.cs.meta
@@ -1,0 +1,3 @@
+fileFormatVersion: 2
+guid: 1f020be81c934474a901e9ad9037bfc8
+timeCreated: 1770880402

--- a/Aspid.MVVM/Assets/Plugins/Aspid/MVVM/StarterKit/Unity/Runtime/Binders/AudioSources/SpatialBlend/AudioSourceSpatialBlendSwitcherBinder.cs
+++ b/Aspid.MVVM/Assets/Plugins/Aspid/MVVM/StarterKit/Unity/Runtime/Binders/AudioSources/SpatialBlend/AudioSourceSpatialBlendSwitcherBinder.cs
@@ -1,0 +1,40 @@
+#nullable enable
+using System;
+using UnityEngine;
+#if UNITY_2023_1_OR_NEWER
+using Converter = Aspid.MVVM.StarterKit.IConverter<float, float>;
+#else
+using Converter = Aspid.MVVM.StarterKit.IConverterFloat;
+#endif
+
+// ReSharper disable once CheckNamespace
+namespace Aspid.MVVM.StarterKit
+{
+    [Serializable]
+    public sealed class AudioSourceSpatialBlendSwitcherBinder : SwitcherBinder<AudioSource, float>
+    {
+        [SerializeReferenceDropdown]
+        [SerializeReference] private Converter? _converter;
+        
+        public AudioSourceSpatialBlendSwitcherBinder(
+            AudioSource target,
+            float trueValue, 
+            float falseValue,
+            BindMode mode)
+            : this(target, trueValue, falseValue, converter: null, mode) { }
+        
+        public AudioSourceSpatialBlendSwitcherBinder(
+            AudioSource target,
+            float trueValue, 
+            float falseValue,
+            Converter? converter = null,
+            BindMode mode = BindMode.OneWay)
+            : base(target, trueValue, falseValue, mode)
+        {
+            _converter = converter;
+        }
+
+        protected override void SetValue(float value) =>
+            Target.spatialBlend = _converter?.Convert(value) ?? value;
+    }
+}

--- a/Aspid.MVVM/Assets/Plugins/Aspid/MVVM/StarterKit/Unity/Runtime/Binders/AudioSources/SpatialBlend/AudioSourceSpatialBlendSwitcherBinder.cs.meta
+++ b/Aspid.MVVM/Assets/Plugins/Aspid/MVVM/StarterKit/Unity/Runtime/Binders/AudioSources/SpatialBlend/AudioSourceSpatialBlendSwitcherBinder.cs.meta
@@ -1,0 +1,3 @@
+fileFormatVersion: 2
+guid: 0cbe2c3e4fc74af78dfd6113e01dca52
+timeCreated: 1770880403

--- a/Aspid.MVVM/Assets/Plugins/Aspid/MVVM/StarterKit/Unity/Runtime/Binders/AudioSources/SpatialBlend/Mono.meta
+++ b/Aspid.MVVM/Assets/Plugins/Aspid/MVVM/StarterKit/Unity/Runtime/Binders/AudioSources/SpatialBlend/Mono.meta
@@ -1,0 +1,3 @@
+fileFormatVersion: 2
+guid: 5380065eb31c4a45ba2e8101b803aadf
+timeCreated: 1770892888

--- a/Aspid.MVVM/Assets/Plugins/Aspid/MVVM/StarterKit/Unity/Runtime/Binders/AudioSources/SpatialBlend/Mono/AudioSourceSpatialBlendEnumGroupMonoBinder.cs
+++ b/Aspid.MVVM/Assets/Plugins/Aspid/MVVM/StarterKit/Unity/Runtime/Binders/AudioSources/SpatialBlend/Mono/AudioSourceSpatialBlendEnumGroupMonoBinder.cs
@@ -1,0 +1,30 @@
+using UnityEngine;
+#if UNITY_2023_1_OR_NEWER
+using Converter = Aspid.MVVM.StarterKit.IConverter<float, float>;
+#else
+using Converter = Aspid.MVVM.StarterKit.IConverterFloat;
+#endif
+
+// ReSharper disable once CheckNamespace
+namespace Aspid.MVVM.StarterKit
+{
+    [AddBinderContextMenu(typeof(AudioSource), SubPath = "EnumGroup")]
+    [AddComponentMenu("Aspid/MVVM/Binders/Audio/AudioSource/AudioSource Binder – SpatialBlend EnumGroup")]
+    public sealed class AudioSourceSpatialBlendEnumGroupMonoBinder : EnumGroupMonoBinder<AudioSource>
+    {
+        [SerializeField] private float _defaultValue;
+        [SerializeField] private float _selectedValue;
+        
+        [SerializeReferenceDropdown]
+        [SerializeReference] private Converter _defaultConverter;
+        
+        [SerializeReferenceDropdown]
+        [SerializeReference] private Converter _selectedConverter;
+        
+        protected override void SetDefaultValue(AudioSource element) =>
+            element.spatialBlend = _defaultConverter?.Convert(_defaultValue) ?? _defaultValue;
+
+        protected override void SetSelectedValue(AudioSource element) =>
+            element.spatialBlend = _selectedConverter?.Convert(_selectedValue) ?? _selectedValue;
+    }
+}

--- a/Aspid.MVVM/Assets/Plugins/Aspid/MVVM/StarterKit/Unity/Runtime/Binders/AudioSources/SpatialBlend/Mono/AudioSourceSpatialBlendEnumGroupMonoBinder.cs.meta
+++ b/Aspid.MVVM/Assets/Plugins/Aspid/MVVM/StarterKit/Unity/Runtime/Binders/AudioSources/SpatialBlend/Mono/AudioSourceSpatialBlendEnumGroupMonoBinder.cs.meta
@@ -1,0 +1,3 @@
+fileFormatVersion: 2
+guid: 6169f8e32efb4ea1b6e3cbb2adade631
+timeCreated: 1770577033

--- a/Aspid.MVVM/Assets/Plugins/Aspid/MVVM/StarterKit/Unity/Runtime/Binders/AudioSources/SpatialBlend/Mono/AudioSourceSpatialBlendEnumMonoBinder.cs
+++ b/Aspid.MVVM/Assets/Plugins/Aspid/MVVM/StarterKit/Unity/Runtime/Binders/AudioSources/SpatialBlend/Mono/AudioSourceSpatialBlendEnumMonoBinder.cs
@@ -1,0 +1,21 @@
+using UnityEngine;
+#if UNITY_2023_1_OR_NEWER
+using Converter = Aspid.MVVM.StarterKit.IConverter<float, float>;
+#else
+using Converter = Aspid.MVVM.StarterKit.IConverterFloat;
+#endif
+
+// ReSharper disable once CheckNamespace
+namespace Aspid.MVVM.StarterKit
+{
+    [AddBinderContextMenu(typeof(AudioSource), SubPath = "Enum")]
+    [AddComponentMenu("Aspid/MVVM/Binders/Audio/AudioSource/AudioSource Binder – SpatialBlend Enum")]
+    public sealed class AudioSourceSpatialBlendEnumMonoBinder : EnumMonoBinder<AudioSource, float>
+    {
+        [SerializeReferenceDropdown]
+        [SerializeReference] private Converter _converter;
+        
+        protected override void SetValue(float value) =>
+            CachedComponent.spatialBlend = _converter?.Convert(value) ?? value;
+    }
+}

--- a/Aspid.MVVM/Assets/Plugins/Aspid/MVVM/StarterKit/Unity/Runtime/Binders/AudioSources/SpatialBlend/Mono/AudioSourceSpatialBlendEnumMonoBinder.cs.meta
+++ b/Aspid.MVVM/Assets/Plugins/Aspid/MVVM/StarterKit/Unity/Runtime/Binders/AudioSources/SpatialBlend/Mono/AudioSourceSpatialBlendEnumMonoBinder.cs.meta
@@ -1,0 +1,3 @@
+fileFormatVersion: 2
+guid: 15a3366a64374e68a7dd294f19a12285
+timeCreated: 1770577033

--- a/Aspid.MVVM/Assets/Plugins/Aspid/MVVM/StarterKit/Unity/Runtime/Binders/AudioSources/SpatialBlend/Mono/AudioSourceSpatialBlendMonoBinder.cs
+++ b/Aspid.MVVM/Assets/Plugins/Aspid/MVVM/StarterKit/Unity/Runtime/Binders/AudioSources/SpatialBlend/Mono/AudioSourceSpatialBlendMonoBinder.cs
@@ -1,0 +1,57 @@
+using System;
+using UnityEngine;
+#if UNITY_2023_1_OR_NEWER
+using Converter = Aspid.MVVM.StarterKit.IConverter<float, float>;
+#else
+using Converter = Aspid.MVVM.StarterKit.IConverterFloat;
+#endif
+
+// ReSharper disable once CheckNamespace
+namespace Aspid.MVVM.StarterKit
+{
+    [AddBinderContextMenu(typeof(AudioSource))]
+    [AddComponentMenu("Aspid/MVVM/Binders/Audio/AudioSource/AudioSource Binder – SpatialBlend")]
+    [BindModeOverride(BindMode.OneWay, BindMode.OneTime, BindMode.OneWayToSource)]
+    public partial class AudioSourceSpatialBlendMonoBinder : ComponentMonoBinder<AudioSource>, INumberBinder, INumberReverseBinder
+    {
+        public event Action<int> IntValueChanged;
+        public event Action<long> LongValueChanged;
+        public event Action<float> FloatValueChanged;
+        public event Action<double> DoubleValueChanged;
+        
+        [SerializeReferenceDropdown]
+        [SerializeReference] private Converter _converter;
+
+        [BinderLog]
+        public void SetValue(float value) =>
+            CachedComponent.spatialBlend = GetConvertedValue(value);
+
+        [BinderLog]
+        public void SetValue(int value) =>
+            SetValue((float)value);
+
+        [BinderLog]
+        public void SetValue(long value) =>
+            SetValue((float)value);
+
+        [BinderLog]
+        public void SetValue(double value) =>
+            SetValue((float)value);
+        
+        protected override void OnBound()
+        {
+            if (Mode is BindMode.OneWayToSource)
+            {
+                var value = GetConvertedValue(CachedComponent.spatialBlend);
+                
+                IntValueChanged?.Invoke((int)value);
+                LongValueChanged?.Invoke((long)value);
+                FloatValueChanged?.Invoke(value);
+                DoubleValueChanged?.Invoke(value);
+            }
+        }
+        
+        private float GetConvertedValue(float value) =>
+            _converter?.Convert(value) ?? value;
+    }
+}

--- a/Aspid.MVVM/Assets/Plugins/Aspid/MVVM/StarterKit/Unity/Runtime/Binders/AudioSources/SpatialBlend/Mono/AudioSourceSpatialBlendMonoBinder.cs.meta
+++ b/Aspid.MVVM/Assets/Plugins/Aspid/MVVM/StarterKit/Unity/Runtime/Binders/AudioSources/SpatialBlend/Mono/AudioSourceSpatialBlendMonoBinder.cs.meta
@@ -1,0 +1,3 @@
+fileFormatVersion: 2
+guid: e621f95244014b948444285ff84644c2
+timeCreated: 1770577033

--- a/Aspid.MVVM/Assets/Plugins/Aspid/MVVM/StarterKit/Unity/Runtime/Binders/AudioSources/SpatialBlend/Mono/AudioSourceSpatialBlendSwitcherMonoBinder.cs
+++ b/Aspid.MVVM/Assets/Plugins/Aspid/MVVM/StarterKit/Unity/Runtime/Binders/AudioSources/SpatialBlend/Mono/AudioSourceSpatialBlendSwitcherMonoBinder.cs
@@ -1,0 +1,21 @@
+using UnityEngine;
+#if UNITY_2023_1_OR_NEWER
+using Converter = Aspid.MVVM.StarterKit.IConverter<float, float>;
+#else
+using Converter = Aspid.MVVM.StarterKit.IConverterFloat;
+#endif
+
+// ReSharper disable once CheckNamespace
+namespace Aspid.MVVM.StarterKit
+{
+    [AddBinderContextMenu(typeof(AudioSource), SubPath = "Switcher")]
+    [AddComponentMenu("Aspid/MVVM/Binders/Audio/AudioSource/AudioSource Binder – SpatialBlend Switcher")]
+    public sealed class AudioSourceSpatialBlendSwitcherMonoBinder : SwitcherMonoBinder<AudioSource, float>
+    {
+        [SerializeReferenceDropdown]
+        [SerializeReference] private Converter _converter;
+        
+        protected override void SetValue(float value) =>
+            CachedComponent.spatialBlend = _converter?.Convert(value) ?? value;
+    }
+}

--- a/Aspid.MVVM/Assets/Plugins/Aspid/MVVM/StarterKit/Unity/Runtime/Binders/AudioSources/SpatialBlend/Mono/AudioSourceSpatialBlendSwitcherMonoBinder.cs.meta
+++ b/Aspid.MVVM/Assets/Plugins/Aspid/MVVM/StarterKit/Unity/Runtime/Binders/AudioSources/SpatialBlend/Mono/AudioSourceSpatialBlendSwitcherMonoBinder.cs.meta
@@ -1,0 +1,3 @@
+fileFormatVersion: 2
+guid: 3c74d6fd66864507a12d8270112ef4f2
+timeCreated: 1770577033

--- a/Aspid.MVVM/Assets/Plugins/Aspid/MVVM/StarterKit/Unity/Runtime/Binders/AudioSources/Spread.meta
+++ b/Aspid.MVVM/Assets/Plugins/Aspid/MVVM/StarterKit/Unity/Runtime/Binders/AudioSources/Spread.meta
@@ -1,0 +1,3 @@
+fileFormatVersion: 2
+guid: a89aabaec6194f9594c756c5d4f6ed63
+timeCreated: 1770892165

--- a/Aspid.MVVM/Assets/Plugins/Aspid/MVVM/StarterKit/Unity/Runtime/Binders/AudioSources/Spread/AudioSourceSpreadBinder.cs
+++ b/Aspid.MVVM/Assets/Plugins/Aspid/MVVM/StarterKit/Unity/Runtime/Binders/AudioSources/Spread/AudioSourceSpreadBinder.cs
@@ -1,0 +1,63 @@
+#nullable enable
+using System;
+using UnityEngine;
+#if UNITY_2023_1_OR_NEWER
+using Converter = Aspid.MVVM.StarterKit.IConverter<float, float>;
+#else
+using Converter = Aspid.MVVM.StarterKit.IConverterFloat;
+#endif
+
+// ReSharper disable once CheckNamespace
+namespace Aspid.MVVM.StarterKit
+{
+    [Serializable]
+    [BindModeOverride(BindMode.OneWay, BindMode.OneTime, BindMode.OneWayToSource)]
+    public class AudioSourceSpreadBinder : TargetBinder<AudioSource>, INumberBinder, INumberReverseBinder
+    {
+        public event Action<int> IntValueChanged;
+        public event Action<long> LongValueChanged;
+        public event Action<float> FloatValueChanged;
+        public event Action<double> DoubleValueChanged;
+        
+        [SerializeReferenceDropdown]
+        [SerializeReference] private Converter? _converter;
+        
+        public AudioSourceSpreadBinder(AudioSource target, BindMode mode)
+            : this(target, converter: null, mode) { }
+        
+        public AudioSourceSpreadBinder(AudioSource target, Converter? converter = null, BindMode mode = BindMode.OneWay)
+            : base(target, mode)
+        {
+            mode.ThrowExceptionIfTwo();
+            _converter = converter;
+        }
+
+        public void SetValue(int value) => 
+            SetValue((float)value);
+
+        public void SetValue(long value) => 
+            SetValue((float)value);
+
+        public void SetValue(float value) =>
+            Target.spread = GetConvertedValue(value);
+
+        public void SetValue(double value) =>
+            SetValue((float)value);
+        
+        protected override void OnBound()
+        {
+            if (Mode is BindMode.OneWayToSource)
+            {
+                var value = GetConvertedValue(Target.spread);
+                
+                IntValueChanged?.Invoke((int)value);
+                LongValueChanged?.Invoke((long)value);
+                FloatValueChanged?.Invoke(value);
+                DoubleValueChanged?.Invoke(value);
+            }
+        }
+        
+        private float GetConvertedValue(float value) =>
+            _converter?.Convert(value) ?? value;
+    }
+}

--- a/Aspid.MVVM/Assets/Plugins/Aspid/MVVM/StarterKit/Unity/Runtime/Binders/AudioSources/Spread/AudioSourceSpreadBinder.cs.meta
+++ b/Aspid.MVVM/Assets/Plugins/Aspid/MVVM/StarterKit/Unity/Runtime/Binders/AudioSources/Spread/AudioSourceSpreadBinder.cs.meta
@@ -1,0 +1,3 @@
+fileFormatVersion: 2
+guid: f81a2392e06245ac81ec87c6f72a21f1
+timeCreated: 1770880453

--- a/Aspid.MVVM/Assets/Plugins/Aspid/MVVM/StarterKit/Unity/Runtime/Binders/AudioSources/Spread/AudioSourceSpreadSwitcherBinder.cs
+++ b/Aspid.MVVM/Assets/Plugins/Aspid/MVVM/StarterKit/Unity/Runtime/Binders/AudioSources/Spread/AudioSourceSpreadSwitcherBinder.cs
@@ -1,0 +1,40 @@
+#nullable enable
+using System;
+using UnityEngine;
+#if UNITY_2023_1_OR_NEWER
+using Converter = Aspid.MVVM.StarterKit.IConverter<float, float>;
+#else
+using Converter = Aspid.MVVM.StarterKit.IConverterFloat;
+#endif
+
+// ReSharper disable once CheckNamespace
+namespace Aspid.MVVM.StarterKit
+{
+    [Serializable]
+    public sealed class AudioSourceSpreadSwitcherBinder : SwitcherBinder<AudioSource, float>
+    {
+        [SerializeReferenceDropdown]
+        [SerializeReference] private Converter? _converter;
+        
+        public AudioSourceSpreadSwitcherBinder(
+            AudioSource target,
+            float trueValue, 
+            float falseValue,
+            BindMode mode)
+            : this(target, trueValue, falseValue, converter: null, mode) { }
+        
+        public AudioSourceSpreadSwitcherBinder(
+            AudioSource target,
+            float trueValue, 
+            float falseValue,
+            Converter? converter = null,
+            BindMode mode = BindMode.OneWay)
+            : base(target, trueValue, falseValue, mode)
+        {
+            _converter = converter;
+        }
+
+        protected override void SetValue(float value) =>
+            Target.spread = _converter?.Convert(value) ?? value;
+    }
+}

--- a/Aspid.MVVM/Assets/Plugins/Aspid/MVVM/StarterKit/Unity/Runtime/Binders/AudioSources/Spread/AudioSourceSpreadSwitcherBinder.cs.meta
+++ b/Aspid.MVVM/Assets/Plugins/Aspid/MVVM/StarterKit/Unity/Runtime/Binders/AudioSources/Spread/AudioSourceSpreadSwitcherBinder.cs.meta
@@ -1,0 +1,3 @@
+fileFormatVersion: 2
+guid: e38e62abccd9485d97e923cd4a04037e
+timeCreated: 1770880886

--- a/Aspid.MVVM/Assets/Plugins/Aspid/MVVM/StarterKit/Unity/Runtime/Binders/AudioSources/Spread/Mono.meta
+++ b/Aspid.MVVM/Assets/Plugins/Aspid/MVVM/StarterKit/Unity/Runtime/Binders/AudioSources/Spread/Mono.meta
@@ -1,0 +1,3 @@
+fileFormatVersion: 2
+guid: 99ac1428d35e4ba7b4a2331ca8aefb4b
+timeCreated: 1770892887

--- a/Aspid.MVVM/Assets/Plugins/Aspid/MVVM/StarterKit/Unity/Runtime/Binders/AudioSources/Spread/Mono/AudioSourceSpreadEnumGroupMonoBinder.cs
+++ b/Aspid.MVVM/Assets/Plugins/Aspid/MVVM/StarterKit/Unity/Runtime/Binders/AudioSources/Spread/Mono/AudioSourceSpreadEnumGroupMonoBinder.cs
@@ -1,0 +1,30 @@
+using UnityEngine;
+#if UNITY_2023_1_OR_NEWER
+using Converter = Aspid.MVVM.StarterKit.IConverter<float, float>;
+#else
+using Converter = Aspid.MVVM.StarterKit.IConverterFloat;
+#endif
+
+// ReSharper disable once CheckNamespace
+namespace Aspid.MVVM.StarterKit
+{
+    [AddBinderContextMenu(typeof(AudioSource), SubPath = "EnumGroup")]
+    [AddComponentMenu("Aspid/MVVM/Binders/Audio/AudioSource/AudioSource Binder – Spread EnumGroup")]
+    public sealed class AudioSourceSpreadEnumGroupMonoBinder : EnumGroupMonoBinder<AudioSource>
+    {
+        [SerializeField] private float _defaultValue;
+        [SerializeField] private float _selectedValue;
+        
+        [SerializeReferenceDropdown]
+        [SerializeReference] private Converter _defaultConverter;
+        
+        [SerializeReferenceDropdown]
+        [SerializeReference] private Converter _selectedConverter;
+        
+        protected override void SetDefaultValue(AudioSource element) =>
+            element.spread = _defaultConverter?.Convert(_defaultValue) ?? _defaultValue;
+
+        protected override void SetSelectedValue(AudioSource element) =>
+            element.spread = _selectedConverter?.Convert(_selectedValue) ?? _selectedValue;
+    }
+}

--- a/Aspid.MVVM/Assets/Plugins/Aspid/MVVM/StarterKit/Unity/Runtime/Binders/AudioSources/Spread/Mono/AudioSourceSpreadEnumGroupMonoBinder.cs.meta
+++ b/Aspid.MVVM/Assets/Plugins/Aspid/MVVM/StarterKit/Unity/Runtime/Binders/AudioSources/Spread/Mono/AudioSourceSpreadEnumGroupMonoBinder.cs.meta
@@ -1,0 +1,3 @@
+fileFormatVersion: 2
+guid: c79e05ebe54b4b4083df772c3cd8b1a0
+timeCreated: 1770880785

--- a/Aspid.MVVM/Assets/Plugins/Aspid/MVVM/StarterKit/Unity/Runtime/Binders/AudioSources/Spread/Mono/AudioSourceSpreadEnumMonoBinder.cs
+++ b/Aspid.MVVM/Assets/Plugins/Aspid/MVVM/StarterKit/Unity/Runtime/Binders/AudioSources/Spread/Mono/AudioSourceSpreadEnumMonoBinder.cs
@@ -1,0 +1,21 @@
+using UnityEngine;
+#if UNITY_2023_1_OR_NEWER
+using Converter = Aspid.MVVM.StarterKit.IConverter<float, float>;
+#else
+using Converter = Aspid.MVVM.StarterKit.IConverterFloat;
+#endif
+
+// ReSharper disable once CheckNamespace
+namespace Aspid.MVVM.StarterKit
+{
+    [AddBinderContextMenu(typeof(AudioSource), SubPath = "Enum")]
+    [AddComponentMenu("Aspid/MVVM/Binders/Audio/AudioSource/AudioSource Binder – Spread Enum")]
+    public sealed class AudioSourceSpreadEnumMonoBinder : EnumMonoBinder<AudioSource, float>
+    {
+        [SerializeReferenceDropdown]
+        [SerializeReference] private Converter _converter;
+        
+        protected override void SetValue(float value) =>
+            CachedComponent.spread = _converter?.Convert(value) ?? value;
+    }
+}

--- a/Aspid.MVVM/Assets/Plugins/Aspid/MVVM/StarterKit/Unity/Runtime/Binders/AudioSources/Spread/Mono/AudioSourceSpreadEnumMonoBinder.cs.meta
+++ b/Aspid.MVVM/Assets/Plugins/Aspid/MVVM/StarterKit/Unity/Runtime/Binders/AudioSources/Spread/Mono/AudioSourceSpreadEnumMonoBinder.cs.meta
@@ -1,0 +1,3 @@
+fileFormatVersion: 2
+guid: 95e5426c2c974a0c8c1bbabe83bead05
+timeCreated: 1770880784

--- a/Aspid.MVVM/Assets/Plugins/Aspid/MVVM/StarterKit/Unity/Runtime/Binders/AudioSources/Spread/Mono/AudioSourceSpreadMonoBinder.cs
+++ b/Aspid.MVVM/Assets/Plugins/Aspid/MVVM/StarterKit/Unity/Runtime/Binders/AudioSources/Spread/Mono/AudioSourceSpreadMonoBinder.cs
@@ -1,0 +1,57 @@
+using System;
+using UnityEngine;
+#if UNITY_2023_1_OR_NEWER
+using Converter = Aspid.MVVM.StarterKit.IConverter<float, float>;
+#else
+using Converter = Aspid.MVVM.StarterKit.IConverterFloat;
+#endif
+
+// ReSharper disable once CheckNamespace
+namespace Aspid.MVVM.StarterKit
+{
+    [AddBinderContextMenu(typeof(AudioSource))]
+    [AddComponentMenu("Aspid/MVVM/Binders/Audio/AudioSource/AudioSource Binder – Spread")]
+    [BindModeOverride(BindMode.OneWay, BindMode.OneTime, BindMode.OneWayToSource)]
+    public partial class AudioSourceSpreadMonoBinder : ComponentMonoBinder<AudioSource>, INumberBinder, INumberReverseBinder
+    {
+        public event Action<int> IntValueChanged;
+        public event Action<long> LongValueChanged;
+        public event Action<float> FloatValueChanged;
+        public event Action<double> DoubleValueChanged;
+        
+        [SerializeReferenceDropdown]
+        [SerializeReference] private Converter _converter;
+
+        [BinderLog]
+        public void SetValue(float value) =>
+            CachedComponent.spread = GetConvertedValue(value);
+
+        [BinderLog]
+        public void SetValue(int value) =>
+            SetValue((float)value);
+
+        [BinderLog]
+        public void SetValue(long value) =>
+            SetValue((float)value);
+
+        [BinderLog]
+        public void SetValue(double value) =>
+            SetValue((float)value);
+        
+        protected override void OnBound()
+        {
+            if (Mode is BindMode.OneWayToSource)
+            {
+                var value = GetConvertedValue(CachedComponent.spread);
+                
+                IntValueChanged?.Invoke((int)value);
+                LongValueChanged?.Invoke((long)value);
+                FloatValueChanged?.Invoke(value);
+                DoubleValueChanged?.Invoke(value);
+            }
+        }
+        
+        private float GetConvertedValue(float value) =>
+            _converter?.Convert(value) ?? value;
+    }
+}

--- a/Aspid.MVVM/Assets/Plugins/Aspid/MVVM/StarterKit/Unity/Runtime/Binders/AudioSources/Spread/Mono/AudioSourceSpreadMonoBinder.cs.meta
+++ b/Aspid.MVVM/Assets/Plugins/Aspid/MVVM/StarterKit/Unity/Runtime/Binders/AudioSources/Spread/Mono/AudioSourceSpreadMonoBinder.cs.meta
@@ -1,0 +1,3 @@
+fileFormatVersion: 2
+guid: ffcf4d34da8741bba07622c93e2d3dd0
+timeCreated: 1770880352

--- a/Aspid.MVVM/Assets/Plugins/Aspid/MVVM/StarterKit/Unity/Runtime/Binders/AudioSources/Spread/Mono/AudioSourceSpreadSwitcherMonoBinder.cs
+++ b/Aspid.MVVM/Assets/Plugins/Aspid/MVVM/StarterKit/Unity/Runtime/Binders/AudioSources/Spread/Mono/AudioSourceSpreadSwitcherMonoBinder.cs
@@ -1,0 +1,21 @@
+using UnityEngine;
+#if UNITY_2023_1_OR_NEWER
+using Converter = Aspid.MVVM.StarterKit.IConverter<float, float>;
+#else
+using Converter = Aspid.MVVM.StarterKit.IConverterFloat;
+#endif
+
+// ReSharper disable once CheckNamespace
+namespace Aspid.MVVM.StarterKit
+{
+    [AddBinderContextMenu(typeof(AudioSource), SubPath = "Switcher")]
+    [AddComponentMenu("Aspid/MVVM/Binders/Audio/AudioSource/AudioSource Binder – Spread Switcher")]
+    public sealed class AudioSourceSpreadSwitcherMonoBinder : SwitcherMonoBinder<AudioSource, float>
+    {
+        [SerializeReferenceDropdown]
+        [SerializeReference] private Converter _converter;
+        
+        protected override void SetValue(float value) =>
+            CachedComponent.spread = _converter?.Convert(value) ?? value;
+    }
+}

--- a/Aspid.MVVM/Assets/Plugins/Aspid/MVVM/StarterKit/Unity/Runtime/Binders/AudioSources/Spread/Mono/AudioSourceSpreadSwitcherMonoBinder.cs.meta
+++ b/Aspid.MVVM/Assets/Plugins/Aspid/MVVM/StarterKit/Unity/Runtime/Binders/AudioSources/Spread/Mono/AudioSourceSpreadSwitcherMonoBinder.cs.meta
@@ -1,0 +1,3 @@
+fileFormatVersion: 2
+guid: b6aaea8e81d2400ebc90f750621a1d13
+timeCreated: 1770880785

--- a/Aspid.MVVM/Assets/Plugins/Aspid/MVVM/StarterKit/Unity/Runtime/Binders/AudioSources/Time.meta
+++ b/Aspid.MVVM/Assets/Plugins/Aspid/MVVM/StarterKit/Unity/Runtime/Binders/AudioSources/Time.meta
@@ -1,0 +1,3 @@
+fileFormatVersion: 2
+guid: 89f4df0b47cc429cbd28e57f1f64f5b3
+timeCreated: 1770892081

--- a/Aspid.MVVM/Assets/Plugins/Aspid/MVVM/StarterKit/Unity/Runtime/Binders/AudioSources/Time/AudioSourceTimeBinder.cs
+++ b/Aspid.MVVM/Assets/Plugins/Aspid/MVVM/StarterKit/Unity/Runtime/Binders/AudioSources/Time/AudioSourceTimeBinder.cs
@@ -1,0 +1,63 @@
+#nullable enable
+using System;
+using UnityEngine;
+#if UNITY_2023_1_OR_NEWER
+using Converter = Aspid.MVVM.StarterKit.IConverter<float, float>;
+#else
+using Converter = Aspid.MVVM.StarterKit.IConverterFloat;
+#endif
+
+// ReSharper disable once CheckNamespace
+namespace Aspid.MVVM.StarterKit
+{
+    [Serializable]
+    [BindModeOverride(BindMode.OneWay, BindMode.OneTime, BindMode.OneWayToSource)]
+    public class AudioSourceTimeBinder : TargetBinder<AudioSource>, INumberBinder, INumberReverseBinder
+    {
+        public event Action<int>? IntValueChanged;
+        public event Action<long>? LongValueChanged;
+        public event Action<float>? FloatValueChanged;
+        public event Action<double>? DoubleValueChanged;
+        
+        [SerializeReferenceDropdown]
+        [SerializeReference] private Converter? _converter;
+        
+        public AudioSourceTimeBinder(AudioSource target, BindMode mode)
+            : this(target, converter: null, mode) { }
+        
+        public AudioSourceTimeBinder(AudioSource target, Converter? converter = null, BindMode mode = BindMode.OneWay)
+            : base(target, mode)
+        {
+            mode.ThrowExceptionIfTwo();
+            _converter = converter;
+        }
+
+        public void SetValue(int value) =>
+            SetValue((float)value);
+
+        public void SetValue(long value) => 
+            SetValue((float)value);
+        
+        public void SetValue(float value) =>
+            Target.time = _converter?.Convert(value) ?? value;
+
+        public void SetValue(double value) =>
+            SetValue((float)value);
+        
+        protected override void OnBound()
+        {
+            if (Mode is BindMode.OneWayToSource)
+            {
+                var value = GetConvertedValue(Target.time);
+                
+                IntValueChanged?.Invoke((int)value);
+                LongValueChanged?.Invoke((long)value);
+                FloatValueChanged?.Invoke(value);
+                DoubleValueChanged?.Invoke(value);
+            }
+        }
+        
+        private float GetConvertedValue(float value) =>
+            _converter?.Convert(value) ?? value;
+    }
+}

--- a/Aspid.MVVM/Assets/Plugins/Aspid/MVVM/StarterKit/Unity/Runtime/Binders/AudioSources/Time/AudioSourceTimeBinder.cs.meta
+++ b/Aspid.MVVM/Assets/Plugins/Aspid/MVVM/StarterKit/Unity/Runtime/Binders/AudioSources/Time/AudioSourceTimeBinder.cs.meta
@@ -1,0 +1,3 @@
+fileFormatVersion: 2
+guid: 2da73c6bfcc94863b877191da9254a9d
+timeCreated: 1770880451

--- a/Aspid.MVVM/Assets/Plugins/Aspid/MVVM/StarterKit/Unity/Runtime/Binders/AudioSources/Time/AudioSourceTimeSwitcherBinder.cs
+++ b/Aspid.MVVM/Assets/Plugins/Aspid/MVVM/StarterKit/Unity/Runtime/Binders/AudioSources/Time/AudioSourceTimeSwitcherBinder.cs
@@ -1,0 +1,40 @@
+#nullable enable
+using System;
+using UnityEngine;
+#if UNITY_2023_1_OR_NEWER
+using Converter = Aspid.MVVM.StarterKit.IConverter<float, float>;
+#else
+using Converter = Aspid.MVVM.StarterKit.IConverterFloat;
+#endif
+
+// ReSharper disable once CheckNamespace
+namespace Aspid.MVVM.StarterKit
+{
+    [Serializable]
+    public sealed class AudioSourceTimeSwitcherBinder : SwitcherBinder<AudioSource, float>
+    {
+        [SerializeReferenceDropdown]
+        [SerializeReference] private Converter? _converter;
+        
+        public AudioSourceTimeSwitcherBinder(
+            AudioSource target,
+            float trueValue, 
+            float falseValue,
+            BindMode mode)
+            : this(target, trueValue, falseValue, converter: null, mode) { }
+        
+        public AudioSourceTimeSwitcherBinder(
+            AudioSource target,
+            float trueValue, 
+            float falseValue,
+            Converter? converter = null,
+            BindMode mode = BindMode.OneWay)
+            : base(target, trueValue, falseValue, mode)
+        {
+            _converter = converter;
+        }
+
+        protected override void SetValue(float value) =>
+            Target.time = _converter?.Convert(value) ?? value;
+    }
+}

--- a/Aspid.MVVM/Assets/Plugins/Aspid/MVVM/StarterKit/Unity/Runtime/Binders/AudioSources/Time/AudioSourceTimeSwitcherBinder.cs.meta
+++ b/Aspid.MVVM/Assets/Plugins/Aspid/MVVM/StarterKit/Unity/Runtime/Binders/AudioSources/Time/AudioSourceTimeSwitcherBinder.cs.meta
@@ -1,0 +1,3 @@
+fileFormatVersion: 2
+guid: 4f52aaae2cb2446db495421cfefce5f4
+timeCreated: 1770880887

--- a/Aspid.MVVM/Assets/Plugins/Aspid/MVVM/StarterKit/Unity/Runtime/Binders/AudioSources/Time/Mono.meta
+++ b/Aspid.MVVM/Assets/Plugins/Aspid/MVVM/StarterKit/Unity/Runtime/Binders/AudioSources/Time/Mono.meta
@@ -1,0 +1,3 @@
+fileFormatVersion: 2
+guid: 4a42ae3be62e49e9b7ad65a14eeeb152
+timeCreated: 1770892885

--- a/Aspid.MVVM/Assets/Plugins/Aspid/MVVM/StarterKit/Unity/Runtime/Binders/AudioSources/Time/Mono/AudioSourceTimeEnumGroupMonoBinder.cs
+++ b/Aspid.MVVM/Assets/Plugins/Aspid/MVVM/StarterKit/Unity/Runtime/Binders/AudioSources/Time/Mono/AudioSourceTimeEnumGroupMonoBinder.cs
@@ -1,0 +1,30 @@
+using UnityEngine;
+#if UNITY_2023_1_OR_NEWER
+using Converter = Aspid.MVVM.StarterKit.IConverter<float, float>;
+#else
+using Converter = Aspid.MVVM.StarterKit.IConverterFloat;
+#endif
+
+// ReSharper disable once CheckNamespace
+namespace Aspid.MVVM.StarterKit
+{
+    [AddBinderContextMenu(typeof(AudioSource), SubPath = "EnumGroup")]
+    [AddComponentMenu("Aspid/MVVM/Binders/Audio/AudioSource/AudioSource Binder – Time EnumGroup")]
+    public sealed class AudioSourceTimeEnumGroupMonoBinder : EnumGroupMonoBinder<AudioSource>
+    {
+        [SerializeField] private float _defaultValue;
+        [SerializeField] private float _selectedValue;
+        
+        [SerializeReferenceDropdown]
+        [SerializeReference] private Converter _defaultConverter;
+        
+        [SerializeReferenceDropdown]
+        [SerializeReference] private Converter _selectedConverter;
+        
+        protected override void SetDefaultValue(AudioSource element) =>
+            element.time = _defaultConverter?.Convert(_defaultValue) ?? _defaultValue;
+
+        protected override void SetSelectedValue(AudioSource element) =>
+            element.time = _selectedConverter?.Convert(_selectedValue) ?? _selectedValue;
+    }
+}

--- a/Aspid.MVVM/Assets/Plugins/Aspid/MVVM/StarterKit/Unity/Runtime/Binders/AudioSources/Time/Mono/AudioSourceTimeEnumGroupMonoBinder.cs.meta
+++ b/Aspid.MVVM/Assets/Plugins/Aspid/MVVM/StarterKit/Unity/Runtime/Binders/AudioSources/Time/Mono/AudioSourceTimeEnumGroupMonoBinder.cs.meta
@@ -1,0 +1,3 @@
+fileFormatVersion: 2
+guid: 7b12ece93d3b42b8be87b790c44dc291
+timeCreated: 1770880835

--- a/Aspid.MVVM/Assets/Plugins/Aspid/MVVM/StarterKit/Unity/Runtime/Binders/AudioSources/Time/Mono/AudioSourceTimeEnumMonoBinder.cs
+++ b/Aspid.MVVM/Assets/Plugins/Aspid/MVVM/StarterKit/Unity/Runtime/Binders/AudioSources/Time/Mono/AudioSourceTimeEnumMonoBinder.cs
@@ -1,0 +1,21 @@
+using UnityEngine;
+#if UNITY_2023_1_OR_NEWER
+using Converter = Aspid.MVVM.StarterKit.IConverter<float, float>;
+#else
+using Converter = Aspid.MVVM.StarterKit.IConverterFloat;
+#endif
+
+// ReSharper disable once CheckNamespace
+namespace Aspid.MVVM.StarterKit
+{
+    [AddBinderContextMenu(typeof(AudioSource), SubPath = "Enum")]
+    [AddComponentMenu("Aspid/MVVM/Binders/Audio/AudioSource/AudioSource Binder – Time Enum")]
+    public sealed class AudioSourceTimeEnumMonoBinder : EnumMonoBinder<AudioSource, float>
+    {
+        [SerializeReferenceDropdown]
+        [SerializeReference] private Converter _converter;
+        
+        protected override void SetValue(float value) =>
+            CachedComponent.time = _converter?.Convert(value) ?? value;
+    }
+}

--- a/Aspid.MVVM/Assets/Plugins/Aspid/MVVM/StarterKit/Unity/Runtime/Binders/AudioSources/Time/Mono/AudioSourceTimeEnumMonoBinder.cs.meta
+++ b/Aspid.MVVM/Assets/Plugins/Aspid/MVVM/StarterKit/Unity/Runtime/Binders/AudioSources/Time/Mono/AudioSourceTimeEnumMonoBinder.cs.meta
@@ -1,0 +1,3 @@
+fileFormatVersion: 2
+guid: 80e224e137b846ddbf9df46ffa7ef972
+timeCreated: 1770880835

--- a/Aspid.MVVM/Assets/Plugins/Aspid/MVVM/StarterKit/Unity/Runtime/Binders/AudioSources/Time/Mono/AudioSourceTimeMonoBinder.cs
+++ b/Aspid.MVVM/Assets/Plugins/Aspid/MVVM/StarterKit/Unity/Runtime/Binders/AudioSources/Time/Mono/AudioSourceTimeMonoBinder.cs
@@ -1,0 +1,57 @@
+using System;
+using UnityEngine;
+#if UNITY_2023_1_OR_NEWER
+using Converter = Aspid.MVVM.StarterKit.IConverter<float, float>;
+#else
+using Converter = Aspid.MVVM.StarterKit.IConverterFloat;
+#endif
+
+// ReSharper disable once CheckNamespace
+namespace Aspid.MVVM.StarterKit
+{
+    [AddBinderContextMenu(typeof(AudioSource))]
+    [AddComponentMenu("Aspid/MVVM/Binders/Audio/AudioSource/AudioSource Binder – Time")]
+    [BindModeOverride(BindMode.OneWay, BindMode.OneTime, BindMode.OneWayToSource)]
+    public partial class AudioSourceTimeMonoBinder : ComponentMonoBinder<AudioSource>, INumberBinder, INumberReverseBinder
+    {
+        public event Action<int> IntValueChanged;
+        public event Action<long> LongValueChanged;
+        public event Action<float> FloatValueChanged;
+        public event Action<double> DoubleValueChanged;
+        
+        [SerializeReferenceDropdown]
+        [SerializeReference] private Converter _converter;
+
+        [BinderLog]
+        public void SetValue(float value) =>
+            CachedComponent.time = GetConvertedValue(value);
+
+        [BinderLog]
+        public void SetValue(int value) =>
+            SetValue((float)value);
+
+        [BinderLog]
+        public void SetValue(long value) =>
+            SetValue((float)value);
+
+        [BinderLog]
+        public void SetValue(double value) =>
+            SetValue((float)value);
+        
+        protected override void OnBound()
+        {
+            if (Mode is BindMode.OneWayToSource)
+            {
+                var value = GetConvertedValue(CachedComponent.time);
+                
+                IntValueChanged?.Invoke((int)value);
+                LongValueChanged?.Invoke((long)value);
+                FloatValueChanged?.Invoke(value);
+                DoubleValueChanged?.Invoke(value);
+            }
+        }
+        
+        private float GetConvertedValue(float value) =>
+            _converter?.Convert(value) ?? value;
+    }
+}

--- a/Aspid.MVVM/Assets/Plugins/Aspid/MVVM/StarterKit/Unity/Runtime/Binders/AudioSources/Time/Mono/AudioSourceTimeMonoBinder.cs.meta
+++ b/Aspid.MVVM/Assets/Plugins/Aspid/MVVM/StarterKit/Unity/Runtime/Binders/AudioSources/Time/Mono/AudioSourceTimeMonoBinder.cs.meta
@@ -1,0 +1,3 @@
+fileFormatVersion: 2
+guid: 4b041bc093c14dd58762eb2cf1a8fca5
+timeCreated: 1770880351

--- a/Aspid.MVVM/Assets/Plugins/Aspid/MVVM/StarterKit/Unity/Runtime/Binders/AudioSources/Time/Mono/AudioSourceTimeSwitcherMonoBinder.cs
+++ b/Aspid.MVVM/Assets/Plugins/Aspid/MVVM/StarterKit/Unity/Runtime/Binders/AudioSources/Time/Mono/AudioSourceTimeSwitcherMonoBinder.cs
@@ -1,0 +1,21 @@
+using UnityEngine;
+#if UNITY_2023_1_OR_NEWER
+using Converter = Aspid.MVVM.StarterKit.IConverter<float, float>;
+#else
+using Converter = Aspid.MVVM.StarterKit.IConverterFloat;
+#endif
+
+// ReSharper disable once CheckNamespace
+namespace Aspid.MVVM.StarterKit
+{
+    [AddBinderContextMenu(typeof(AudioSource), SubPath = "Switcher")]
+    [AddComponentMenu("Aspid/MVVM/Binders/Audio/AudioSource/AudioSource Binder – Time Switcher")]
+    public sealed class AudioSourceTimeSwitcherMonoBinder : SwitcherMonoBinder<AudioSource, float>
+    {
+        [SerializeReferenceDropdown]
+        [SerializeReference] private Converter _converter;
+        
+        protected override void SetValue(float value) =>
+            CachedComponent.time = _converter?.Convert(value) ?? value;
+    }
+}

--- a/Aspid.MVVM/Assets/Plugins/Aspid/MVVM/StarterKit/Unity/Runtime/Binders/AudioSources/Time/Mono/AudioSourceTimeSwitcherMonoBinder.cs.meta
+++ b/Aspid.MVVM/Assets/Plugins/Aspid/MVVM/StarterKit/Unity/Runtime/Binders/AudioSources/Time/Mono/AudioSourceTimeSwitcherMonoBinder.cs.meta
@@ -1,0 +1,3 @@
+fileFormatVersion: 2
+guid: eb592a67fbea4cdfb5c54d4d0a256554
+timeCreated: 1770880836

--- a/Aspid.MVVM/Assets/Plugins/Aspid/MVVM/StarterKit/Unity/Runtime/Binders/AudioSources/TimeSamples.meta
+++ b/Aspid.MVVM/Assets/Plugins/Aspid/MVVM/StarterKit/Unity/Runtime/Binders/AudioSources/TimeSamples.meta
@@ -1,0 +1,3 @@
+fileFormatVersion: 2
+guid: d6eb60feafe1467f9cfa9f06ca977c81
+timeCreated: 1770892103

--- a/Aspid.MVVM/Assets/Plugins/Aspid/MVVM/StarterKit/Unity/Runtime/Binders/AudioSources/TimeSamples/AudioSourceTimeSamplesBinder.cs
+++ b/Aspid.MVVM/Assets/Plugins/Aspid/MVVM/StarterKit/Unity/Runtime/Binders/AudioSources/TimeSamples/AudioSourceTimeSamplesBinder.cs
@@ -1,0 +1,63 @@
+#nullable enable
+using System;
+using UnityEngine;
+#if UNITY_2023_1_OR_NEWER
+using Converter = Aspid.MVVM.StarterKit.IConverter<int, int>;
+#else
+using Converter = Aspid.MVVM.StarterKit.IConverterInt;
+#endif
+
+// ReSharper disable once CheckNamespace
+namespace Aspid.MVVM.StarterKit
+{
+    [Serializable]
+    [BindModeOverride(BindMode.OneWay, BindMode.OneTime, BindMode.OneWayToSource)]
+    public class AudioSourceTimeSamplesBinder : TargetBinder<AudioSource>, INumberBinder, INumberReverseBinder
+    {
+        public event Action<int>? IntValueChanged;
+        public event Action<long>? LongValueChanged;
+        public event Action<float>? FloatValueChanged;
+        public event Action<double>? DoubleValueChanged;
+        
+        [SerializeReferenceDropdown]
+        [SerializeReference] private Converter? _converter;
+        
+        public AudioSourceTimeSamplesBinder(AudioSource target, BindMode mode)
+            : this(target, converter: null, mode) { }
+        
+        public AudioSourceTimeSamplesBinder(AudioSource target, Converter? converter = null, BindMode mode = BindMode.OneWay)
+            : base(target, mode)
+        {
+            mode.ThrowExceptionIfTwo();
+            _converter = converter;
+        }
+
+        public void SetValue(int value) =>
+            Target.timeSamples = GetConvertedValue(value);
+
+        public void SetValue(float value) =>
+            SetValue((int)value);
+
+        public void SetValue(long value) => 
+            SetValue((int)value);
+
+        public void SetValue(double value) => 
+            SetValue((int)value);
+        
+        protected override void OnBound()
+        {
+            if (Mode is BindMode.OneWayToSource)
+            {
+                var value = GetConvertedValue(Target.timeSamples);
+                
+                IntValueChanged?.Invoke(value);
+                LongValueChanged?.Invoke(value);
+                FloatValueChanged?.Invoke(value);
+                DoubleValueChanged?.Invoke(value);
+            }
+        }
+        
+        private int GetConvertedValue(int value) =>
+            _converter?.Convert(value) ?? value;
+    }
+}

--- a/Aspid.MVVM/Assets/Plugins/Aspid/MVVM/StarterKit/Unity/Runtime/Binders/AudioSources/TimeSamples/AudioSourceTimeSamplesBinder.cs.meta
+++ b/Aspid.MVVM/Assets/Plugins/Aspid/MVVM/StarterKit/Unity/Runtime/Binders/AudioSources/TimeSamples/AudioSourceTimeSamplesBinder.cs.meta
@@ -1,0 +1,3 @@
+fileFormatVersion: 2
+guid: 3fe6e294688147c3b716e649e9024f65
+timeCreated: 1770880452

--- a/Aspid.MVVM/Assets/Plugins/Aspid/MVVM/StarterKit/Unity/Runtime/Binders/AudioSources/TimeSamples/AudioSourceTimeSamplesSwitcherBinder.cs
+++ b/Aspid.MVVM/Assets/Plugins/Aspid/MVVM/StarterKit/Unity/Runtime/Binders/AudioSources/TimeSamples/AudioSourceTimeSamplesSwitcherBinder.cs
@@ -1,0 +1,40 @@
+#nullable enable
+using System;
+using UnityEngine;
+#if UNITY_2023_1_OR_NEWER
+using Converter = Aspid.MVVM.StarterKit.IConverter<int, int>;
+#else
+using Converter = Aspid.MVVM.StarterKit.IConverterInt;
+#endif
+
+// ReSharper disable once CheckNamespace
+namespace Aspid.MVVM.StarterKit
+{
+    [Serializable]
+    public sealed class AudioSourceTimeSamplesSwitcherBinder : SwitcherBinder<AudioSource, int>
+    {
+        [SerializeReferenceDropdown]
+        [SerializeReference] private Converter? _converter;
+        
+        public AudioSourceTimeSamplesSwitcherBinder(
+            AudioSource target,
+            int trueValue, 
+            int falseValue,
+            BindMode mode)
+            : this(target, trueValue, falseValue, converter: null, mode) { }
+        
+        public AudioSourceTimeSamplesSwitcherBinder(
+            AudioSource target,
+            int trueValue, 
+            int falseValue,
+            Converter? converter = null,
+            BindMode mode = BindMode.OneWay)
+            : base(target, trueValue, falseValue, mode)
+        {
+            _converter = converter;
+        }
+
+        protected override void SetValue(int value) =>
+            Target.timeSamples = _converter?.Convert(value) ?? value;
+    }
+}

--- a/Aspid.MVVM/Assets/Plugins/Aspid/MVVM/StarterKit/Unity/Runtime/Binders/AudioSources/TimeSamples/AudioSourceTimeSamplesSwitcherBinder.cs.meta
+++ b/Aspid.MVVM/Assets/Plugins/Aspid/MVVM/StarterKit/Unity/Runtime/Binders/AudioSources/TimeSamples/AudioSourceTimeSamplesSwitcherBinder.cs.meta
@@ -1,0 +1,3 @@
+fileFormatVersion: 2
+guid: b2d5e21fc2d442f6bf85e5455f4999e7
+timeCreated: 1770880887

--- a/Aspid.MVVM/Assets/Plugins/Aspid/MVVM/StarterKit/Unity/Runtime/Binders/AudioSources/TimeSamples/Mono.meta
+++ b/Aspid.MVVM/Assets/Plugins/Aspid/MVVM/StarterKit/Unity/Runtime/Binders/AudioSources/TimeSamples/Mono.meta
@@ -1,0 +1,3 @@
+fileFormatVersion: 2
+guid: d71ad5a1f35d4a9aaa445bb83cf16c84
+timeCreated: 1770892884

--- a/Aspid.MVVM/Assets/Plugins/Aspid/MVVM/StarterKit/Unity/Runtime/Binders/AudioSources/TimeSamples/Mono/AudioSourceTimeSamplesEnumGroupMonoBinder.cs
+++ b/Aspid.MVVM/Assets/Plugins/Aspid/MVVM/StarterKit/Unity/Runtime/Binders/AudioSources/TimeSamples/Mono/AudioSourceTimeSamplesEnumGroupMonoBinder.cs
@@ -1,0 +1,30 @@
+using UnityEngine;
+#if UNITY_2023_1_OR_NEWER
+using Converter = Aspid.MVVM.StarterKit.IConverter<int, int>;
+#else
+using Converter = Aspid.MVVM.StarterKit.IConverterInt;
+#endif
+
+// ReSharper disable once CheckNamespace
+namespace Aspid.MVVM.StarterKit
+{
+    [AddBinderContextMenu(typeof(AudioSource), SubPath = "EnumGroup")]
+    [AddComponentMenu("Aspid/MVVM/Binders/Audio/AudioSource/AudioSource Binder – TimeSamples EnumGroup")]
+    public sealed class AudioSourceTimeSamplesEnumGroupMonoBinder : EnumGroupMonoBinder<AudioSource>
+    {
+        [SerializeField] private int _defaultValue;
+        [SerializeField] private int _selectedValue;
+        
+        [SerializeReferenceDropdown]
+        [SerializeReference] private Converter _defaultConverter;
+        
+        [SerializeReferenceDropdown]
+        [SerializeReference] private Converter _selectedConverter;
+        
+        protected override void SetDefaultValue(AudioSource element) =>
+            element.timeSamples = _defaultConverter?.Convert(_defaultValue) ?? _defaultValue;
+
+        protected override void SetSelectedValue(AudioSource element) =>
+            element.timeSamples = _selectedConverter?.Convert(_selectedValue) ?? _selectedValue;
+    }
+}

--- a/Aspid.MVVM/Assets/Plugins/Aspid/MVVM/StarterKit/Unity/Runtime/Binders/AudioSources/TimeSamples/Mono/AudioSourceTimeSamplesEnumGroupMonoBinder.cs.meta
+++ b/Aspid.MVVM/Assets/Plugins/Aspid/MVVM/StarterKit/Unity/Runtime/Binders/AudioSources/TimeSamples/Mono/AudioSourceTimeSamplesEnumGroupMonoBinder.cs.meta
@@ -1,0 +1,3 @@
+fileFormatVersion: 2
+guid: eb5acc4b44444d2d8f3ed5fd8f00802f
+timeCreated: 1770880836

--- a/Aspid.MVVM/Assets/Plugins/Aspid/MVVM/StarterKit/Unity/Runtime/Binders/AudioSources/TimeSamples/Mono/AudioSourceTimeSamplesEnumMonoBinder.cs
+++ b/Aspid.MVVM/Assets/Plugins/Aspid/MVVM/StarterKit/Unity/Runtime/Binders/AudioSources/TimeSamples/Mono/AudioSourceTimeSamplesEnumMonoBinder.cs
@@ -1,0 +1,21 @@
+using UnityEngine;
+#if UNITY_2023_1_OR_NEWER
+using Converter = Aspid.MVVM.StarterKit.IConverter<int, int>;
+#else
+using Converter = Aspid.MVVM.StarterKit.IConverterInt;
+#endif
+
+// ReSharper disable once CheckNamespace
+namespace Aspid.MVVM.StarterKit
+{
+    [AddBinderContextMenu(typeof(AudioSource), SubPath = "Enum")]
+    [AddComponentMenu("Aspid/MVVM/Binders/Audio/AudioSource/AudioSource Binder – TimeSamples Enum")]
+    public sealed class AudioSourceTimeSamplesEnumMonoBinder : EnumMonoBinder<AudioSource, int>
+    {
+        [SerializeReferenceDropdown]
+        [SerializeReference] private Converter _converter;
+        
+        protected override void SetValue(int value) =>
+            CachedComponent.timeSamples = _converter?.Convert(value) ?? value;
+    }
+}

--- a/Aspid.MVVM/Assets/Plugins/Aspid/MVVM/StarterKit/Unity/Runtime/Binders/AudioSources/TimeSamples/Mono/AudioSourceTimeSamplesEnumMonoBinder.cs.meta
+++ b/Aspid.MVVM/Assets/Plugins/Aspid/MVVM/StarterKit/Unity/Runtime/Binders/AudioSources/TimeSamples/Mono/AudioSourceTimeSamplesEnumMonoBinder.cs.meta
@@ -1,0 +1,3 @@
+fileFormatVersion: 2
+guid: f4905fcce0e440ab8a53b3c5be512427
+timeCreated: 1770880836

--- a/Aspid.MVVM/Assets/Plugins/Aspid/MVVM/StarterKit/Unity/Runtime/Binders/AudioSources/TimeSamples/Mono/AudioSourceTimeSamplesMonoBinder.cs
+++ b/Aspid.MVVM/Assets/Plugins/Aspid/MVVM/StarterKit/Unity/Runtime/Binders/AudioSources/TimeSamples/Mono/AudioSourceTimeSamplesMonoBinder.cs
@@ -1,0 +1,57 @@
+using System;
+using UnityEngine;
+#if UNITY_2023_1_OR_NEWER
+using Converter = Aspid.MVVM.StarterKit.IConverter<int, int>;
+#else
+using Converter = Aspid.MVVM.StarterKit.IConverterInt;
+#endif
+
+// ReSharper disable once CheckNamespace
+namespace Aspid.MVVM.StarterKit
+{
+    [AddBinderContextMenu(typeof(AudioSource))]
+    [AddComponentMenu("Aspid/MVVM/Binders/Audio/AudioSource/AudioSource Binder – TimeSamples")]
+    [BindModeOverride(BindMode.OneWay, BindMode.OneTime, BindMode.OneWayToSource)]
+    public partial class AudioSourceTimeSamplesMonoBinder : ComponentMonoBinder<AudioSource>, INumberBinder, INumberReverseBinder
+    {
+        public event Action<int> IntValueChanged;
+        public event Action<long> LongValueChanged;
+        public event Action<float> FloatValueChanged;
+        public event Action<double> DoubleValueChanged;
+        
+        [SerializeReferenceDropdown]
+        [SerializeReference] private Converter _converter;
+
+        [BinderLog]
+        public void SetValue(int value) =>
+            CachedComponent.timeSamples = GetConvertedValue(value);
+        
+        [BinderLog]
+        public void SetValue(float value) =>
+            SetValue((int)value);
+        
+        [BinderLog]
+        public void SetValue(long value) =>
+            SetValue((int)value);
+        
+        [BinderLog]
+        public void SetValue(double value) =>
+            SetValue((int)value);
+        
+        protected override void OnBound()
+        {
+            if (Mode is BindMode.OneWayToSource)
+            {
+                var value = GetConvertedValue(CachedComponent.timeSamples);
+                
+                IntValueChanged?.Invoke(value);
+                LongValueChanged?.Invoke(value);
+                FloatValueChanged?.Invoke(value);
+                DoubleValueChanged?.Invoke(value);
+            }
+        }
+        
+        private int GetConvertedValue(int value) =>
+            _converter?.Convert(value) ?? value;
+    }
+}

--- a/Aspid.MVVM/Assets/Plugins/Aspid/MVVM/StarterKit/Unity/Runtime/Binders/AudioSources/TimeSamples/Mono/AudioSourceTimeSamplesMonoBinder.cs.meta
+++ b/Aspid.MVVM/Assets/Plugins/Aspid/MVVM/StarterKit/Unity/Runtime/Binders/AudioSources/TimeSamples/Mono/AudioSourceTimeSamplesMonoBinder.cs.meta
@@ -1,0 +1,3 @@
+fileFormatVersion: 2
+guid: cfa72af8d59346809898df9d075d00b5
+timeCreated: 1770880351

--- a/Aspid.MVVM/Assets/Plugins/Aspid/MVVM/StarterKit/Unity/Runtime/Binders/AudioSources/TimeSamples/Mono/AudioSourceTimeSamplesSwitcherMonoBinder.cs
+++ b/Aspid.MVVM/Assets/Plugins/Aspid/MVVM/StarterKit/Unity/Runtime/Binders/AudioSources/TimeSamples/Mono/AudioSourceTimeSamplesSwitcherMonoBinder.cs
@@ -1,0 +1,21 @@
+using UnityEngine;
+#if UNITY_2023_1_OR_NEWER
+using Converter = Aspid.MVVM.StarterKit.IConverter<int, int>;
+#else
+using Converter = Aspid.MVVM.StarterKit.IConverterInt;
+#endif
+
+// ReSharper disable once CheckNamespace
+namespace Aspid.MVVM.StarterKit
+{
+    [AddBinderContextMenu(typeof(AudioSource), SubPath = "Switcher")]
+    [AddComponentMenu("Aspid/MVVM/Binders/Audio/AudioSource/AudioSource Binder – TimeSamples Switcher")]
+    public sealed class AudioSourceTimeSamplesSwitcherMonoBinder : SwitcherMonoBinder<AudioSource, int>
+    {
+        [SerializeReferenceDropdown]
+        [SerializeReference] private Converter _converter;
+        
+        protected override void SetValue(int value) =>
+            CachedComponent.timeSamples = _converter?.Convert(value) ?? value;
+    }
+}

--- a/Aspid.MVVM/Assets/Plugins/Aspid/MVVM/StarterKit/Unity/Runtime/Binders/AudioSources/TimeSamples/Mono/AudioSourceTimeSamplesSwitcherMonoBinder.cs.meta
+++ b/Aspid.MVVM/Assets/Plugins/Aspid/MVVM/StarterKit/Unity/Runtime/Binders/AudioSources/TimeSamples/Mono/AudioSourceTimeSamplesSwitcherMonoBinder.cs.meta
@@ -1,0 +1,3 @@
+fileFormatVersion: 2
+guid: f2ac3e924cfa4dd4921ce4d3d56dbd37
+timeCreated: 1770880836

--- a/Aspid.MVVM/Assets/Plugins/Aspid/MVVM/StarterKit/Unity/Runtime/Binders/AudioSources/Volume.meta
+++ b/Aspid.MVVM/Assets/Plugins/Aspid/MVVM/StarterKit/Unity/Runtime/Binders/AudioSources/Volume.meta
@@ -1,0 +1,3 @@
+fileFormatVersion: 2
+guid: 9ef89e1298b34c6c90a2abea1ac1b4a7
+timeCreated: 1770892063

--- a/Aspid.MVVM/Assets/Plugins/Aspid/MVVM/StarterKit/Unity/Runtime/Binders/AudioSources/Volume/AudioSourceVolumeBinder.cs
+++ b/Aspid.MVVM/Assets/Plugins/Aspid/MVVM/StarterKit/Unity/Runtime/Binders/AudioSources/Volume/AudioSourceVolumeBinder.cs
@@ -1,0 +1,63 @@
+#nullable enable
+using System;
+using UnityEngine;
+#if UNITY_2023_1_OR_NEWER
+using Converter = Aspid.MVVM.StarterKit.IConverter<float, float>;
+#else
+using Converter = Aspid.MVVM.StarterKit.IConverterFloat;
+#endif
+
+// ReSharper disable once CheckNamespace
+namespace Aspid.MVVM.StarterKit
+{
+    [Serializable]
+    [BindModeOverride(BindMode.OneWay, BindMode.OneTime, BindMode.OneWayToSource)]
+    public class AudioSourceVolumeBinder : TargetBinder<AudioSource>, INumberBinder, INumberReverseBinder
+    {
+        public event Action<int>? IntValueChanged;
+        public event Action<long>? LongValueChanged;
+        public event Action<float>? FloatValueChanged;
+        public event Action<double>? DoubleValueChanged;
+        
+        [SerializeReferenceDropdown]
+        [SerializeReference] private Converter? _converter;
+        
+        public AudioSourceVolumeBinder(AudioSource target, BindMode mode)
+            : this(target, converter: null, mode) { }
+        
+        public AudioSourceVolumeBinder(AudioSource target, Converter? converter = null, BindMode mode = BindMode.OneWay)
+            : base(target, mode)
+        {
+            mode.ThrowExceptionIfTwo();
+            _converter = converter;
+        }
+
+        public void SetValue(int value) =>
+            SetValue((float)value);
+
+        public void SetValue(long value) =>
+            SetValue((float)value);
+        
+        public void SetValue(float value) =>
+            Target.volume = _converter?.Convert(value) ?? value;
+
+        public void SetValue(double value) =>
+            SetValue((float)value);
+        
+        protected override void OnBound()
+        {
+            if (Mode is BindMode.OneWayToSource)
+            {
+                var value = GetConvertedValue(Target.volume);
+                
+                IntValueChanged?.Invoke((int)value);
+                LongValueChanged?.Invoke((long)value);
+                FloatValueChanged?.Invoke(value);
+                DoubleValueChanged?.Invoke(value);
+            }
+        }
+        
+        private float GetConvertedValue(float value) =>
+            _converter?.Convert(value) ?? value;
+    }
+}

--- a/Aspid.MVVM/Assets/Plugins/Aspid/MVVM/StarterKit/Unity/Runtime/Binders/AudioSources/Volume/AudioSourceVolumeBinder.cs.meta
+++ b/Aspid.MVVM/Assets/Plugins/Aspid/MVVM/StarterKit/Unity/Runtime/Binders/AudioSources/Volume/AudioSourceVolumeBinder.cs.meta
@@ -1,0 +1,3 @@
+fileFormatVersion: 2
+guid: 07c6d45b1cd7467ab8505a09f030ad77
+timeCreated: 1770880586

--- a/Aspid.MVVM/Assets/Plugins/Aspid/MVVM/StarterKit/Unity/Runtime/Binders/AudioSources/Volume/AudioSourceVolumeSwitcherBinder.cs
+++ b/Aspid.MVVM/Assets/Plugins/Aspid/MVVM/StarterKit/Unity/Runtime/Binders/AudioSources/Volume/AudioSourceVolumeSwitcherBinder.cs
@@ -1,0 +1,40 @@
+#nullable enable
+using System;
+using UnityEngine;
+#if UNITY_2023_1_OR_NEWER
+using Converter = Aspid.MVVM.StarterKit.IConverter<float, float>;
+#else
+using Converter = Aspid.MVVM.StarterKit.IConverterFloat;
+#endif
+
+// ReSharper disable once CheckNamespace
+namespace Aspid.MVVM.StarterKit
+{
+    [Serializable]
+    public sealed class AudioSourceVolumeSwitcherBinder : SwitcherBinder<AudioSource, float>
+    {
+        [SerializeReferenceDropdown]
+        [SerializeReference] private Converter? _converter;
+        
+        public AudioSourceVolumeSwitcherBinder(
+            AudioSource target,
+            float trueValue, 
+            float falseValue,
+            BindMode mode)
+            : this(target, trueValue, falseValue, converter: null, mode) { }
+        
+        public AudioSourceVolumeSwitcherBinder(
+            AudioSource target,
+            float trueValue, 
+            float falseValue,
+            Converter? converter = null,
+            BindMode mode = BindMode.OneWay)
+            : base(target, trueValue, falseValue, mode)
+        {
+            _converter = converter;
+        }
+
+        protected override void SetValue(float value) =>
+            Target.volume = _converter?.Convert(value) ?? value;
+    }
+}

--- a/Aspid.MVVM/Assets/Plugins/Aspid/MVVM/StarterKit/Unity/Runtime/Binders/AudioSources/Volume/AudioSourceVolumeSwitcherBinder.cs.meta
+++ b/Aspid.MVVM/Assets/Plugins/Aspid/MVVM/StarterKit/Unity/Runtime/Binders/AudioSources/Volume/AudioSourceVolumeSwitcherBinder.cs.meta
@@ -1,0 +1,3 @@
+fileFormatVersion: 2
+guid: b5a07c81c4314bcd9e43858fff74c24d
+timeCreated: 1770880400

--- a/Aspid.MVVM/Assets/Plugins/Aspid/MVVM/StarterKit/Unity/Runtime/Binders/AudioSources/Volume/Mono.meta
+++ b/Aspid.MVVM/Assets/Plugins/Aspid/MVVM/StarterKit/Unity/Runtime/Binders/AudioSources/Volume/Mono.meta
@@ -1,0 +1,3 @@
+fileFormatVersion: 2
+guid: 26494d46b9a743e7ac319fb3d48ea23b
+timeCreated: 1770892883

--- a/Aspid.MVVM/Assets/Plugins/Aspid/MVVM/StarterKit/Unity/Runtime/Binders/AudioSources/Volume/Mono/AudioSourceVolumeEnumGroupMonoBinder.cs
+++ b/Aspid.MVVM/Assets/Plugins/Aspid/MVVM/StarterKit/Unity/Runtime/Binders/AudioSources/Volume/Mono/AudioSourceVolumeEnumGroupMonoBinder.cs
@@ -1,0 +1,30 @@
+using UnityEngine;
+#if UNITY_2023_1_OR_NEWER
+using Converter = Aspid.MVVM.StarterKit.IConverter<float, float>;
+#else
+using Converter = Aspid.MVVM.StarterKit.IConverterFloat;
+#endif
+
+// ReSharper disable once CheckNamespace
+namespace Aspid.MVVM.StarterKit
+{
+    [AddBinderContextMenu(typeof(AudioSource), SubPath = "EnumGroup")]
+    [AddComponentMenu("Aspid/MVVM/Binders/Audio/AudioSource/AudioSource Binder – Volume EnumGroup")]
+    public sealed class AudioSourceVolumeEnumGroupMonoBinder : EnumGroupMonoBinder<AudioSource>
+    {
+        [SerializeField] [Range(0, 1)] private float _defaultValue;
+        [SerializeField] [Range(0, 1)] private float _selectedValue;
+        
+        [SerializeReferenceDropdown]
+        [SerializeReference] private Converter _defaultConverter;
+        
+        [SerializeReferenceDropdown]
+        [SerializeReference] private Converter _selectedConverter;
+        
+        protected override void SetDefaultValue(AudioSource element) =>
+            element.volume = _defaultConverter?.Convert(_defaultValue) ?? _defaultValue;
+
+        protected override void SetSelectedValue(AudioSource element) =>
+            element.volume = _selectedConverter?.Convert(_selectedValue) ?? _selectedValue;
+    }
+}

--- a/Aspid.MVVM/Assets/Plugins/Aspid/MVVM/StarterKit/Unity/Runtime/Binders/AudioSources/Volume/Mono/AudioSourceVolumeEnumGroupMonoBinder.cs.meta
+++ b/Aspid.MVVM/Assets/Plugins/Aspid/MVVM/StarterKit/Unity/Runtime/Binders/AudioSources/Volume/Mono/AudioSourceVolumeEnumGroupMonoBinder.cs.meta
@@ -1,0 +1,3 @@
+fileFormatVersion: 2
+guid: e8cbe0deea0548debbcb17f9cfc54851
+timeCreated: 1770576978

--- a/Aspid.MVVM/Assets/Plugins/Aspid/MVVM/StarterKit/Unity/Runtime/Binders/AudioSources/Volume/Mono/AudioSourceVolumeEnumMonoBinder.cs
+++ b/Aspid.MVVM/Assets/Plugins/Aspid/MVVM/StarterKit/Unity/Runtime/Binders/AudioSources/Volume/Mono/AudioSourceVolumeEnumMonoBinder.cs
@@ -1,0 +1,21 @@
+using UnityEngine;
+#if UNITY_2023_1_OR_NEWER
+using Converter = Aspid.MVVM.StarterKit.IConverter<float, float>;
+#else
+using Converter = Aspid.MVVM.StarterKit.IConverterFloat;
+#endif
+
+// ReSharper disable once CheckNamespace
+namespace Aspid.MVVM.StarterKit
+{
+    [AddBinderContextMenu(typeof(AudioSource), SubPath = "Enum")]
+    [AddComponentMenu("Aspid/MVVM/Binders/Audio/AudioSource/AudioSource Binder – Volume Enum")]
+    public sealed class AudioSourceVolumeEnumMonoBinder : EnumMonoBinder<AudioSource, float>
+    {
+        [SerializeReferenceDropdown]
+        [SerializeReference] private Converter _converter;
+        
+        protected override void SetValue(float value) =>
+            CachedComponent.volume = _converter?.Convert(value) ?? value;
+    }
+}

--- a/Aspid.MVVM/Assets/Plugins/Aspid/MVVM/StarterKit/Unity/Runtime/Binders/AudioSources/Volume/Mono/AudioSourceVolumeEnumMonoBinder.cs.meta
+++ b/Aspid.MVVM/Assets/Plugins/Aspid/MVVM/StarterKit/Unity/Runtime/Binders/AudioSources/Volume/Mono/AudioSourceVolumeEnumMonoBinder.cs.meta
@@ -1,0 +1,3 @@
+fileFormatVersion: 2
+guid: d4edc23cf8e94413a4561ff116a292e7
+timeCreated: 1770576978

--- a/Aspid.MVVM/Assets/Plugins/Aspid/MVVM/StarterKit/Unity/Runtime/Binders/AudioSources/Volume/Mono/AudioSourceVolumeMonoBinder.cs
+++ b/Aspid.MVVM/Assets/Plugins/Aspid/MVVM/StarterKit/Unity/Runtime/Binders/AudioSources/Volume/Mono/AudioSourceVolumeMonoBinder.cs
@@ -1,0 +1,57 @@
+using System;
+using UnityEngine;
+#if UNITY_2023_1_OR_NEWER
+using Converter = Aspid.MVVM.StarterKit.IConverter<float, float>;
+#else
+using Converter = Aspid.MVVM.StarterKit.IConverterFloat;
+#endif
+
+// ReSharper disable once CheckNamespace
+namespace Aspid.MVVM.StarterKit
+{
+    [AddBinderContextMenu(typeof(AudioSource))]
+    [AddComponentMenu("Aspid/MVVM/Binders/Audio/AudioSource/AudioSource Binder – Volume")]
+    [BindModeOverride(BindMode.OneWay, BindMode.OneTime, BindMode.OneWayToSource)]
+    public partial class AudioSourceVolumeMonoBinder : ComponentMonoBinder<AudioSource>, INumberBinder, INumberReverseBinder
+    {
+        public event Action<int> IntValueChanged;
+        public event Action<long> LongValueChanged;
+        public event Action<float> FloatValueChanged;
+        public event Action<double> DoubleValueChanged;
+        
+        [SerializeReferenceDropdown]
+        [SerializeReference] private Converter _converter;
+
+        [BinderLog]
+        public void SetValue(float value) =>
+            CachedComponent.volume = GetConvertedValue(value);
+
+        [BinderLog]
+        public void SetValue(int value) =>
+            SetValue((float)value);
+
+        [BinderLog]
+        public void SetValue(long value) =>
+            SetValue((float)value);
+
+        [BinderLog]
+        public void SetValue(double value) =>
+            SetValue((float)value);
+        
+        protected override void OnBound()
+        {
+            if (Mode is BindMode.OneWayToSource)
+            {
+                var value = GetConvertedValue(CachedComponent.volume);
+                
+                IntValueChanged?.Invoke((int)value);
+                LongValueChanged?.Invoke((long)value);
+                FloatValueChanged?.Invoke(value);
+                DoubleValueChanged?.Invoke(value);
+            }
+        }
+        
+        private float GetConvertedValue(float value) =>
+            _converter?.Convert(value) ?? value;
+    }
+}

--- a/Aspid.MVVM/Assets/Plugins/Aspid/MVVM/StarterKit/Unity/Runtime/Binders/AudioSources/Volume/Mono/AudioSourceVolumeMonoBinder.cs.meta
+++ b/Aspid.MVVM/Assets/Plugins/Aspid/MVVM/StarterKit/Unity/Runtime/Binders/AudioSources/Volume/Mono/AudioSourceVolumeMonoBinder.cs.meta
@@ -1,0 +1,3 @@
+fileFormatVersion: 2
+guid: 105b6e43fa8e497d9b779d6e9544b452
+timeCreated: 1770576978

--- a/Aspid.MVVM/Assets/Plugins/Aspid/MVVM/StarterKit/Unity/Runtime/Binders/AudioSources/Volume/Mono/AudioSourceVolumeSwitcherMonoBinder.cs
+++ b/Aspid.MVVM/Assets/Plugins/Aspid/MVVM/StarterKit/Unity/Runtime/Binders/AudioSources/Volume/Mono/AudioSourceVolumeSwitcherMonoBinder.cs
@@ -1,0 +1,21 @@
+using UnityEngine;
+#if UNITY_2023_1_OR_NEWER
+using Converter = Aspid.MVVM.StarterKit.IConverter<float, float>;
+#else
+using Converter = Aspid.MVVM.StarterKit.IConverterFloat;
+#endif
+
+// ReSharper disable once CheckNamespace
+namespace Aspid.MVVM.StarterKit
+{
+    [AddBinderContextMenu(typeof(AudioSource), SubPath = "Switcher")]
+    [AddComponentMenu("Aspid/MVVM/Binders/Audio/AudioSource/AudioSource Binder – Volume Switcher")]
+    public sealed class AudioSourceVolumeSwitcherMonoBinder : SwitcherMonoBinder<AudioSource, float>
+    {
+        [SerializeReferenceDropdown]
+        [SerializeReference] private Converter _converter;
+        
+        protected override void SetValue(float value) =>
+            CachedComponent.volume = _converter?.Convert(value) ?? value;
+    }
+}

--- a/Aspid.MVVM/Assets/Plugins/Aspid/MVVM/StarterKit/Unity/Runtime/Binders/AudioSources/Volume/Mono/AudioSourceVolumeSwitcherMonoBinder.cs.meta
+++ b/Aspid.MVVM/Assets/Plugins/Aspid/MVVM/StarterKit/Unity/Runtime/Binders/AudioSources/Volume/Mono/AudioSourceVolumeSwitcherMonoBinder.cs.meta
@@ -1,0 +1,3 @@
+fileFormatVersion: 2
+guid: b2a8cd9b067c43e683a711d171b2a020
+timeCreated: 1770576978


### PR DESCRIPTION
Adds binder components for Unity's `AudioSource` component, enabling ViewModel properties to drive volume, pitch, mute state, audio clip assignment, and playback control at runtime.