### PR TITLE
Fix CollectionChanged event-handler leak in CollectionBinderBase

### DIFF
--- a/Aspid.MVVM/Assets/Aspid/MVVM/StarterKit/Runtime/Binders/Collections/CollectionBinderBase.cs
+++ b/Aspid.MVVM/Assets/Aspid/MVVM/StarterKit/Runtime/Binders/Collections/CollectionBinderBase.cs
@@ -48,12 +48,8 @@ namespace Aspid.MVVM.StarterKit
         {
             if (Collection is not null)
                 OnReset();
-            
-            switch (Collection)
-            {
-                case IReadOnlyFilteredList<T> filteredList: filteredList.CollectionChanged -= OnCollectionChanged; break;
-                case IReadOnlyObservableList<T> observableList: observableList.CollectionChanged -= OnCollectionChanged; break;
-            }
+
+            UnsubscribeFromCollection();
             
             Collection = collection;
             if (Collection is null) return;
@@ -142,11 +138,7 @@ namespace Aspid.MVVM.StarterKit
         /// </summary>
         protected override void OnUnbound()
         {
-            switch (Collection)
-            {
-                case IReadOnlyFilteredList<T> filteredList: filteredList.CollectionChanged -= OnCollectionChanged; break;
-                case IReadOnlyObservableList<T> observableList: observableList.CollectionChanged -= OnCollectionChanged; break;
-            }
+            UnsubscribeFromCollection();
         }
 
         /// <summary>
@@ -155,13 +147,17 @@ namespace Aspid.MVVM.StarterKit
         /// </summary>
         public virtual void Dispose()
         {
+            UnsubscribeFromCollection();
+            OnReset();
+        }
+
+        private void UnsubscribeFromCollection()
+        {
             switch (Collection)
             {
                 case IReadOnlyFilteredList<T> filteredList: filteredList.CollectionChanged -= OnCollectionChanged; break;
                 case IReadOnlyObservableList<T> observableList: observableList.CollectionChanged -= OnCollectionChanged; break;
             }
-
-            OnReset();
         }
     }
 }

--- a/Aspid.MVVM/Assets/Aspid/MVVM/StarterKit/Runtime/Binders/Collections/CollectionBinderBase.cs
+++ b/Aspid.MVVM/Assets/Aspid/MVVM/StarterKit/Runtime/Binders/Collections/CollectionBinderBase.cs
@@ -16,7 +16,10 @@ namespace Aspid.MVVM.StarterKit
     /// When a new collection is assigned via <see cref="SetValue"/>, the previously held collection is reset
     /// first via <see cref="OnReset"/>, then the new items are passed to <see cref="OnAdded"/> if the collection
     /// is non-empty.
-    /// The class also implements <see cref="IDisposable"/>; disposing it calls <see cref="OnReset"/>.
+    /// When the binder is unbound (via <see cref="Binder.Unbind"/>), <see cref="OnUnbound"/> unsubscribes from
+    /// the collection's <c>CollectionChanged</c> event to prevent handler leaks.
+    /// The class also implements <see cref="IDisposable"/>; disposing it unsubscribes from
+    /// <c>CollectionChanged</c> and then calls <see cref="OnReset"/>.
     /// </remarks>
     public abstract class CollectionBinderBase<T> : Binder, 
         IBinder<IReadOnlyCollection<T>>,
@@ -134,9 +137,31 @@ namespace Aspid.MVVM.StarterKit
         protected abstract void OnReset();
 
         /// <summary>
-        /// Resets the binder by calling <see cref="OnReset"/>.
+        /// Called after unbinding. Unsubscribes from <see cref="INotifyCollectionChanged"/> on the
+        /// currently bound collection to prevent event-handler leaks.
         /// </summary>
-        public virtual void Dispose() =>
+        protected override void OnUnbound()
+        {
+            switch (Collection)
+            {
+                case IReadOnlyFilteredList<T> filteredList: filteredList.CollectionChanged -= OnCollectionChanged; break;
+                case IReadOnlyObservableList<T> observableList: observableList.CollectionChanged -= OnCollectionChanged; break;
+            }
+        }
+
+        /// <summary>
+        /// Unsubscribes from <see cref="INotifyCollectionChanged"/> on the currently bound collection,
+        /// then resets the binder by calling <see cref="OnReset"/>.
+        /// </summary>
+        public virtual void Dispose()
+        {
+            switch (Collection)
+            {
+                case IReadOnlyFilteredList<T> filteredList: filteredList.CollectionChanged -= OnCollectionChanged; break;
+                case IReadOnlyObservableList<T> observableList: observableList.CollectionChanged -= OnCollectionChanged; break;
+            }
+
             OnReset();
+        }
     }
 }


### PR DESCRIPTION
## Summary

- `CollectionBinderBase<T>.SetValue()` subscribed to `CollectionChanged` on observable/filtered collections but `OnUnbound()` was never overridden, so handlers remained attached after the binder was unbound from its ViewModel — a classic event-handler leak.
- `Dispose()` only called `OnReset()` without unsubscribing, leaving the same leak when the binder was disposed directly.
- Added an `OnUnbound()` override that runs the same unsubscribe switch as `SetValue()`, covering the unbind path.
- Updated `Dispose()` to also unsubscribe before calling `OnReset()`, covering the dispose path.

## Notes for review

The fix intentionally does **not** null out `Collection` in `OnUnbound()` — the field may still be readable by subclasses for teardown work in `OnReset()` triggered by other paths. The unsubscribe is the only action needed here to stop the leak.

## Linked issues

N/A