### PR TITLE
ci: add PR ready labels workflow

### DIFF
--- a/.github/workflows/pr-ready-labels.yml
+++ b/.github/workflows/pr-ready-labels.yml
@@ -1,0 +1,36 @@
+name: PR Ready Labels
+
+on:
+  pull_request_target:
+    types: [ready_for_review, converted_to_draft]
+
+permissions:
+  pull-requests: write
+
+jobs:
+  update-labels:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Ready for review
+        if: github.event.action == 'ready_for_review'
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const { owner, repo } = context.repo;
+            const issue_number = context.payload.pull_request.number;
+            try {
+              await github.rest.issues.removeLabel({ owner, repo, issue_number, name: 'status: work-in-progress' });
+            } catch {}
+            await github.rest.issues.addLabels({ owner, repo, issue_number, labels: ['status: needs-review'] });
+
+      - name: Converted to draft
+        if: github.event.action == 'converted_to_draft'
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const { owner, repo } = context.repo;
+            const issue_number = context.payload.pull_request.number;
+            try {
+              await github.rest.issues.removeLabel({ owner, repo, issue_number, name: 'status: needs-review' });
+            } catch {}
+            await github.rest.issues.addLabels({ owner, repo, issue_number, labels: ['status: work-in-progress'] });


### PR DESCRIPTION
## Summary
- Adds workflow to `main` so GitHub can discover it for all branches
- On `ready_for_review`: removes `status: work-in-progress`, adds `status: needs-review`
- On `converted_to_draft`: the reverse
- Uses `pull_request_target` to read workflow from the base branch of the PR

## Why on main?
GitHub discovers workflow files only from the default branch. Without this, the workflow is invisible for PRs targeting non-default branches like `Version/Aspid.MVVM-1.1.0`.