### PR TITLE
Group MonoView inspector binders by [Header] into collapsible foldouts

### DIFF
--- a/Aspid.MVVM/Assets/Plugins/Aspid/MVVM/Unity/Editor/Scripts/Meta/BindablePropertyMeta.cs
+++ b/Aspid.MVVM/Assets/Plugins/Aspid/MVVM/Unity/Editor/Scripts/Meta/BindablePropertyMeta.cs
@@ -8,7 +8,9 @@ namespace Aspid.MVVM
 {
     /// <summary>
     /// Metadata describing a single bindable property on an <see cref="IViewModel"/> type,
-    /// including its resolved type, binding ID, generated property name, and supported <see cref="BindMode"/>.
+    /// including its resolved type, binding ID, generated property name, supported <see cref="BindMode"/>,
+    /// and inspector layout hints (header text and vertical spacing read from Unity's
+    /// <see cref="UnityEngine.HeaderAttribute"/> and <see cref="UnityEngine.SpaceAttribute"/>).
     /// </summary>
     public class BindablePropertyMeta
     {
@@ -16,13 +18,18 @@ namespace Aspid.MVVM
         public readonly string Id;
         public readonly string Name;
         public readonly BindMode Mode;
-        
+        public readonly string Header;
+        public readonly bool IsCommand;
+
         public BindablePropertyMeta(Type memberContainerType, MemberInfo memberInfo)
         {
             if (!IsBindableProperty(memberContainerType, memberInfo))
                 throw new ArgumentException("Invalid bindable property");
 
             Name = memberInfo.Name;
+
+            var unityHeader = memberInfo.GetCustomAttribute<UnityEngine.HeaderAttribute>();
+            Header = string.IsNullOrWhiteSpace(unityHeader?.header) ? null : unityHeader.header;
             
             var bindIdAttribute = memberInfo.GetCustomAttribute<BindIdAttribute>();
             Id = bindIdAttribute is not null ? bindIdAttribute.Id : BinderFieldInfoExtensions.GetBinderId(memberInfo.Name);
@@ -62,7 +69,8 @@ namespace Aspid.MVVM
                 case MethodInfo methodInfo:
                     if (bindIdAttribute is null)
                         Id += "Command";
-                    
+
+                    IsCommand = true;
                     Mode = BindMode.OneTime;
                     Name += "Command";
                     

--- a/Aspid.MVVM/Assets/Plugins/Aspid/MVVM/Unity/Editor/Scripts/Views/MonoViewEditor.cs
+++ b/Aspid.MVVM/Assets/Plugins/Aspid/MVVM/Unity/Editor/Scripts/Views/MonoViewEditor.cs
@@ -31,7 +31,10 @@ namespace Aspid.MVVM
         public ShowDesignViewModelAttribute ShowDesignViewModelAttribute { get; private set; }
         
         public SerializedProperty DesignViewModelAssemblyQualifiedNameProperty { get; private set; }
-        
+
+        public IReadOnlyDictionary<string, BindablePropertyMeta> MetaById { get; private set; }
+            = new Dictionary<string, BindablePropertyMeta>();
+
         protected ValidableBindersById LastBinders { get; private set; }
         
         public IEnumerable<IMonoBinderValidable> UnassignedBinders => TargetAsView 
@@ -185,6 +188,8 @@ namespace Aspid.MVVM
             
             if (viewModelType is null)
             {
+                MetaById = new Dictionary<string, BindablePropertyMeta>();
+
                 for (var i = 0; i < BindersList.ArraySize; i++)
                 {
                     var hasBinder = false;
@@ -193,8 +198,9 @@ namespace Aspid.MVVM
                     
                     for (var j = 0; j < monoBindersProperty.arraySize; j++)
                     {
-                        hasBinder = monoBindersProperty.GetArrayElementAtIndex(j).objectReferenceValue;
-                        if (hasBinder) break;
+                        if (monoBindersProperty.GetArrayElementAtIndex(j).objectReferenceValue == null) continue;
+                        hasBinder = true;
+                        break;
                     }
 
                     if (!hasBinder)
@@ -207,6 +213,12 @@ namespace Aspid.MVVM
 
             var viewModelMeta = new ViewModelMeta(viewModelType);
             var viewMeta = new ViewMeta(TargetAsView.GetType());
+
+            var metaById = new Dictionary<string, BindablePropertyMeta>(viewModelMeta.BindableProperties.Count);
+            foreach (var meta in viewModelMeta.BindableProperties)
+                metaById[meta.Id] = meta;
+            
+            MetaById = metaById;
 
             var bindableProperties = viewModelMeta.BindableProperties
                 .Where(bindableProperty => viewMeta.BinderProperties.All(binderProperty => binderProperty.Id != bindableProperty.Id))
@@ -221,8 +233,9 @@ namespace Aspid.MVVM
                 var array = new Object[element.MonoBindersProperty.arraySize];
                 for (var j = 0; j < array.Length; j++)
                     array[j] = element.MonoBindersProperty.GetArrayElementAtIndex(j).objectReferenceValue;
-                
-                fieldsById.Add(element.Id, array);
+
+                if (!fieldsById.ContainsKey(element.Id))
+                    fieldsById.Add(element.Id, array);
             }
             
             BindersList.ArraySize = bindableProperties.Length;
@@ -244,15 +257,6 @@ namespace Aspid.MVVM
                 }
                 else
                 {
-                    if (!fieldsById.ContainsKey(property.Id))
-                    {
-                        for (var j = 0; j < monoBindersProperty.arraySize; j++)
-                        {
-                            if (monoBindersProperty.GetArrayElementAtIndex(j).objectReferenceValue is IMonoBinderValidable monoBinder)
-                                monoBinder.Reset(MonoBinderResetMode.Soft);
-                        }
-                    }
-                    
                     monoBindersProperty.arraySize = 0;
                 }
                 

--- a/Aspid.MVVM/Assets/Plugins/Aspid/MVVM/Unity/Editor/Scripts/Views/VisualElements/MonoViewVisualElement.cs
+++ b/Aspid.MVVM/Assets/Plugins/Aspid/MVVM/Unity/Editor/Scripts/Views/VisualElements/MonoViewVisualElement.cs
@@ -26,6 +26,7 @@ namespace Aspid.MVVM
         where TEditor : MonoViewEditor<TView, TEditor>
     {
         private const string GeneralBindersId = "general-binders";
+        private const string HeaderFoldoutViewDataKeyPrefix = "AspidMonoView.Header";
         
         private UnassignedBindersVisualElement<TView, TEditor>? _unassignedBindersVisualElement;
         
@@ -114,20 +115,118 @@ namespace Aspid.MVVM
 
         private VisualElement BuildGeneralBinders()
         {
-            var container = new VisualElement().SetName(GeneralBindersId);
+            var rootContainer = new VisualElement()
+                .SetName(GeneralBindersId);
+
+            var currentGroupCount = 0;
+            string? currentGroup = null;
+            IntegerField? currentCounter = null;
+            var target = rootContainer;
+            var metaById = Editor.MetaById;
+            var viewTypeName = Editor.TargetAsView ? Editor.TargetAsView.GetType().FullName : "Unknown";
 
             for (var i = 0; i < Editor.BindersList.ArraySize; i++)
             {
                 var element = Editor.BindersList.GetArrayElementAtIndex(i);
                 var capturedAssemblyQualifiedName = element.AssemblyQualifiedName;
 
-                var property = new MonoBinderPropertyField(element.MonoBindersProperty, label: ObjectNames.NicifyVariableName(element.Id), element.Id, capturedAssemblyQualifiedName)
+                metaById.TryGetValue(element.Id, out var meta);
+
+                if (meta?.IsCommand is true)
+                {
+                    if (currentGroup is not null)
+                    {
+                        FinalizeFoldoutCount();
+                        target = rootContainer;
+                        currentGroup = null;
+                        currentCounter = null;
+                        currentGroupCount = 0;
+                    }
+                }
+                else
+                {
+                    var header = string.IsNullOrWhiteSpace(meta?.Header) ? null : meta!.Header;
+                    if (header is not null && header != currentGroup)
+                    {
+                        FinalizeFoldoutCount();
+
+                        var (foldout, counter) = BuildHeaderFoldout(header, viewTypeName);
+                        rootContainer.Add(foldout);
+                        target = foldout.contentContainer;
+                        currentGroup = header;
+                        currentCounter = counter;
+                        currentGroupCount = 0;
+                    }
+                }
+
+                var property = new MonoBinderPropertyField(
+                        element.MonoBindersProperty,
+                        label: ObjectNames.NicifyVariableName(element.Id), 
+                        binderId: element.Id,
+                        assemblyQualifiedName: capturedAssemblyQualifiedName)
                     .SetMargin(top: 3);
-                
-                container.Add(property);
+
+                target.Add(property);
+
+                if (currentCounter is not null)
+                    currentGroupCount++;
             }
 
-            return container;
+            FinalizeFoldoutCount();
+            return rootContainer;
+
+            void FinalizeFoldoutCount() =>
+                currentCounter?.SetValueWithoutNotify(currentGroupCount);
+        }
+
+        private static (Foldout foldout, IntegerField counter) BuildHeaderFoldout(string header, string viewTypeName)
+        {
+            var foldout = new Foldout()
+            .SetValue(true)
+            .SetText(header)
+            .SetPadding(left: 0)
+            .SetMargin(top: 3, right: 0)
+            .SetViewDataKey($"{HeaderFoldoutViewDataKeyPrefix}.{viewTypeName}.{header}");
+            
+            foldout.contentContainer
+                .SetMargin(left: 0)
+                .SetPadding(left: 10)
+                .AddChild(new AspidDividingLine()
+                    .SetPosition(Position.Absolute)
+                    .SetDistance(top: 3, bottom: 0, left: 3)
+                    .SetDirection(AspidDividingLineDirectionStyle.Type.Vertical));
+
+            var counter = new IntegerField()
+                .SetMargin(0)
+                .SetWidth(50)
+                .SetMinWidth(50)
+                .SetMaxWidth(50)
+                .SetEnabledSelf(false)
+                .SetPickingMode(PickingMode.Ignore);
+            
+            counter.Q<TextElement>().SetMarginLeft(0).SetPaddingLeft(2);
+            counter.RegisterCallback<AttachToPanelEvent>(_ =>
+            {
+                IgnorePickingRecursive(counter);
+            });
+
+            foldout.Q<Toggle>()
+                .SetMargin(0)
+                .SetBorderRadius(5)
+                .SetAlignItems(Align.Center)
+                .SetFlexDirection(FlexDirection.Row)
+                .SetPadding(top: 2, right: 5, bottom: 2, left: 3)
+                .SetBackgroundColor(new Color(0x38 / 255f, 0x38 / 255f, 0x38 / 255f))
+                .AddChild(counter);
+
+            return (foldout, counter);
+        }
+
+        private static void IgnorePickingRecursive(VisualElement element)
+        {
+            element.pickingMode = PickingMode.Ignore;
+            foreach (var child in element.Children())
+                IgnorePickingRecursive(child);
         }
 
         private UnassignedBindersVisualElement<TView, TEditor> BuildUnassignedBinders()


### PR DESCRIPTION
## Summary

Group bindable properties in the `MonoView` inspector by Unity's
`[Header]` attribute so large views become navigable. Each header turns
into a `Foldout` that:

- shows the header text on its toggle row,
- displays a live counter with the number of binders currently in the group,
- persists its expanded/collapsed state per view type via `viewDataKey`,
- renders a vertical divider so nested binder rows stay visually scoped.

Commands always break out of the current header group and are rendered at
the root, matching how they read on the ViewModel side.

## Changes

- `BindablePropertyMeta` now reads `UnityEngine.HeaderAttribute` from the
  bindable member and exposes `Header` (nullable) and `IsCommand` flags
  alongside the existing `Type` / `Id` / `Name` / `Mode`.
- `MonoViewEditor` exposes `MetaById` so the visual element can resolve
  header / command info for each entry in the binders list without
  rebuilding the meta. As a side effect:
    - `fieldsById` is now guarded against duplicate ids,
    - the soft `Reset` call on unmatched binders is dropped — the
      surrounding code clears the array immediately after, so the reset
      was dead.
- `MonoViewVisualElement.BuildGeneralBinders` walks the binders list in
  order and opens / closes `Foldout` groups based on the resolved header,
  populating the counter as binders are added.

## Test plan

- [ ] Open a `MonoView` whose ViewModel uses `[Header(...)]` on several
      bindable properties and confirm consecutive entries collapse under
      one foldout with the right count.
- [ ] Toggle a foldout, reselect the view, and confirm the expanded
      state is restored per view type.
- [ ] Add a `[RelayCommand]` between two `[Header]` groups and confirm
      it renders at the root and starts a fresh group for the next
      header.
- [ ] Inspect a view with no headers and confirm the layout is
      unchanged from before this PR.