### PR TITLE
fix(editor): stop infinite validation loop for List<> binder fields

### DIFF
--- a/Aspid.MVVM/Assets/Aspid/MVVM/Unity/Editor/Scripts/Reflection/RequiredFieldForMonoBinder.cs
+++ b/Aspid.MVVM/Assets/Aspid/MVVM/Unity/Editor/Scripts/Reflection/RequiredFieldForMonoBinder.cs
@@ -180,7 +180,7 @@ namespace Aspid.MVVM
 
             while (fieldType.IsGenericType && fieldType.GetGenericTypeDefinition() == typeof(List<>))
             {
-                fieldType = field.FieldType;
+                fieldType = fieldType.GetGenericArguments()[0];
             }
 
             return !fieldType.IsArray


### PR DESCRIPTION
## Summary
Fix an infinite loop in editor field validation that hangs the Unity main thread when a binder field is a `List<>`.

## Problem
In `RequiredFieldForMonoBinder.IsValidation(FieldInfo field)` the `List<>`-unwrap loop reassigned the same `List<>` type each iteration instead of descending into the generic element type, so the loop condition never changed and never terminated, hanging Unity's main thread.
File: Aspid.MVVM/Assets/Aspid/MVVM/Unity/Editor/Scripts/Reflection/RequiredFieldForMonoBinder.cs:183

## Fix
- `fix(editor): unwrap List<> element type to stop infinite validation loop` — change the loop body from `fieldType = field.FieldType;` to `fieldType = fieldType.GetGenericArguments()[0];`, matching the `GetGenericArguments()[0]` pattern already used in `TypeExtensions.GetUnitySerializableType`.

## Verification
Static review only — Unity runtime is NOT compiled in this environment; needs Unity Editor compile + play-mode validation.

Found via automated release-readiness audit for 1.1.0.