### PR TITLE
fix(collections): ignore empty filter slots in OrCompositeCollectionFilter

### DIFF
--- a/Aspid.MVVM/Assets/Aspid/MVVM/StarterKit/Runtime/Collections/Filters/Composites/OrCompositeCollectionFilter.cs
+++ b/Aspid.MVVM/Assets/Aspid/MVVM/StarterKit/Runtime/Collections/Filters/Composites/OrCompositeCollectionFilter.cs
@@ -30,8 +30,10 @@ namespace Aspid.MVVM.StarterKit
 
         private bool Filter(T value)
         {
-            return _filters.Select(filter => filter?.Get())
-                .Any(predicate => predicate?.Invoke(value) ?? true);
+            return _filters
+                .Select(filter => filter?.Get())
+                .Where(predicate => predicate is not null)
+                .Any(predicate => predicate!(value));
         }
     }
 }


### PR DESCRIPTION
## Summary
Empty ("None") SerializeReference slots no longer force an OR composite filter to pass every item.

## Problem
`OrCompositeCollectionFilter<T, TFilter>.Filter` (StarterKit/Runtime/Collections/Filters/Composites/OrCompositeCollectionFilter.cs:33-34) used `.Any(predicate => predicate?.Invoke(value) ?? true)`. A null predicate from an empty/"None" `[SerializeReference]` slot evaluated to `?? true`, so `Any()` always returned true and the OR filter silently passed every item, disabling filtering.

## Fix
Commit `fix(collections): skip empty filter slots in OrCompositeCollectionFilter`: filter out null predicates with `.Where(predicate => predicate is not null)` before `.Any(predicate => predicate!(value))`, so empty slots no longer force a pass. The sibling `AndCompositeCollectionFilter` keeps its `?? true` because that is correct AND semantics (a null slot must not block) and was intentionally left unchanged.

## Verification
Static review only — Unity runtime is NOT compiled in this environment; needs Unity Editor compile + play-mode validation.

Found via automated release-readiness audit for 1.1.0.