### PR TITLE
fix(collections): index views by list index in ObservableList OnMove

### DIFF
--- a/Aspid.MVVM/Assets/Aspid/MVVM/StarterKit/Unity/Runtime/Binders/Collections/ObservableLists/ViewModel/Mono/ObservableListViewModelMonoBinder.cs
+++ b/Aspid.MVVM/Assets/Aspid/MVVM/StarterKit/Unity/Runtime/Binders/Collections/ObservableLists/ViewModel/Mono/ObservableListViewModelMonoBinder.cs
@@ -106,11 +106,12 @@ namespace Aspid.MVVM.StarterKit
 
         protected sealed override void OnMove(IViewModel oldItem, IViewModel newItem, int oldStartingIndex, int newStartingIndex)
         {
-            var oldSiblingIndex = Views[oldStartingIndex].transform.GetSiblingIndex();
-            var newSiblingIndex = Views[newStartingIndex].transform.GetSiblingIndex();
-            
-            Views[oldSiblingIndex].transform.SetSiblingIndex(newSiblingIndex);
-            Views[newSiblingIndex].transform.SetSiblingIndex(oldSiblingIndex);
+            var view = Views[oldStartingIndex];
+
+            Views.RemoveAt(oldStartingIndex);
+            Views.Insert(newStartingIndex, view);
+
+            view.transform.SetSiblingIndex(newStartingIndex);
         }
 
         protected sealed override void OnReset()

--- a/Aspid.MVVM/Assets/Aspid/MVVM/StarterKit/Unity/Runtime/Binders/Collections/ObservableLists/ViewModel/ObservableListViewModelBinder.cs
+++ b/Aspid.MVVM/Assets/Aspid/MVVM/StarterKit/Unity/Runtime/Binders/Collections/ObservableLists/ViewModel/ObservableListViewModelBinder.cs
@@ -149,11 +149,12 @@ namespace Aspid.MVVM.StarterKit
 
         protected sealed override void OnMove(IViewModel oldItem, IViewModel newItem, int oldStartingIndex, int newStartingIndex)
         {
-            var oldSiblingIndex = Views[oldStartingIndex].transform.GetSiblingIndex();
-            var newSiblingIndex = Views[newStartingIndex].transform.GetSiblingIndex();
+            var view = Views[oldStartingIndex];
 
-            Views[oldSiblingIndex].transform.SetSiblingIndex(newSiblingIndex);
-            Views[newSiblingIndex].transform.SetSiblingIndex(oldSiblingIndex);
+            Views.RemoveAt(oldStartingIndex);
+            Views.Insert(newStartingIndex, view);
+
+            view.transform.SetSiblingIndex(newStartingIndex);
         }
 
         protected sealed override void OnReset()


### PR DESCRIPTION
## Summary
Fix `OnMove` in the ObservableList ViewModel binders to use the collection (list) index instead of the Unity sibling/transform index, and to reorder the backing `_views` list.

## Problem
`OnMove` read Unity sibling indices via `transform.GetSiblingIndex()` and then used those values to index the `Views` list. When the sibling index did not equal the list index this returned the wrong view or threw `ArgumentOutOfRangeException`. It also never reordered the backing `_views` list, leaving it out of sync with the collection. This contradicts the index contract used by the sibling methods (`OnAdded` inserts at `newStartingIndex`, `OnRemoved` indexes/removes at `oldStartingIndex`, `OnReplace` indexes at `newStartingIndex` — all list indices).

- `ObservableListViewModelMonoBinder.cs:107-114`
- `ObservableListViewModelBinder.cs:150-157`

## Fix
Move the view using the list `oldStartingIndex`/`newStartingIndex`: take the view at `oldStartingIndex`, remove it from `_views`, re-insert it at `newStartingIndex`, and set its transform sibling index to `newStartingIndex`. This keeps the backing list and the transform hierarchy in sync with the move.

- Commit 1: `ObservableListViewModelMonoBinder.cs` (mono binder)
- Commit 2: `ObservableListViewModelBinder.cs` (serializable binder)

The change is identical in both files (they duplicate the bug).

## Verification
Static review only — the Unity runtime is NOT compiled in this environment. Needs Unity Editor compile plus play-mode validation (move items within a bound observable list and confirm views reorder without exceptions and `_views` stays in sync).

Found via automated release-readiness audit for 1.1.0.