### PR TITLE
fix(dynamic-viewmodel): pass full DynamicPropertyData to factory

### DIFF
--- a/Aspid.MVVM/Assets/Aspid/MVVM/StarterKit/Runtime/ViewModels/Dynamic/DynamicViewModel.Create.cs
+++ b/Aspid.MVVM/Assets/Aspid/MVVM/StarterKit/Runtime/ViewModels/Dynamic/DynamicViewModel.Create.cs
@@ -5,48 +5,48 @@ namespace Aspid.MVVM.StarterKit
 {
     public sealed partial class DynamicViewModel
     {
-        public static DynamicViewModel Create<T>(DynamicPropertyData<T> p) => 
-            new(new Dictionary<string, IDynamicProperty> 
-            { 
-                [p.Id] = DynamicPropertyFactory.Create(p.Value), 
+        public static DynamicViewModel Create<T>(DynamicPropertyData<T> p) =>
+            new(new Dictionary<string, IDynamicProperty>
+            {
+                [p.Id] = DynamicPropertyFactory.Create(p),
             });
-        
-        public static DynamicViewModel Create<T>(bool throwErrorIfNotFindProperty, DynamicPropertyData<T> p) => 
-            new(throwErrorIfNotFindProperty, new Dictionary<string, IDynamicProperty> 
-            { 
-                [p.Id] = DynamicPropertyFactory.Create(p.Value), 
+
+        public static DynamicViewModel Create<T>(bool throwErrorIfNotFindProperty, DynamicPropertyData<T> p) =>
+            new(throwErrorIfNotFindProperty, new Dictionary<string, IDynamicProperty>
+            {
+                [p.Id] = DynamicPropertyFactory.Create(p),
             });
-        
+
         public static DynamicViewModel Create<T1, T2>(
             DynamicPropertyData<T1> p1,
             DynamicPropertyData<T2> p2) =>
             new(new Dictionary<string, IDynamicProperty>
             {
-                [p1.Id] = DynamicPropertyFactory.Create(p1.Value),
-                [p2.Id] = DynamicPropertyFactory.Create(p2.Value),
+                [p1.Id] = DynamicPropertyFactory.Create(p1),
+                [p2.Id] = DynamicPropertyFactory.Create(p2),
             });
-        
+
         public static DynamicViewModel Create<T1, T2>(
             bool throwErrorIfNotFindProperty,
             DynamicPropertyData<T1> p1,
             DynamicPropertyData<T2> p2) =>
             new(throwErrorIfNotFindProperty, new Dictionary<string, IDynamicProperty>
             {
-                [p1.Id] = DynamicPropertyFactory.Create(p1.Value),
-                [p2.Id] = DynamicPropertyFactory.Create(p2.Value),
+                [p1.Id] = DynamicPropertyFactory.Create(p1),
+                [p2.Id] = DynamicPropertyFactory.Create(p2),
             });
-        
+
         public static DynamicViewModel Create<T1, T2, T3>(
             DynamicPropertyData<T1> p1,
             DynamicPropertyData<T2> p2,
             DynamicPropertyData<T3> p3) =>
             new(new Dictionary<string, IDynamicProperty>
             {
-                [p1.Id] = DynamicPropertyFactory.Create(p1.Value),
-                [p2.Id] = DynamicPropertyFactory.Create(p2.Value),
-                [p3.Id] = DynamicPropertyFactory.Create(p3.Value),
+                [p1.Id] = DynamicPropertyFactory.Create(p1),
+                [p2.Id] = DynamicPropertyFactory.Create(p2),
+                [p3.Id] = DynamicPropertyFactory.Create(p3),
             });
-        
+
         public static DynamicViewModel Create<T1, T2, T3>(
             bool throwErrorIfNotFindProperty,
             DynamicPropertyData<T1> p1,
@@ -54,11 +54,11 @@ namespace Aspid.MVVM.StarterKit
             DynamicPropertyData<T3> p3) =>
             new(throwErrorIfNotFindProperty, new Dictionary<string, IDynamicProperty>
             {
-                [p1.Id] = DynamicPropertyFactory.Create(p1.Value),
-                [p2.Id] = DynamicPropertyFactory.Create(p2.Value),
-                [p3.Id] = DynamicPropertyFactory.Create(p3.Value),
+                [p1.Id] = DynamicPropertyFactory.Create(p1),
+                [p2.Id] = DynamicPropertyFactory.Create(p2),
+                [p3.Id] = DynamicPropertyFactory.Create(p3),
             });
-        
+
         public static DynamicViewModel Create<T1, T2, T3, T4>(
             DynamicPropertyData<T1> p1,
             DynamicPropertyData<T2> p2,
@@ -66,12 +66,12 @@ namespace Aspid.MVVM.StarterKit
             DynamicPropertyData<T4> p4) =>
             new(new Dictionary<string, IDynamicProperty>
             {
-                [p1.Id] = DynamicPropertyFactory.Create(p1.Value),
-                [p2.Id] = DynamicPropertyFactory.Create(p2.Value),
-                [p3.Id] = DynamicPropertyFactory.Create(p3.Value),
-                [p4.Id] = DynamicPropertyFactory.Create(p4.Value),
+                [p1.Id] = DynamicPropertyFactory.Create(p1),
+                [p2.Id] = DynamicPropertyFactory.Create(p2),
+                [p3.Id] = DynamicPropertyFactory.Create(p3),
+                [p4.Id] = DynamicPropertyFactory.Create(p4),
             });
-        
+
         public static DynamicViewModel Create<T1, T2, T3, T4>(
             bool throwErrorIfNotFindProperty,
             DynamicPropertyData<T1> p1,
@@ -80,146 +80,146 @@ namespace Aspid.MVVM.StarterKit
             DynamicPropertyData<T4> p4) =>
             new(throwErrorIfNotFindProperty, new Dictionary<string, IDynamicProperty>
             {
-                [p1.Id] = DynamicPropertyFactory.Create(p1.Value),
-                [p2.Id] = DynamicPropertyFactory.Create(p2.Value),
-                [p3.Id] = DynamicPropertyFactory.Create(p3.Value),
-                [p4.Id] = DynamicPropertyFactory.Create(p4.Value),
+                [p1.Id] = DynamicPropertyFactory.Create(p1),
+                [p2.Id] = DynamicPropertyFactory.Create(p2),
+                [p3.Id] = DynamicPropertyFactory.Create(p3),
+                [p4.Id] = DynamicPropertyFactory.Create(p4),
             });
-        
+
         public static DynamicViewModel Create<T1, T2, T3, T4, T5>(
-            DynamicPropertyData<T1> p1, 
-            DynamicPropertyData<T2> p2, 
+            DynamicPropertyData<T1> p1,
+            DynamicPropertyData<T2> p2,
             DynamicPropertyData<T3> p3,
             DynamicPropertyData<T4> p4,
             DynamicPropertyData<T5> p5) =>
             new(new Dictionary<string, IDynamicProperty>
             {
-                [p1.Id] = DynamicPropertyFactory.Create(p1.Value),
-                [p2.Id] = DynamicPropertyFactory.Create(p2.Value),
-                [p3.Id] = DynamicPropertyFactory.Create(p3.Value),
-                [p4.Id] = DynamicPropertyFactory.Create(p4.Value),
-                [p5.Id] = DynamicPropertyFactory.Create(p5.Value),
+                [p1.Id] = DynamicPropertyFactory.Create(p1),
+                [p2.Id] = DynamicPropertyFactory.Create(p2),
+                [p3.Id] = DynamicPropertyFactory.Create(p3),
+                [p4.Id] = DynamicPropertyFactory.Create(p4),
+                [p5.Id] = DynamicPropertyFactory.Create(p5),
             });
-        
+
         public static DynamicViewModel Create<T1, T2, T3, T4, T5>(
             bool throwErrorIfNotFindProperty,
-            DynamicPropertyData<T1> p1, 
-            DynamicPropertyData<T2> p2, 
+            DynamicPropertyData<T1> p1,
+            DynamicPropertyData<T2> p2,
             DynamicPropertyData<T3> p3,
             DynamicPropertyData<T4> p4,
             DynamicPropertyData<T5> p5) =>
             new(throwErrorIfNotFindProperty, new Dictionary<string, IDynamicProperty>
             {
-                [p1.Id] = DynamicPropertyFactory.Create(p1.Value),
-                [p2.Id] = DynamicPropertyFactory.Create(p2.Value),
-                [p3.Id] = DynamicPropertyFactory.Create(p3.Value),
-                [p4.Id] = DynamicPropertyFactory.Create(p4.Value),
-                [p5.Id] = DynamicPropertyFactory.Create(p5.Value),
+                [p1.Id] = DynamicPropertyFactory.Create(p1),
+                [p2.Id] = DynamicPropertyFactory.Create(p2),
+                [p3.Id] = DynamicPropertyFactory.Create(p3),
+                [p4.Id] = DynamicPropertyFactory.Create(p4),
+                [p5.Id] = DynamicPropertyFactory.Create(p5),
             });
-        
+
         public static DynamicViewModel Create<T1, T2, T3, T4, T5, T6>(
-            DynamicPropertyData<T1> p1, 
+            DynamicPropertyData<T1> p1,
             DynamicPropertyData<T2> p2,
             DynamicPropertyData<T3> p3,
-            DynamicPropertyData<T4> p4, 
-            DynamicPropertyData<T5> p5, 
+            DynamicPropertyData<T4> p4,
+            DynamicPropertyData<T5> p5,
             DynamicPropertyData<T6> p6) =>
             new(new Dictionary<string, IDynamicProperty>
             {
-                [p1.Id] = DynamicPropertyFactory.Create(p1.Value),
-                [p2.Id] = DynamicPropertyFactory.Create(p2.Value),
-                [p3.Id] = DynamicPropertyFactory.Create(p3.Value),
-                [p4.Id] = DynamicPropertyFactory.Create(p4.Value),
-                [p5.Id] = DynamicPropertyFactory.Create(p5.Value),
-                [p6.Id] = DynamicPropertyFactory.Create(p6.Value),
+                [p1.Id] = DynamicPropertyFactory.Create(p1),
+                [p2.Id] = DynamicPropertyFactory.Create(p2),
+                [p3.Id] = DynamicPropertyFactory.Create(p3),
+                [p4.Id] = DynamicPropertyFactory.Create(p4),
+                [p5.Id] = DynamicPropertyFactory.Create(p5),
+                [p6.Id] = DynamicPropertyFactory.Create(p6),
             });
-        
+
         public static DynamicViewModel Create<T1, T2, T3, T4, T5, T6>(
             bool throwErrorIfNotFindProperty,
-            DynamicPropertyData<T1> p1, 
+            DynamicPropertyData<T1> p1,
             DynamicPropertyData<T2> p2,
             DynamicPropertyData<T3> p3,
-            DynamicPropertyData<T4> p4, 
-            DynamicPropertyData<T5> p5, 
+            DynamicPropertyData<T4> p4,
+            DynamicPropertyData<T5> p5,
             DynamicPropertyData<T6> p6) =>
             new(throwErrorIfNotFindProperty, new Dictionary<string, IDynamicProperty>
             {
-                [p1.Id] = DynamicPropertyFactory.Create(p1.Value),
-                [p2.Id] = DynamicPropertyFactory.Create(p2.Value),
-                [p3.Id] = DynamicPropertyFactory.Create(p3.Value),
-                [p4.Id] = DynamicPropertyFactory.Create(p4.Value),
-                [p5.Id] = DynamicPropertyFactory.Create(p5.Value),
-                [p6.Id] = DynamicPropertyFactory.Create(p6.Value),
+                [p1.Id] = DynamicPropertyFactory.Create(p1),
+                [p2.Id] = DynamicPropertyFactory.Create(p2),
+                [p3.Id] = DynamicPropertyFactory.Create(p3),
+                [p4.Id] = DynamicPropertyFactory.Create(p4),
+                [p5.Id] = DynamicPropertyFactory.Create(p5),
+                [p6.Id] = DynamicPropertyFactory.Create(p6),
             });
-        
+
         public static DynamicViewModel Create<T1, T2, T3, T4, T5, T6, T7>(
             DynamicPropertyData<T1> p1,
-            DynamicPropertyData<T2> p2, 
-            DynamicPropertyData<T3> p3, 
+            DynamicPropertyData<T2> p2,
+            DynamicPropertyData<T3> p3,
             DynamicPropertyData<T4> p4,
             DynamicPropertyData<T5> p5,
-            DynamicPropertyData<T6> p6, 
+            DynamicPropertyData<T6> p6,
             DynamicPropertyData<T7> p7) =>
             new(new Dictionary<string, IDynamicProperty>
             {
-                [p1.Id] = DynamicPropertyFactory.Create(p1.Value),
-                [p2.Id] = DynamicPropertyFactory.Create(p2.Value),
-                [p3.Id] = DynamicPropertyFactory.Create(p3.Value),
-                [p4.Id] = DynamicPropertyFactory.Create(p4.Value),
-                [p5.Id] = DynamicPropertyFactory.Create(p5.Value),
-                [p6.Id] = DynamicPropertyFactory.Create(p6.Value),
-                [p7.Id] = DynamicPropertyFactory.Create(p7.Value),
+                [p1.Id] = DynamicPropertyFactory.Create(p1),
+                [p2.Id] = DynamicPropertyFactory.Create(p2),
+                [p3.Id] = DynamicPropertyFactory.Create(p3),
+                [p4.Id] = DynamicPropertyFactory.Create(p4),
+                [p5.Id] = DynamicPropertyFactory.Create(p5),
+                [p6.Id] = DynamicPropertyFactory.Create(p6),
+                [p7.Id] = DynamicPropertyFactory.Create(p7),
             });
-        
+
         public static DynamicViewModel Create<T1, T2, T3, T4, T5, T6, T7>(
             bool throwErrorIfNotFindProperty,
             DynamicPropertyData<T1> p1,
-            DynamicPropertyData<T2> p2, 
-            DynamicPropertyData<T3> p3, 
+            DynamicPropertyData<T2> p2,
+            DynamicPropertyData<T3> p3,
             DynamicPropertyData<T4> p4,
             DynamicPropertyData<T5> p5,
-            DynamicPropertyData<T6> p6, 
+            DynamicPropertyData<T6> p6,
             DynamicPropertyData<T7> p7) =>
             new(throwErrorIfNotFindProperty, new Dictionary<string, IDynamicProperty>
             {
-                [p1.Id] = DynamicPropertyFactory.Create(p1.Value),
-                [p2.Id] = DynamicPropertyFactory.Create(p2.Value),
-                [p3.Id] = DynamicPropertyFactory.Create(p3.Value),
-                [p4.Id] = DynamicPropertyFactory.Create(p4.Value),
-                [p5.Id] = DynamicPropertyFactory.Create(p5.Value),
-                [p6.Id] = DynamicPropertyFactory.Create(p6.Value),
-                [p7.Id] = DynamicPropertyFactory.Create(p7.Value),
+                [p1.Id] = DynamicPropertyFactory.Create(p1),
+                [p2.Id] = DynamicPropertyFactory.Create(p2),
+                [p3.Id] = DynamicPropertyFactory.Create(p3),
+                [p4.Id] = DynamicPropertyFactory.Create(p4),
+                [p5.Id] = DynamicPropertyFactory.Create(p5),
+                [p6.Id] = DynamicPropertyFactory.Create(p6),
+                [p7.Id] = DynamicPropertyFactory.Create(p7),
             });
 
         public static DynamicViewModel Create<T1, T2, T3, T4, T5, T6, T7, T8>(
             DynamicPropertyData<T1> p1,
-            DynamicPropertyData<T2> p2, 
-            DynamicPropertyData<T3> p3, 
+            DynamicPropertyData<T2> p2,
+            DynamicPropertyData<T3> p3,
             DynamicPropertyData<T4> p4,
             DynamicPropertyData<T5> p5,
-            DynamicPropertyData<T6> p6, 
+            DynamicPropertyData<T6> p6,
             DynamicPropertyData<T7> p7,
             DynamicPropertyData<T8> p8) =>
             new(new Dictionary<string, IDynamicProperty>
             {
-                [p1.Id] = DynamicPropertyFactory.Create(p1.Value),
-                [p2.Id] = DynamicPropertyFactory.Create(p2.Value),
-                [p3.Id] = DynamicPropertyFactory.Create(p3.Value),
-                [p4.Id] = DynamicPropertyFactory.Create(p4.Value),
-                [p5.Id] = DynamicPropertyFactory.Create(p5.Value),
-                [p6.Id] = DynamicPropertyFactory.Create(p6.Value),
-                [p7.Id] = DynamicPropertyFactory.Create(p7.Value),
-                [p8.Id] = DynamicPropertyFactory.Create(p8.Value),
+                [p1.Id] = DynamicPropertyFactory.Create(p1),
+                [p2.Id] = DynamicPropertyFactory.Create(p2),
+                [p3.Id] = DynamicPropertyFactory.Create(p3),
+                [p4.Id] = DynamicPropertyFactory.Create(p4),
+                [p5.Id] = DynamicPropertyFactory.Create(p5),
+                [p6.Id] = DynamicPropertyFactory.Create(p6),
+                [p7.Id] = DynamicPropertyFactory.Create(p7),
+                [p8.Id] = DynamicPropertyFactory.Create(p8),
             });
-        
+
         public static DynamicViewModel Create<T1, T2, T3, T4, T5, T6, T7, T8>(
             bool throwErrorIfNotFindProperty,
             DynamicPropertyData<T1> p1,
-            DynamicPropertyData<T2> p2, 
-            DynamicPropertyData<T3> p3, 
+            DynamicPropertyData<T2> p2,
+            DynamicPropertyData<T3> p3,
             DynamicPropertyData<T4> p4,
             DynamicPropertyData<T5> p5,
-            DynamicPropertyData<T6> p6, 
+            DynamicPropertyData<T6> p6,
             DynamicPropertyData<T7> p7,
             DynamicPropertyData<T8> p8) =>
             new(throwErrorIfNotFindProperty, new Dictionary<string, IDynamicProperty>


### PR DESCRIPTION
## Summary

- **Bug:** All `DynamicViewModel.Create` overloads (1–7 type params, plus the non-`throwError` 8-param variant) called `DynamicPropertyFactory.Create(p.Value)`, discarding `p.Mode`. Because the `Create<T>(T value, BindMode mode = BindMode.OneTime)` overload was resolved, every dynamic property was silently created as `BindMode.OneTime` regardless of what the caller specified.
- **Root cause:** The correct pattern — passing the full `DynamicPropertyData<T>` struct — was only used in the `bool throwErrorIfNotFindProperty` + 8 type-param overload.
- **Fix:** Changed every `DynamicPropertyFactory.Create(pN.Value)` to `DynamicPropertyFactory.Create(pN)` across all 16 affected overloads (1–8 type params, with and without `throwErrorIfNotFindProperty`), so the factory receives both `Value` and `Mode`.

## Test plan

- [ ] Verify that a `DynamicPropertyData<T>` created with an explicit `BindMode` (e.g. `BindMode.TwoWay`) results in a property with that mode when the corresponding `Create` overload is called.
- [ ] Regression: `BindMode.OneTime` still works when specified explicitly.
- [ ] Smoke-test the existing samples (HelloWorld, TodoList, Stats) to confirm no runtime regressions.