### PR TITLE
Centralize inspector indent on visual element roots

### DIFF
--- a/Aspid.MVVM/Assets/Plugins/Aspid/MVVM/Unity/Editor/Scripts/Binders/MonoBinderVisualElement.cs
+++ b/Aspid.MVVM/Assets/Plugins/Aspid/MVVM/Unity/Editor/Scripts/Binders/MonoBinderVisualElement.cs
@@ -100,6 +100,7 @@ namespace Aspid.MVVM
         {
             return new VisualElement()
                 .AddStyleSheetsFromResource(AspidStyles.DefaultStyleSheet)
+                .AddClass(AspidStyles.InspectorStyleClass)
                 .AddChild(BuildHeader())
                 .AddChild(BuildIdSelector())
                 .AddChild(new PropertyField(_editor.IdProperty.ValueProperty).SetDisplay(DisplayStyle.None))
@@ -116,7 +117,7 @@ namespace Aspid.MVVM
                     Status = Status,
                     Subtext = ScriptSubtext,
                 }
-                .SetMargin(top: 3, left: -10f);
+                .SetMargin(top: 3);
         }
 
         protected virtual VisualElement BuildIdSelector()
@@ -144,7 +145,7 @@ namespace Aspid.MVVM
              modeField.AddToClassList("aspid-mono-binder-id-selector-mode");
 
              var container = new AspidBox(AspidBoxPreset.Default.SetTheme(ThemeStyle.Type.Dark))
-                 .SetMargin(top: 5, left: -10f);
+                 .SetMargin(top: 5);
              container.styleSheets.Add(_idSelectorStyleSheet);
              container.AddToClassList("aspid-mono-binder-id-selector");
 
@@ -265,7 +266,7 @@ namespace Aspid.MVVM
                 .AddChild(isDebugPropertyField));
 
             _logsContainer = new AspidBox().SetName("Logs")
-                .SetMargin(top: 5, left: -10f)
+                .SetMargin(top: 5)
                 .AddChild(title);
             
             isDebugPropertyField.RegisterValueChangeCallback(e =>

--- a/Aspid.MVVM/Assets/Plugins/Aspid/MVVM/Unity/Editor/Scripts/ViewModels/VisualElements/Containers/CommandsContainer.cs
+++ b/Aspid.MVVM/Assets/Plugins/Aspid/MVVM/Unity/Editor/Scripts/ViewModels/VisualElements/Containers/CommandsContainer.cs
@@ -52,7 +52,7 @@ namespace Aspid.MVVM
             });
             
             this.AddChild(new AspidBox().SetName("Commands")
-                .SetMargin(top: 5, left: -10f)
+                .SetMargin(top: 5)
                 .AddChild(title)
                 .AddChild(container));
 

