### PR TITLE
fix(converters): guard division-by-zero and float precision in numeric converters

### DIFF
--- a/Aspid.MVVM/Assets/Aspid/MVVM/StarterKit/Runtime/Converters/Bools/NumberToBoolConverter.cs
+++ b/Aspid.MVVM/Assets/Aspid/MVVM/StarterKit/Runtime/Converters/Bools/NumberToBoolConverter.cs
@@ -44,7 +44,38 @@ namespace Aspid.MVVM.StarterKit
         /// </summary>
         /// <param name="value">The value to compare.</param>
         /// <returns>The result of the comparison operation.</returns>
-        public bool Convert(float value) => _comparison switch
+        public bool Convert(float value) =>
+            Compare(value);
+
+        /// <summary>
+        /// Converts a double value to boolean using the configured comparison.
+        /// </summary>
+        /// <param name="value">The value to compare.</param>
+        /// <returns>The result of the comparison operation.</returns>
+        public bool Convert(double value) =>
+            Compare(value);
+
+        /// <summary>
+        /// Converts an int value to boolean using the configured comparison.
+        /// </summary>
+        /// <param name="value">The value to compare.</param>
+        /// <returns>The result of the comparison operation.</returns>
+        public bool Convert(int value) =>
+            Compare(value);
+
+        /// <summary>
+        /// Converts a long value to boolean using the configured comparison.
+        /// </summary>
+        /// <param name="value">The value to compare.</param>
+        /// <returns>The result of the comparison operation.</returns>
+        public bool Convert(long value) =>
+            Compare(value);
+
+        /// <summary>
+        /// Performs the configured comparison in double precision so that large
+        /// integer and double magnitudes compare exactly without float rounding.
+        /// </summary>
+        private bool Compare(double value) => _comparison switch
         {
             Comparisons.LessThan => value < _value,
             Comparisons.GreaterThan => value > _value,
@@ -54,30 +85,6 @@ namespace Aspid.MVVM.StarterKit
             Comparisons.Inequality => !Approximately(_value, value),
             _ => throw new ArgumentOutOfRangeException()
         };
-
-        /// <summary>
-        /// Converts a double value to boolean by casting to float.
-        /// </summary>
-        /// <param name="value">The value to compare.</param>
-        /// <returns>The result of the comparison operation.</returns>
-        public bool Convert(double value) =>
-            Convert((float)value);
-
-        /// <summary>
-        /// Converts an int value to boolean by casting to float.
-        /// </summary>
-        /// <param name="value">The value to compare.</param>
-        /// <returns>The result of the comparison operation.</returns>
-        public bool Convert(int value) =>
-            Convert((float)value);
-
-        /// <summary>
-        /// Converts a long value to boolean by casting to float.
-        /// </summary>
-        /// <param name="value">The value to compare.</param>
-        /// <returns>The result of the comparison operation.</returns>
-        public bool Convert(long value) =>
-            Convert((float)value);
 
         /// <summary>
         /// Checks if two float values are approximately equal with tolerance for floating-point precision.

--- a/Aspid.MVVM/Assets/Aspid/MVVM/StarterKit/Runtime/Converters/Numbers/ArithmeticNumberConverter.cs
+++ b/Aspid.MVVM/Assets/Aspid/MVVM/StarterKit/Runtime/Converters/Numbers/ArithmeticNumberConverter.cs
@@ -87,10 +87,19 @@ namespace Aspid.MVVM.StarterKit
         {
             NumberOperation.Plus => value + _coefficient,
             NumberOperation.Minus => value - _coefficient,
-            NumberOperation.Division => value / _coefficient,
+            NumberOperation.Division => Divide(value),
             NumberOperation.Multiply => value * _coefficient,
             _ => throw new ArgumentOutOfRangeException()
         };
+
+        private double Divide(double value)
+        {
+            if (_coefficient != 0) return value / _coefficient;
+
+            UnityEngine.Debug.LogError(
+                $"{nameof(ArithmeticNumberConverter)}: division by zero coefficient. Returning the input value unchanged.");
+            return value;
+        }
         
         double IConverter<int, double>.Convert(int value) =>
             ((IConverter<double, double>)this).Convert(value);


### PR DESCRIPTION
## Summary
Fix two correctness bugs in the StarterKit numeric converters: division-by-zero in `ArithmeticNumberConverter` and float-precision loss in `NumberToBoolConverter`.

## Problem
- `ArithmeticNumberConverter.cs:90` — When the operation is `Division` and `_coefficient` is `0` (the inspector default for `_coefficient`), `value / _coefficient` yields Infinity/NaN, and the unchecked integer casts (`ArithmeticNumberConverter.cs:44-68`) then return garbage for out-of-range results.
- `NumberToBoolConverter.cs:63-80` — The `double`, `int` and `long` overloads cast the input to `(float)` before comparing, so magnitudes above 2^24 round and compare incorrectly.

## Fix
- **Commit 1 (`ArithmeticNumberConverter`):** Route the `Division` case through a private `Divide` helper that guards against a zero coefficient. When dividing by zero it returns the input value unchanged (no division) and emits `UnityEngine.Debug.LogError`, matching the project's pattern of downgrading invalid configuration to `LogError` rather than throwing. All other arithmetic is untouched; cast handling left as-is.
- **Commit 2 (`NumberToBoolConverter`):** Introduce a private `Compare(double value)` that performs the comparison in double precision, and route all overloads (`float`, `double`, `int`, `long`) through it instead of casting wide types down to `float`. Large `long`/`int`/`double` values now compare exactly. Existing comparison semantics (Equal/Inequality/Greater/etc.) and the recent Inequality fix are preserved.

## Verification
Static review only — Unity runtime is NOT compiled in this environment; needs Unity Editor compile + play-mode validation.

Found via automated release-readiness audit for 1.1.0.