### PR TITLE
Fix shared singleton mutation in OneTime bindable member Get methods

### DIFF
--- a/Assets/Plugins/Aspid/MVVM/Source/ViewModels/BindableMembers/Classes/OneTimeBindableMember.cs
+++ b/Assets/Plugins/Aspid/MVVM/Source/ViewModels/BindableMembers/Classes/OneTimeBindableMember.cs
@@ -9,19 +9,20 @@ namespace Aspid.MVVM
     /// <typeparam name="T">The type of the value to be bound.</typeparam>
     public sealed class OneTimeBindableMember<T> : OneTimeBindableMember, IReadOnlyValueBindableMember<T>
     {
-        private static readonly OneTimeBindableMember<T> _instance = new();
-    
         /// <summary>
-        /// Gets or sets the current value.
+        /// Gets the current value.
         /// </summary>
         public T? Value { get; private set; }
-        
+
         /// <summary>
         /// Gets the binding mode for this member.
         /// </summary>
         public BindMode Mode => BindMode.OneTime;
 
-        private OneTimeBindableMember() { }
+        private OneTimeBindableMember(T? value)
+        {
+            Value = value;
+        }
 
         /// <inheritdoc />
         /// <summary>
@@ -60,18 +61,17 @@ namespace Aspid.MVVM
         }
 
         /// <summary>
-        /// Creates a reusable instance and assigns the provided value for one-time binding.
+        /// Creates a new instance configured with the provided value for one-time binding.
         /// </summary>
         /// <param name="value">The value to be provided to the binder.</param>
-        /// <returns>A singleton instance of <see cref="OneTimeBindableMember{T}"/> configured with the specified value.</returns>
+        /// <returns>A new <see cref="OneTimeBindableMember{T}"/> instance configured with the specified value.</returns>
         public static OneTimeBindableMember<T> Get(T value)
         {
 #if UNITY_2022_1_OR_NEWER && !ASPID_MVVM_UNITY_PROFILER_DISABLED
             using (GetMarker.Auto())
 #endif
             {
-                _instance.Value = value;
-                return _instance;
+                return new(value);
             }
         }
     }

--- a/Assets/Plugins/Aspid/MVVM/Source/ViewModels/BindableMembers/Enum/OneTimeEnumBindableMember.cs
+++ b/Assets/Plugins/Aspid/MVVM/Source/ViewModels/BindableMembers/Enum/OneTimeEnumBindableMember.cs
@@ -10,23 +10,20 @@ namespace Aspid.MVVM
     public sealed class OneTimeEnumBindableMember<T> : OneTimeStructBindableMember<T, Enum>
         where T : struct, Enum
     {
-        private static readonly OneTimeEnumBindableMember<T> _instance = new();
-    
-        private OneTimeEnumBindableMember() { }
-    
+        private OneTimeEnumBindableMember(T value) : base(value) { }
+
         /// <summary>
-        /// Creates a reusable instance and assigns the provided enum value for one-time binding.
+        /// Creates a new instance configured with the provided enum value for one-time binding.
         /// </summary>
         /// <param name="value">The enum value to provide to the binder.</param>
-        /// <returns>A singleton instance of <see cref="OneTimeEnumBindableMember{T}"/> configured with the specified value.</returns>
+        /// <returns>A new <see cref="OneTimeEnumBindableMember{T}"/> instance configured with the specified value.</returns>
         public static OneTimeEnumBindableMember<T> Get(T value)
         {
 #if UNITY_2022_1_OR_NEWER && !ASPID_MVVM_UNITY_PROFILER_DISABLED
             using (GetMarker.Auto())
 #endif
             {
-                _instance.Value = value;
-                return _instance;
+                return new(value);
             }
         }
     }

