### PR TITLE
ci(release): run generator and analyzer tests before publishing

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -163,6 +163,12 @@ jobs:
           dotnet build -c Release Aspid.MVVM.Analyzers/Aspid.MVVM.Analyzers.sln
           dotnet build -c Release Aspid.MVVM.Unity.Generators/Aspid.MVVM.Unity.Generators.sln
 
+      - name: Run generator and analyzer tests
+        run: |
+          set -euo pipefail
+          dotnet test -c Release Aspid.MVVM.Generators/Aspid.MVVM.Generators.sln --no-build
+          dotnet test -c Release Aspid.MVVM.Analyzers/Aspid.MVVM.Analyzers.sln --no-build
+
       - name: Verify committed generator DLLs match the freshly-built ones
         # Directory.Build.targets / CopyToUnity copies the built DLLs over the
         # committed ones. If git sees no diff afterwards, the source tree and


### PR DESCRIPTION
## Summary

- Adds a `Run generator and analyzer tests` step to `release.yml` between the build step and the DLL verification step
- Both `Aspid.MVVM.Generators.sln` and `Aspid.MVVM.Analyzers.sln` are tested with `dotnet test -c Release --no-build` so no re-compilation is needed
- Ensures all generator and analyzer tests pass before the release proceeds to DLL verification and publishing

## Test plan

- [ ] Trigger the release workflow on a test tag and confirm the new step runs and passes
- [ ] Introduce a deliberate test failure in a generator/analyzer, re-run, and confirm the workflow aborts at the test step before publishing

🤖 Generated with [Claude Code](https://claude.com/claude-code)