### PR TITLE
fix(virtualized-list): use _views.Length instead of ItemsSource.Count in OnAdded/OnRemoved

### DIFF
--- a/Aspid.MVVM/Assets/Aspid/MVVM/StarterKit/Unity/Runtime/Components/UI/VirtualizedList.cs
+++ b/Aspid.MVVM/Assets/Aspid/MVVM/StarterKit/Unity/Runtime/Components/UI/VirtualizedList.cs
@@ -265,7 +265,7 @@ namespace Aspid.MVVM.StarterKit
         {
             var viewIndex = newStartingIndex - _previousViewModelTopIndex;
 
-            if (viewIndex < 0 || viewIndex <= ItemsSource.Count) Refresh();
+            if (viewIndex < 0 || viewIndex < _views.Length) Refresh();
             else ResizeContent();
         }
 
@@ -279,7 +279,7 @@ namespace Aspid.MVVM.StarterKit
         {
             var viewIndex = oldStartingIndex - _previousViewModelTopIndex;
 
-            if (viewIndex < 0 || viewIndex <= ItemsSource.Count) Refresh();
+            if (viewIndex < 0 || viewIndex < _views.Length) Refresh();
             else ResizeContent();
         }
 


### PR DESCRIPTION
## Summary

- In `VirtualizedList.OnAdded` and `VirtualizedList.OnRemoved`, the guard condition `viewIndex <= ItemsSource.Count` was always true for any non-negative `viewIndex`, making the `else ResizeContent()` branch unreachable dead code.
- Fixed by replacing `viewIndex <= ItemsSource.Count` with `viewIndex < _views.Length` on both lines (268 and 282), so the check correctly tests whether the changed index falls within the currently visible window.

## Root Cause

`viewIndex` is computed as `startingIndex - _previousViewModelTopIndex`. For an add/remove beyond the visible window, `viewIndex` can be a large positive number. The old comparison `viewIndex <= ItemsSource.Count` is trivially true for any valid index, so `ResizeContent()` was never called directly — only the much heavier `Refresh()` was ever reached.

The correct semantic is: if the change is *inside* the visible window (`viewIndex < _views.Length`), do a full `Refresh()`; otherwise only `ResizeContent()` to update the scroll area size.

## Test plan

- [ ] Add an item beyond the currently visible window and confirm only `ResizeContent()` is called (no full `Refresh()`).
- [ ] Add/remove an item within the visible window and confirm `Refresh()` is still called.
- [ ] Smoke-test the VirtualizedList sample scene to confirm no regressions in scroll/render behaviour.

🤖 Generated with [Claude Code](https://claude.com/claude-code)