### PR TITLE
fix(binders): repair custom-interactable command binder constructors

### DIFF
--- a/Aspid.MVVM/Assets/Aspid/MVVM/StarterKit/Unity/Runtime/Binders/Scrollbars/Command/ScrollbarCommandBinder.cs
+++ b/Aspid.MVVM/Assets/Aspid/MVVM/StarterKit/Unity/Runtime/Binders/Scrollbars/Command/ScrollbarCommandBinder.cs
@@ -50,7 +50,7 @@ namespace Aspid.MVVM.StarterKit
         public ScrollbarCommandBinder(Scrollbar target,
             ICanExecuteView customInteractable,
             BindMode mode = BindMode.OneWay)
-            : this(target, InteractableMode.Custom, mode)
+            : base(target, mode)
         {
             mode.ThrowExceptionIfTwo();
             _interactableMode = InteractableMode.Custom;

--- a/Aspid.MVVM/Assets/Aspid/MVVM/StarterKit/Unity/Runtime/Binders/Sliders/Command/SliderCommandBinder.cs
+++ b/Aspid.MVVM/Assets/Aspid/MVVM/StarterKit/Unity/Runtime/Binders/Sliders/Command/SliderCommandBinder.cs
@@ -42,7 +42,7 @@ namespace Aspid.MVVM.StarterKit
         /// <param name="customInteractable">A custom view that reflects the command's CanExecute state.</param>
         /// <param name="mode">The binding mode. Must not be <see cref="BindMode.TwoWay"/>.</param>
         public SliderCommandBinder(Slider target, ICanExecuteView customInteractable, BindMode mode = BindMode.OneWay)
-            : this(target, InteractableMode.Custom, mode)
+            : base(target, mode)
         {
             mode.ThrowExceptionIfTwo();
             _interactableMode = InteractableMode.Custom;

--- a/Aspid.MVVM/Assets/Aspid/MVVM/StarterKit/Unity/Runtime/Binders/Toggles/Command/ToggleCommandBinder.cs
+++ b/Aspid.MVVM/Assets/Aspid/MVVM/StarterKit/Unity/Runtime/Binders/Toggles/Command/ToggleCommandBinder.cs
@@ -36,7 +36,7 @@ namespace Aspid.MVVM.StarterKit
         /// <param name="customInteractable">A custom view that reflects the command's CanExecute state.</param>
         /// <param name="mode">The binding mode. Must not be <see cref="BindMode.TwoWay"/>.</param>
         public ToggleCommandBinder(Toggle target, ICanExecuteView customInteractable, BindMode mode = BindMode.OneWay)
-            : this(target, InteractableMode.Custom, mode)
+            : base(target, mode)
         {
             mode.ThrowExceptionIfTwo();
             _interactableMode = InteractableMode.Custom;


### PR DESCRIPTION
## Summary
Repair the always-throwing custom-interactable constructors on the Toggle, Slider, and Scrollbar command binders.

## Problem
On the non-generic command binders, the public constructor `(target, ICanExecuteView customInteractable, BindMode mode)` chained to `: this(target, InteractableMode.Custom, mode)`. That `(target, InteractableMode, BindMode)` constructor throws `ArgumentOutOfRangeException` whenever the mode is `InteractableMode.Custom`, so the custom-interactable feature always threw before reaching its own body (the `_customInteractable` assignment was unreachable).

Affected lines:
- `Aspid.MVVM/Assets/Aspid/MVVM/StarterKit/Unity/Runtime/Binders/Toggles/Command/ToggleCommandBinder.cs:39`
- `Aspid.MVVM/Assets/Aspid/MVVM/StarterKit/Unity/Runtime/Binders/Sliders/Command/SliderCommandBinder.cs:45`
- `Aspid.MVVM/Assets/Aspid/MVVM/StarterKit/Unity/Runtime/Binders/Scrollbars/Command/ScrollbarCommandBinder.cs:53`

## Fix
Change each non-generic `ICanExecuteView` constructor chain from `: this(target, InteractableMode.Custom, mode)` to `: base(target, mode)`, matching the already-correct `ButtonCommandBinder`. The existing ctor body is preserved (`mode.ThrowExceptionIfTwo()`, `_interactableMode = InteractableMode.Custom`, `_customInteractable` null-check). The generic `<T>`/`<T1,T2>`/`<T1,T2,T3>` overloads were already correct and are untouched.

One commit per binder:
- `fix(binders): fix Toggle command binder custom-interactable ctor`
- `fix(binders): fix Slider command binder custom-interactable ctor`
- `fix(binders): fix Scrollbar command binder custom-interactable ctor`

## Verification
Static review only — the Unity runtime is NOT compiled in this environment. Needs Unity Editor compile plus play-mode validation to confirm the custom-interactable constructors instantiate and that `ICanExecuteView.SetCanExecute` is driven correctly.

Found via automated release-readiness audit for 1.1.0.