### PR TITLE
fix(commands): return EmptyExecution instead of Empty in generic GetSelfOrEmptyExecution

### DIFF
--- a/Aspid.MVVM/Assets/Aspid/MVVM/Source/Commands/Extensions/RelayCommandExtensions.cs
+++ b/Aspid.MVVM/Assets/Aspid/MVVM/Source/Commands/Extensions/RelayCommandExtensions.cs
@@ -46,7 +46,7 @@ namespace Aspid.MVVM
         /// <returns>The original command if not null; otherwise, an empty execution command.</returns>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static IRelayCommand<T?> GetSelfOrEmptyExecution<T>(this IRelayCommand<T?>? command) =>
-            command ?? RelayCommand<T?>.Empty;
+            command ?? RelayCommand<T?>.EmptyExecution;
         #endregion
 
         #region Get Empty RelayCommand<T1, T2> Methods
@@ -66,7 +66,7 @@ namespace Aspid.MVVM
         /// <returns>The original command if not null; otherwise, an empty execution command.</returns>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static IRelayCommand<T1?, T2?> GetSelfOrEmptyExecution<T1, T2>(this IRelayCommand<T1?, T2?>? command) =>
-            command ?? RelayCommand<T1?, T2?>.Empty;
+            command ?? RelayCommand<T1?, T2?>.EmptyExecution;
         #endregion
 
         #region Get Empty RelayCommand<T1, T2, T3> Methods
@@ -88,7 +88,7 @@ namespace Aspid.MVVM
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static IRelayCommand<T1?, T2?, T3?> GetSelfOrEmptyExecution<T1, T2, T3>(
             this IRelayCommand<T1?, T2?, T3?>? command) =>
-            command ?? RelayCommand<T1?, T2?, T3?>.Empty;
+            command ?? RelayCommand<T1?, T2?, T3?>.EmptyExecution;
         #endregion
         
         #region Get Empty RelayCommand<T1, T2, T3, T4> Methods
@@ -110,7 +110,7 @@ namespace Aspid.MVVM
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static IRelayCommand<T1?, T2?, T3?, T4?> GetSelfOrEmptyExecution<T1, T2, T3, T4>(
             this IRelayCommand<T1?, T2?, T3?, T4?>? command) =>
-            command ?? RelayCommand<T1?, T2?, T3?, T4?>.Empty;
+            command ?? RelayCommand<T1?, T2?, T3?, T4?>.EmptyExecution;
         #endregion
     }
 }


### PR DESCRIPTION
## Summary

All 4 generic overloads of `GetSelfOrEmptyExecution` in `RelayCommandExtensions` were incorrectly returning `.Empty` (CanExecute=false) instead of `.EmptyExecution` (CanExecute=true). Only the non-generic overload was correct. This caused commands bound via the generic overloads to be permanently disabled when their source was null.

## Changes

- `GetSelfOrEmptyExecution<T>`: `RelayCommand<T?>.Empty` → `RelayCommand<T?>.EmptyExecution`
- `GetSelfOrEmptyExecution<T1, T2>`: `RelayCommand<T1?, T2?>.Empty` → `RelayCommand<T1?, T2?>.EmptyExecution`
- `GetSelfOrEmptyExecution<T1, T2, T3>`: `RelayCommand<T1?, T2?, T3?>.Empty` → `RelayCommand<T1?, T2?, T3?>.EmptyExecution`
- `GetSelfOrEmptyExecution<T1, T2, T3, T4>`: `RelayCommand<T1?, T2?, T3?, T4?>.Empty` → `RelayCommand<T1?, T2?, T3?, T4?>.EmptyExecution`

## Test plan

- [ ] Verify that a binding using `GetSelfOrEmptyExecution<T>` with a null command returns a command where `CanExecute` is `true`
- [ ] Verify that a binding using `GetSelfOrEmpty<T>` with a null command still returns a command where `CanExecute` is `false` (unchanged)
- [ ] Confirm non-generic `GetSelfOrEmptyExecution` behaviour is unchanged