### PR TITLE
Replace Aspid.Collections submodule with UPM git package

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -7,6 +7,3 @@
 [submodule "Aspid.MVVM.Generators"]
 	path = Aspid.MVVM.Generators
 	url = git@github.com:VPDPersonal/Aspid.MVVM.Generators.git
-[submodule "Aspid.MVVM/Assets/Plugins/Aspid/Collections"]
-	path = Aspid.MVVM/Assets/Aspid/Collections
-	url = https://github.com/VPDPersonal/Aspid.Collections

--- a/Aspid.MVVM/Assets/Aspid/Collections.meta
+++ b/Aspid.MVVM/Assets/Aspid/Collections.meta
@@ -1,8 +1,0 @@
-fileFormatVersion: 2
-guid: 0cae0365f7e74c9c87efe4aae89e2963
-folderAsset: yes
-DefaultImporter:
-  externalObjects: {}
-  userData: 
-  assetBundleName: 
-  assetBundleVariant: 

--- a/Aspid.MVVM/Assets/Plugins/Aspid.meta
+++ b/Aspid.MVVM/Assets/Plugins/Aspid.meta
@@ -1,3 +1,0 @@
-fileFormatVersion: 2
-guid: 28bfba45abb8475b951f9d09218c56f8
-timeCreated: 1727267614

--- a/Aspid.MVVM/Packages/manifest.json
+++ b/Aspid.MVVM/Packages/manifest.json
@@ -15,6 +15,7 @@
     "com.unity.timeline": "1.8.11",
     "com.unity.ugui": "2.0.0",
     "jp.hadashikick.vcontainer": "https://github.com/hadashiA/VContainer.git?path=VContainer/Assets/VContainer#1.16.0",
+    "tech.aspid.collections": "https://github.com/VPDPersonal/Aspid.Collections.git#upm",
     "com.unity.modules.accessibility": "1.0.0",
     "com.unity.modules.adaptiveperformance": "1.0.0",
     "com.unity.modules.ai": "1.0.0",

--- a/Aspid.MVVM/Packages/packages-lock.json
+++ b/Aspid.MVVM/Packages/packages-lock.json
@@ -300,6 +300,15 @@
       "dependencies": {},
       "hash": "e75c3d407af049e5bb2bc87dbdb0338ecddfedbd"
     },
+    "tech.aspid.collections": {
+      "version": "https://github.com/VPDPersonal/Aspid.Collections.git#upm",
+      "depth": 0,
+      "source": "git",
+      "dependencies": {
+        "com.unity.test-framework": "1.6.0"
+      },
+      "hash": "c050c3cee1c9a322d378d705d2af709ee85bc429"
+    },
     "com.unity.modules.accessibility": {
       "version": "1.0.0",
       "depth": 0,


### PR DESCRIPTION
## Summary

- Remove the `Aspid.Collections` git submodule from `Assets/Aspid/`
- Add `tech.aspid.collections` as a UPM git dependency (`upm` branch)
- Clean up `.gitmodules` and leftover meta files

## Motivation

Submodule-based integration required manual sync (`git submodule update`) and caused friction during cloning and CI. A UPM git package is resolved automatically by Unity's Package Manager, simplifying the workflow.

## Test plan

- [ ] Unity project resolves `tech.aspid.collections` on open
- [ ] Observable collections compile and work at runtime
- [ ] Samples referencing collections still function correctly