### PR TITLE
Merge pull request #54 from VPDPersonal/Bug/Fix-NotifyCanExecuteChangedAll-Generated

### DIFF
--- a/Aspid.MVVM/Assets/Aspid/MVVM/CHANGELOG.md
+++ b/Aspid.MVVM/Assets/Aspid/MVVM/CHANGELOG.md
@@ -19,7 +19,7 @@ The format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/) and 
 - `GeneralView` merged into `MonoView` — single non-abstract base view.
 - New `ValueViewModel`, `AnyReverseBinder`, `OneWayToSourceComponentBinders`, AudioSource / LayoutGroup / Dropdown / Selectable / Object-Name binders.
 - `Aspid.UnityFastTools` integrated, many editor visuals migrated to FastTools equivalents.
-- All sub-projects extracted into git submodules: `Aspid.Collections`, `Aspid.Internal.Unity`, `Aspid.MVVM.Generators`, `Aspid.MVVM.Analyzers`, `Aspid.MVVM.Unity.Generators`.
+- All sub-projects extracted into git submodules (`Aspid.MVVM.Generators`, `Aspid.MVVM.Analyzers`, `Aspid.MVVM.Unity.Generators`); `Aspid.Collections` later moved to a UPM git package.
 - Target Unity raised to `6000.3.0f1` (minimum stays `2022.3`).
 - Mass XML documentation pass over the entire binder catalog plus `XmlDocConventions.md`.
 
