### PR TITLE
fix(binders): avoid double conversion in GraphicColorComponent binders

### DIFF
--- a/Aspid.MVVM/Assets/Aspid/MVVM/StarterKit/Unity/Runtime/Binders/Graphics/ColorComponent/GraphicColorComponentBinder.cs
+++ b/Aspid.MVVM/Assets/Aspid/MVVM/StarterKit/Unity/Runtime/Binders/Graphics/ColorComponent/GraphicColorComponentBinder.cs
@@ -20,8 +20,8 @@ namespace Aspid.MVVM.StarterKit
         /// <inheritdoc/>
         protected sealed override float Property
         {
-            get => GetConvertedValue(Target.GetColorComponent(_colorComponent));
-            set => Target.SetColorComponent(_colorComponent, GetConvertedValue(value));
+            get => Target.GetColorComponent(_colorComponent);
+            set => Target.SetColorComponent(_colorComponent, value);
         }
         
         /// <summary>

--- a/Aspid.MVVM/Assets/Aspid/MVVM/StarterKit/Unity/Runtime/Binders/Graphics/ColorComponent/Mono/GraphicColorComponentMonoBinder.cs
+++ b/Aspid.MVVM/Assets/Aspid/MVVM/StarterKit/Unity/Runtime/Binders/Graphics/ColorComponent/Mono/GraphicColorComponentMonoBinder.cs
@@ -22,7 +22,7 @@ namespace Aspid.MVVM.StarterKit
         protected sealed override float Property
         {
             get => CachedComponent.GetColorComponent(_colorComponent);
-            set => CachedComponent.SetColorComponent(_colorComponent, GetConvertedValue(value));
+            set => CachedComponent.SetColorComponent(_colorComponent, value);
         }
     }
 }


### PR DESCRIPTION
## Summary
Remove the redundant `IConverter<float,float>` application in the `GraphicColorComponent` binders so the configured converter runs exactly once.

## Problem
Both binders re-applied `GetConvertedValue` inside their `Property` accessor while the base pipeline (`TargetBinder<TTarget,TProperty>.SetValue` / `RaiseValueChanged` / `TargetFloatBinder.OnBound`) already wraps every `Property` read/write with `GetConvertedValue`. This doubled the conversion, so non-idempotent converters (scale/offset/gamma) corrupted the channel.

- `GraphicColorComponentBinder.cs` (Property get/set, lines 23-24): both getter and setter called `GetConvertedValue` on top of the base pipeline.
- `Mono/GraphicColorComponentMonoBinder.cs` (Property setter, line 25): setter called `GetConvertedValue` on top of the base pipeline; the getter was already raw and left unchanged.

## Fix
Single commit `fix(binders): remove redundant converter call in GraphicColorComponent binders`:
- `GraphicColorComponentBinder.Property`: getter now `Target.GetColorComponent(_colorComponent)`, setter now `Target.SetColorComponent(_colorComponent, value)` — base applies the converter once.
- `GraphicColorComponentMonoBinder.Property` setter now `CachedComponent.SetColorComponent(_colorComponent, value)`; getter untouched (already correct).

## Verification
Static review only — Unity runtime is NOT compiled in this environment. Confirmed by reading the base classes (`TargetBinder`, `TargetFloatBinder`, `ComponentMonoBinder`, `ComponentFloatMonoBinder`) that `GetConvertedValue` is applied around `Property` in both directions, so the accessor-level call was redundant. Needs Unity Editor compile + play-mode validation with a non-idempotent converter to confirm channel values are correct.

Found via automated release-readiness audit for 1.1.0.