### PR TITLE
fix(binders): correct inverted variable check in LocalizeStringEvent binders

### DIFF
--- a/Aspid.MVVM/Assets/Aspid/MVVM/StarterKit/Unity/Runtime/Binders/LocalizeStringEvents/Variable/LocalizeStringEventVariableBinder.cs
+++ b/Aspid.MVVM/Assets/Aspid/MVVM/StarterKit/Unity/Runtime/Binders/LocalizeStringEvents/Variable/LocalizeStringEventVariableBinder.cs
@@ -167,10 +167,10 @@ namespace Aspid.MVVM.StarterKit
             IVariable? variable = null;
             var stringReference = Target.StringReference;
 
-            if (stringReference?.TryGetValue(_variableName, out variable) ?? false)
+            if (!(stringReference?.TryGetValue(_variableName, out variable) ?? false))
             {
                 variable = new T();
-                stringReference.Add(_variableName, variable);
+                stringReference?.Add(_variableName, variable);
             }
             
             return variable is T specificVariable 

--- a/Aspid.MVVM/Assets/Aspid/MVVM/StarterKit/Unity/Runtime/Binders/LocalizeStringEvents/Variable/Mono/LocalizeStringEventVariableMonoBinder.cs
+++ b/Aspid.MVVM/Assets/Aspid/MVVM/StarterKit/Unity/Runtime/Binders/LocalizeStringEvents/Variable/Mono/LocalizeStringEventVariableMonoBinder.cs
@@ -165,10 +165,10 @@ namespace Aspid.MVVM.StarterKit
             IVariable variable = null;
             var stringReference = CachedComponent.StringReference;
 
-            if (stringReference?.TryGetValue(_variableName, out variable) ?? false)
+            if (!(stringReference?.TryGetValue(_variableName, out variable) ?? false))
             {
                 variable = new T();
-                stringReference.Add(_variableName, variable);
+                stringReference?.Add(_variableName, variable);
             }
             
             return variable is T specificVariable 


### PR DESCRIPTION
## Summary
Fix an inverted guard in the LocalizeStringEvent variable binders that caused the create-variable block to run only when the variable already existed.

## Problem
In `GetSpecificVariable<T>()` the condition was inverted: `if (stringReference?.TryGetValue(_variableName, out variable) ?? false)` ran the "create new variable" block when the variable ALREADY existed, calling `stringReference.Add(...)` with a duplicate key (`ArgumentException`). When the variable was missing, the block was skipped, leaving `variable` null and throwing `InvalidCastException`.

- `Aspid.MVVM/Assets/Aspid/MVVM/StarterKit/Unity/Runtime/Binders/LocalizeStringEvents/Variable/LocalizeStringEventVariableBinder.cs:170`
- `Aspid.MVVM/Assets/Aspid/MVVM/StarterKit/Unity/Runtime/Binders/LocalizeStringEvents/Variable/Mono/LocalizeStringEventVariableMonoBinder.cs:168`

## Fix
Single commit `fix(binders): invert variable-exists check in LocalizeStringEvent variable binders`:
- Inverted the guard to `if (!(stringReference?.TryGetValue(_variableName, out variable) ?? false))` so a new variable is created only when it does NOT exist.
- Changed `stringReference.Add(...)` to `stringReference?.Add(...)` to preserve null-safety.
- Applied identically in both binder files.

## Verification
Static review only — Unity runtime is NOT compiled in this environment; needs Unity Editor compile + play-mode validation.

Found via automated release-readiness audit for 1.1.0.