@@ -72,6 +72,7 @@ The format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/) and 
 - Additional InputField binders + large refactor (PR #51).
 - Dropdown / Selectable binders (PR #61).
 - `Addressable` binders gained an opt-in seamless swap mode.
+- `GameObjectInstantiateAddressableMonoBinder` for prefab spawning via Addressables.
 
 #### Binders — improvements
 - `OnReplace` / `OnMove` events forwarded to binder hooks; batch `Replace` unrolled into per-item `OnReplace` calls.
@@ -85,17 +86,20 @@ The format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/) and 
 - `IAnyBinder` BinderLog support.
 
 #### Collections
-- `Aspid.Collections` extracted into a git submodule.
+- `Aspid.Collections` initially extracted into a git submodule, then replaced with a UPM git package (`tech.aspid.collections`) (PR #79).
 - `FilteredList` and `BindAlso` fixes.
 - New collections tests.
 - `Replace` / `Move` notifications surfaced to binders.
 
 #### Project structure / infrastructure
-- Submodules wired in (PR #38): `Aspid.Internal.Unity`, `Aspid.MVVM.Generators`, `Aspid.MVVM.Analyzers`, `Aspid.MVVM.Unity.Generators`, `Aspid.Collections`.
+- Submodules wired in (PR #38): `Aspid.MVVM.Generators`, `Aspid.MVVM.Analyzers`, `Aspid.MVVM.Unity.Generators`.
+- `Aspid.Internal.Unity` submodule added, then removed — functionality absorbed into the main project.
 - Unity project relocated from repo root into `Aspid.MVVM/`.
+- MVVM package moved from `Plugins/Aspid/` to `Assets/Aspid/` (PR #77).
 - `package.json` placed inside the package; `unity` field set to `2022.3`; version `1.1.0`.
 - Root `CLAUDE.md` describing structure and conventions.
 - GitHub Actions: Claude PR Assistant + Code Review workflows (PR #64).
+- GitHub Actions: Release workflow for stable and preview UPM branches with DLL verification (PR #78).
 
 #### Integrations / dependencies
 - `Aspid.UnityFastTools` integration `0.0.1-alpha.3` (PR #26); subsequent bumps to `alpha.5` / `alpha.7`.

--- a/Aspid.MVVM/Assets/Aspid/MVVM/CHANGELOG.md
+++ b/Aspid.MVVM/Assets/Aspid/MVVM/CHANGELOG.md
@@ -2,9 +2,8 @@
 
 All notable changes to **Aspid.MVVM** are documented in this file.
 
-The format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/) and the project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
-
-> Migration instructions for upgrading from 1.0 to 1.1 are in [MIGRATION.md](MIGRATION.md).
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ---
 

--- a/Aspid.MVVM/Assets/Aspid/MVVM/CHANGELOG.md
+++ b/Aspid.MVVM/Assets/Aspid/MVVM/CHANGELOG.md
@@ -30,29 +30,29 @@ The format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/) and 
 - **`NotifyCanExecuteChangedAll()`** generator method (PR #52, fixed in #54).
 - **`ValueViewModel`** — minimal ViewModel wrapper around a single value with full XML docs (PR #63).
 - Keyword field support in the generator (PR #55).
-- `EmptyExecution` static instance on `RelayCommand`; try/catch in `RelayCommandField`.
-- Interface support for `ViewModel` (`IMyVm` can now be picked as a design ViewModel).
-- Profiler markers expanded across binder lifecycle.
+- `EmptyExecution` static instance on `RelayCommand` (PR #36); try/catch in `RelayCommandField` (PR #43).
+- Interface support for `ViewModel` (`IMyVm` can now be picked as a design ViewModel) (PR #53).
+- Profiler markers expanded across binder lifecycle (PR #15).
 - **Virtual binder fields** — generator auto-emits `MonoBinder[]` slots for `IView<TViewModel>` bindable members that are not declared on the View. Opt out via `[View(AutoBinderFields = false)]`; `ScriptableObject`-derived views are always skipped (PR #74, generator PR `Aspid.MVVM.Generators#13`).
 
 #### Views
 - **`GeneralView`** added (PR #43), then merged into `MonoView` (PR #48). `MonoView` is now non-abstract and self-contained.
-- `RelayCommand` support inside `View` / `MonoView`; `CommandsContainer` refactor; `CommandContainer in View`.
+- `RelayCommand` support inside `View` / `MonoView`; `CommandsContainer` refactor; `CommandContainer in View` (PR #43).
 - `ViewInitializer` overhaul (PR #41, #50) — context for `ViewInitializers`.
-- `DestroyView` mode in editor; `DestroyViewModel` extension fixes.
+- `DestroyView` mode in editor; `DestroyViewModel` extension fixes (PR #43, #53).
 - `PrefabViewFactory` / `PrefabViewPool` upgraded.
-- `ViewModelPickerWindow` with dropdown + improved navigation.
-- `[AddComponentMenu]` for `MonoView`, snake-style for settings menu.
-- `MonoView` editor refactor; fixed generated fields and base inspector display.
+- `ViewModelPickerWindow` with dropdown + improved navigation (PR #53).
+- `[AddComponentMenu]` for `MonoView`; snake-style for settings menu (PR #47).
+- `MonoView` editor refactor; fixed generated fields and base inspector display (PR #32).
 - `DesignViewModel` upgrade (PR #53) including legacy Unity support.
 
 #### Editor / Inspector
 - New UI Toolkit inspectors for `MonoBinder`, `MonoView`, `MonoViewModel` (PR #31, #32, #35).
-- `InspectorHeaderPanel`, `AspidInspectorHeader`, `AspidPropertyField`, `AspidDividingLine` shared visuals.
-- USS-driven theme: `AspidToggle`, IMGUI foldout drawer margin fix, IMGUIContainer wrapping in styled `AspidPropertyField`.
+- `InspectorHeaderPanel`, `AspidInspectorHeader`, `AspidPropertyField`, `AspidDividingLine` shared visuals (PR #32, #40).
+- USS-driven theme: `AspidToggle` (PR #47), IMGUI foldout drawer margin fix, IMGUIContainer wrapping in styled `AspidPropertyField`.
 - `EnumMonoBinderEditor` (PR #57); `EnumValuesPropertyDrawer` fixes; `EnumValues` sample and `ComponentTypeSelector` documentation.
-- Drag & Drop for unassigned and general binders (groups + Auto-Assign + Select / Restore buttons).
-- `RequireBinder` and child View / Binder validation (alpha).
+- Drag & Drop for unassigned and general binders (groups + Auto-Assign + Select / Restore buttons) (PR #43).
+- `RequireBinder` and child View / Binder validation (alpha) (PR #43).
 - `Aspid.MVVM Settings` window prototype (PR #47).
 - **`HeaderGroup` foldout attributes** — `HeaderGroupAttribute` (single field), `HeaderGroupStartAttribute` / `HeaderGroupEndAttribute` (range) tag binder fields and VM members into named, collapsible inspector foldouts. New `HeaderGroupRouter` is consumed by `MonoViewVisualElement` / `AspidBaseInspectorVisualElement` instead of inline foldout layout. Stripped from non-`DEBUG` / non-`UNITY_EDITOR` builds (PR #74).
 
@@ -110,16 +110,16 @@ The format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/) and 
 
 #### Documentation
 - `XmlDocConventions.md` added and refined.
-- Mass XML doc pass across all binder families: AudioSource, CanvasGroup, Collider, Animator, Behaviour, GameObject, Layout, UnityGeneric, Selectable, Graphic, Image, RawImage, Renderer, Transform, Slider, InputField, Toggle, Button, EventTrigger, ScrollBar, ScrollRect, Dropdown, Object, LineRenderer, Casters, LocalizeStringEvent, VirtualizedList plus base `MonoBinder` / Behaviour subfolders.
+- Mass XML doc pass across all binder families: AudioSource, CanvasGroup, Collider, Animator, Behaviour, GameObject, Layout, UnityGeneric, Selectable, Graphic, Image, RawImage, Renderer, Transform, Slider, InputField, Toggle, Button, EventTrigger, ScrollBar, ScrollRect, Dropdown, Object, LineRenderer, Casters, LocalizeStringEvent, VirtualizedList plus base `MonoBinder` / Behaviour subfolders (PR #62).
 - XML docs for converters.
 - `ComponentTypeSelector` documentation and `EnumValues` sample.
-- `Readme.md` relocated and tweaked.
+- `Readme.md` relocated (PR #77) and tweaked (PR #71).
 
 ### Changed (behaviour)
 
-- `MonoView` is no longer `abstract`; it is a concrete component with its own serialized binders list and `[RequireBinder]` validation. Existing subclasses still work.
-- `MonoView.Dispose()` no longer destroys the host GameObject — it only calls `Deinitialize()`. Call `Object.Destroy(gameObject)` explicitly if needed.
-- `MonoBinder.Bind()` no longer throws when called on an already-bound binder; it logs an error and returns instead.
+- `MonoView` is no longer `abstract`; it is a concrete component with its own serialized binders list and `[RequireBinder]` validation. Existing subclasses still work (PR #48).
+- `MonoView.Dispose()` no longer destroys the host GameObject — it only calls `Deinitialize()`. Call `Object.Destroy(gameObject)` explicitly if needed (PR #48).
+- `MonoBinder.Bind()` no longer throws when called on an already-bound binder; it logs an error and returns instead (PR #62).
 - `[AddComponentMenu]` paths reorganized — for example `Collections/Observable List Binder - ViewModel` → `Collection/Observable List Binder – ViewModel` (singular form, en-dash).
 
 ### Removed
@@ -143,10 +143,10 @@ The format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/) and 
 ### Fixed
 
 - `MonoView`: generated field handling, validation, infinite-loop validation.
-- `ViewInitializers` — multiple fixes.
+- `ViewInitializers` — multiple fixes (PR #41, #50).
 - `AddressableMonoBinder` — multiple fixes.
 - `EnumValue`, `EnumValuesPropertyDrawer`, `SerializableTypeDrawer`, `SerializePropertyExtensions`.
-- `BindAlso`, `MonoBinders`, base `Binder` — assorted fixes.
+- `BindAlso`, `MonoBinders`, base `Binder` — assorted fixes (PR #62).
 - `EnumValue` validation downgraded from exception to `Debug.LogError`.
 - Removed stray `Header("Target")` and obsolete files (`NewFields`, `Commands.meta`, `DebugViewModel`).
 - `#if !ASPID_MVVM_EDITOR_DISABLED` guards added in missing places.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -114,13 +114,13 @@ The Unity project is opened via the Unity Editor (2022.3+); there is no CLI buil
 ## Gotchas
 
 - **Generator artifacts are committed.** Built DLLs (`Aspid.MVVM.Generators.dll`, `Aspid.MVVM.Analyzers.dll`, `Aspid.MVVM.Unity.Generators.dll`) live under `Aspid.MVVM/Assets/Aspid/MVVM/` and are checked into the repo. After changing a generator, rebuild its solution and commit the refreshed DLL — Unity consumes the DLL, not source.
-- **Submodules are required.** Cloning without `--recurse-submodules` leaves `Aspid.Collections` and the generator/analyzer repos empty; Unity won't compile.
+- **Submodules are required.** Cloning without `--recurse-submodules` leaves the generator/analyzer repos empty; Unity won't compile. `Aspid.Collections` is consumed as a UPM git package (not a submodule).
 - **`.NET 9.0 SDK` is pinned** via `global.json` in each generator/analyzer root. Older SDKs fail to build.
 - **Classes using `[ViewModel]`, `[Bind]`, `[RelayCommand]` must be `partial`** — the generator emits a second partial; without the modifier you get compile errors instead of generated members.
 
 ## Git Submodules
 
-The project uses 4 git submodules. After cloning, initialize with:
+The project uses 3 git submodules. After cloning, initialize with:
 
 ```bash
 git submodule update --init --recursive
@@ -130,7 +130,8 @@ Submodules:
 - `Aspid.MVVM.Generators`
 - `Aspid.MVVM.Analyzers`
 - `Aspid.MVVM.Unity.Generators`
-- `Aspid.Collections`
+
+`Aspid.Collections` is consumed as a UPM git package (`tech.aspid.collections`).
 
 ## Branch Strategy
 


### PR DESCRIPTION
Fixes the source-generated `NotifyCanExecuteChangedAll` method in ViewModel partial classes. The generated code was not notifying all `RelayCommand` instances, so command `CanExecute` states did not refresh correctly in bound UI elements. Merges the fix originally implemented in PR #54 from the development branch.