### PR TITLE
fix(collections): align subscribe/unsubscribe targets in ObservableListBinder

### DIFF
--- a/Aspid.MVVM/Assets/Aspid/MVVM/StarterKit/Runtime/Binders/Collections/Lists/ObservableListBinder.cs
+++ b/Aspid.MVVM/Assets/Aspid/MVVM/StarterKit/Runtime/Binders/Collections/Lists/ObservableListBinder.cs
@@ -80,7 +80,7 @@ namespace Aspid.MVVM.StarterKit
 
             OnAdded(List, newStartingIndex: 0);
 
-            switch (list)
+            switch (List)
             {
                 case IReadOnlyFilteredList<T> filteredList: filteredList.CollectionChanged += OnCollectionChanged; break;
                 case IReadOnlyObservableList<T> observableList: observableList.CollectionChanged += OnCollectionChanged; break;


### PR DESCRIPTION
## Summary

- In `ObservableListBinder<T>.InitializeList`, the `CollectionChanged` subscription was placed on the raw `list` parameter, while `DeinitializeList` unsubscribed from the `List` property.
- When `GetFilterList()` returns a non-null wrapper, `List` is set to the wrapper but `list` is still the original — so subscribe and unsubscribe targeted different objects, leaking the event handler.
- Fix: change `switch (list)` to `switch (List)` in `InitializeList` so both operations target the same (post-filter) object.

## Notes for review

The change is a single-token fix (`list` → `List` on line 83). The path only diverges when a subclass overrides `GetFilterList` to return a non-null wrapper — the default implementation returns `null` so plain usages are unaffected today, but the leak would silently manifest in any subclass that wraps the list.

## Linked issues

N/A