### PR TITLE
Fix Inequality comparison in NumberToBoolConverter

### DIFF
--- a/Aspid.MVVM/Assets/Aspid/MVVM/StarterKit/Runtime/Converters/Bools/NumberToBoolConverter.cs
+++ b/Aspid.MVVM/Assets/Aspid/MVVM/StarterKit/Runtime/Converters/Bools/NumberToBoolConverter.cs
@@ -51,7 +51,7 @@ namespace Aspid.MVVM.StarterKit
             Comparisons.LessThanOrEqual => value <= _value,
             Comparisons.GreaterThanOrEqual => value >= _value,
             Comparisons.Equal => Approximately(_value, value),
-            Comparisons.Inequality => Approximately(_value, value),
+            Comparisons.Inequality => !Approximately(_value, value),
             _ => throw new ArgumentOutOfRangeException()
         };
 


### PR DESCRIPTION
## Summary

- `Comparisons.Inequality` in `NumberToBoolConverter.Convert(float)` was calling `Approximately(_value, value)` without negation, making it behave identically to `Comparisons.Equal`
- Fix: add `!` before `Approximately(...)` so the switch arm returns `true` when the two values are **not** approximately equal

## Notes for review

One-character change; no other behaviour affected. All other switch arms (`LessThan`, `GreaterThan`, `LessThanOrEqual`, `GreaterThanOrEqual`, `Equal`) are untouched.

## Linked issues

N/A