--- a/Aspid.MVVM/Assets/Plugins/Aspid/MVVM/Unity/Editor/Scripts/ViewModels/VisualElements/ViewModelVisualElement.cs
+++ b/Aspid.MVVM/Assets/Plugins/Aspid/MVVM/Unity/Editor/Scripts/ViewModels/VisualElements/ViewModelVisualElement.cs
@@ -57,7 +57,8 @@ namespace Aspid.MVVM
 
         private void Build()
         {
-            this.AddStyleSheetsFromResource(AspidStyles.DefaultStyleSheet);
+            this.AddStyleSheetsFromResource(AspidStyles.DefaultStyleSheet)
+                .AddClass(AspidStyles.InspectorStyleClass);
 
             Add(BuildHeader());
             
@@ -90,7 +91,7 @@ namespace Aspid.MVVM
 
         private AspidInspectorHeader BuildHeader() =>
             new AspidInspectorHeader(GetScriptName(), Editor.TargetAsViewModel) { Subtext = GetScriptSubtext() }
-                .SetMargin(top: 3, left: -10f);
+                .SetMargin(top: 3);
 
         protected virtual VisualElement? OnBuiltHeader() => null;
 

--- a/Aspid.MVVM/Assets/Plugins/Aspid/MVVM/Unity/Editor/Scripts/Views/VisualElements/MonoViewVisualElement.cs
+++ b/Aspid.MVVM/Assets/Plugins/Aspid/MVVM/Unity/Editor/Scripts/Views/VisualElements/MonoViewVisualElement.cs
@@ -89,7 +89,7 @@ namespace Aspid.MVVM
         private VisualElement BuildDesignViewModel()
         {
             var container = new AspidBox(AspidBoxPreset.Default.SetTheme(ThemeStyle.Type.Dark))
-                .SetMargin(top: 5, left: -10f);
+                .SetMargin(top: 5);
             container.AddChild(new AspidLabel(text: "Design ViewModel").SetMarginBottom(5));
             
             var attribute = Editor.ShowDesignViewModelAttribute;
@@ -107,7 +107,7 @@ namespace Aspid.MVVM
         private VisualElement BuiltGeneralBinders()
         {
             var container = new AspidBox()
-                .SetMargin(top: 5, left: -10f);
+                .SetMargin(top: 5);
 
             return container
                 .AddChild(BuildGeneralBinders());

--- a/Aspid.MVVM/Assets/Plugins/Aspid/MVVM/Unity/Editor/Scripts/Views/VisualElements/UnassignedBindersVisualElement.cs
+++ b/Aspid.MVVM/Assets/Plugins/Aspid/MVVM/Unity/Editor/Scripts/Views/VisualElements/UnassignedBindersVisualElement.cs
@@ -75,7 +75,7 @@ namespace Aspid.MVVM
         private VisualElement Build()
         {
             return new AspidBox()
-                .SetMargin(top: 5, left: -10f)
+                .SetMargin(top: 5)
                 .AddChild(new AspidHelpBox(WarningTitle, WarningMessage, AspidHelpBoxPreset.Default.SetMessageType(HelpBoxMessageType.Warning))
                     .SetMargin(bottom: 5))
                 .AddChild(_unassignedBindersContainer);

--- a/Aspid.MVVM/Assets/Plugins/Aspid/MVVM/Unity/Editor/Scripts/Views/VisualElements/ViewVisualElement.cs
+++ b/Aspid.MVVM/Assets/Plugins/Aspid/MVVM/Unity/Editor/Scripts/Views/VisualElements/ViewVisualElement.cs
@@ -71,7 +71,8 @@ namespace Aspid.MVVM
         #region Build Methods
         private void Build()
         {
-            this.AddStyleSheetsFromResource(AspidStyles.DefaultStyleSheet);
+            this.AddStyleSheetsFromResource(AspidStyles.DefaultStyleSheet)
+                .AddClass(AspidStyles.InspectorStyleClass);
 
             Add(BuildHeader());
             
@@ -95,7 +96,7 @@ namespace Aspid.MVVM
 
         private AspidInspectorHeader BuildHeader() =>
             new AspidInspectorHeader(label: GetScriptName(), Editor.TargetAsView) { Status = Status, Subtext = GetScriptSubtext() }
-                .SetMargin(top: 3, left: -10f);
+                .SetMargin(top: 3);
 
         protected virtual VisualElement? OnBuiltHeader() => null;
         
@@ -110,7 +111,7 @@ namespace Aspid.MVVM
             // TODO Aspid.MVVM Unity – Rename Name
             return new AspidBox()
                 .SetName("view-model-debug-panel")
-                .SetMargin(top: 5, left: -10f)
+                .SetMargin(top: 5)
                 .AddChild(new DebugViewModelPanel(Editor.TargetAsView));
         }
         #endregion

--- a/Aspid.MVVM/Assets/Plugins/Aspid/MVVM/Unity/Editor/Scripts/VisualElements/AspidBaseInspectorVisualElement.cs
+++ b/Aspid.MVVM/Assets/Plugins/Aspid/MVVM/Unity/Editor/Scripts/VisualElements/AspidBaseInspectorVisualElement.cs
@@ -25,7 +25,7 @@ namespace Aspid.MVVM
         private static VisualElement Build(SerializedObject serializedObject, string? title, IReadOnlyCollection<string>? propertiesExcluding)
         {
             var container = new AspidBox()
-                .SetMargin(top: 5, left: -10f);
+                .SetMargin(top: 5);
 
             if (!string.IsNullOrWhiteSpace(title))
                 container.AddChild(new AspidLabel(title).SetMarginBottom(5));


### PR DESCRIPTION
## Summary

Refactor of how the `-10px` inspector indent and inner property-field margin reset are applied.

- `ViewVisualElement`, `ViewModelVisualElement`, and `MonoBinderVisualElement` now add `AspidStyles.InspectorStyleClass` (`aspid-fasttools-inspector-container`) directly on the root visual element, so the `margin-left: -10px` and the descendant `unity-base-field__inspector-field` margin reset from `Aspid-FastTools-Default-Dark.uss` apply once at the root.
- Removed redundant `.SetMargin(left: -10f)` from every child container that previously had to compensate manually:
  - `AspidInspectorHeader` in `ViewVisualElement` / `ViewModelVisualElement` / `MonoBinderVisualElement`.
  - `view-model-debug-panel` `AspidBox` in `ViewVisualElement`.
  - `Commands` `AspidBox` in `CommandsContainer`.
  - Base inspector `AspidBox` in `AspidBaseInspectorVisualElement`.
  - `aspid-mono-binder-id-selector` and `Logs` `AspidBox` in `MonoBinderVisualElement`.

As a side effect, raw `PropertyField` instances inside these inspectors (e.g. the `DesignViewModel` field on `MonoView`) now pick up the `unity-base-field__inspector-field` margin reset and align with surrounding `AspidLabel`s and `AspidBox` edges without needing per-field workarounds.

No behavior change at runtime — editor-only.

## Test plan
- [ ] Open a `MonoView` inspector — `Design ViewModel` field is flush-left with the `Design ViewModel` label and the box edge.
- [ ] Open a `ViewModel` inspector — header, base inspector and commands containers still align with the inspector edge (no double-shift or visual regression).
- [ ] Open a `MonoBinder` inspector — header, id selector, parameters and logs containers still align correctly.
- [ ] Verify no horizontal scroll / clipping appears on narrow inspectors.