--- a/Assets/Plugins/Aspid/MVVM/Source/ViewModels/BindableMembers/Struct/OneTimeStructBindableMember.cs
+++ b/Assets/Plugins/Aspid/MVVM/Source/ViewModels/BindableMembers/Struct/OneTimeStructBindableMember.cs
@@ -10,23 +10,20 @@ namespace Aspid.MVVM
     public sealed class OneTimeStructBindableMember<T> : OneTimeStructBindableMember<T, ValueType>
         where T : struct
     {
-        private static readonly OneTimeStructBindableMember<T> _instance = new();
-        
-        private OneTimeStructBindableMember() { }
-    
+        private OneTimeStructBindableMember(T value) : base(value) { }
+
         /// <summary>
-        /// Creates a reusable instance and assigns the provided value for one-time binding.
+        /// Creates a new instance configured with the provided value for one-time binding.
         /// </summary>
         /// <param name="value">The value to be provided to the binder.</param>
-        /// <returns>A singleton instance of <see cref="OneTimeStructBindableMember{T}"/> configured with the specified value.</returns>
+        /// <returns>A new <see cref="OneTimeStructBindableMember{T}"/> instance configured with the specified value.</returns>
         public static OneTimeStructBindableMember<T> Get(T value)
         {
 #if UNITY_2022_1_OR_NEWER && !ASPID_MVVM_UNITY_PROFILER_DISABLED
             using (GetMarker.Auto())
-#endif  
+#endif
             {
-                _instance.Value = value;
-                return _instance;
+                return new(value);
             }
         }
     }
@@ -41,16 +38,19 @@ namespace Aspid.MVVM
         where TBoxed : class
     {
         /// <summary>
-        /// Gets or sets the current value.
+        /// Gets the current value.
         /// </summary>
-        public T Value { get; private protected set; }
-        
+        public T Value { get; }
+
         /// <summary>
         /// Gets the binding mode for this member.
         /// </summary>
-        public BindMode Mode => BindMode.OneTime;    
-    
-        private protected OneTimeStructBindableMember() { }
+        public BindMode Mode => BindMode.OneTime;
+
+        private protected OneTimeStructBindableMember(T value)
+        {
+            Value = value;
+        }
 
         /// <inheritdoc />
         /// <summary>


### PR DESCRIPTION
## Summary

- `OneTimeBindableMember<T>.Get()`, `OneTimeStructBindableMember<T>.Get()`, and `OneTimeEnumBindableMember<T>.Get()` all mutated a shared static `_instance` and returned it. Any caller that retained the reference across two `Get()` calls on the same type would silently observe the second value instead of the first.
- Replaced the singleton pattern with fresh instance allocation per call. Value is now set via constructor rather than post-construction mutation, making each returned instance independently immutable.
- Allocation cost is negligible: OneTime bindings fire exactly once per bind cycle, so this is a one-shot heap allocation per binding — identical in practice to what was already happening at bind time.

## Notes for review

The `Value` property on `OneTimeStructBindableMember<T, TBoxed>` was changed from `{ get; private protected set; }` to `{ get; }` (init-only via constructor). This is a tighter contract that prevents any future accidental mutation from derived types.

No generated code changes are needed — the generator emits `SomeType.Get(memberName)` whose result is consumed immediately, so the fix is transparent.

## Linked issues

N/A

<details>
<summary>🇷🇺 Описание на русском</summary>

## Summary

- `OneTimeBindableMember<T>.Get()`, `OneTimeStructBindableMember<T>.Get()` и `OneTimeEnumBindableMember<T>.Get()` мутировали общий статический `_instance` и возвращали его. Любой вызывающий код, удержавший ссылку между двумя `Get()` по одному типу, молча наблюдал второе значение вместо первого.
- Паттерн синглтона заменён на аллокацию свежего экземпляра на каждый вызов. Значение теперь задаётся конструктором, а не мутацией после создания, — каждый возвращённый экземпляр независимо иммутабелен.
- Цена аллокации пренебрежима: OneTime-биндинги срабатывают ровно один раз за цикл бинда, так что это одноразовая heap-аллокация на биндинг — на практике то же, что уже происходило при бинде.

## Notes for review

Свойство `Value` у `OneTimeStructBindableMember<T, TBoxed>` изменено с `{ get; private protected set; }` на `{ get; }` (init-only через конструктор). Это более жёсткий контракт, исключающий будущие случайные мутации из наследников.

Изменения сгенерированного кода не нужны — генератор эмитит `SomeType.Get(memberName)`, результат которого потребляется сразу, так что фикс прозрачен.

</details>
