### PR TITLE
docs(release): prepare 1.1.0 changelog, migration and package metadata

### DIFF
--- a/Aspid.MVVM/Assets/Aspid/MVVM/CHANGELOG.md
+++ b/Aspid.MVVM/Assets/Aspid/MVVM/CHANGELOG.md
@@ -7,6 +7,27 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ---
 
+## [Unreleased]
+
+### Changed
+
+- **BREAKING:** package id renamed from `com.aspid.mvvm` to `tech.aspid.mvvm` (PR #99). Consumers must update `Packages/manifest.json` and any UPM git URL that referenced the old id.
+
+### Fixed
+
+- `UnbindSafely`: corrected the thrown exception type (PR #82).
+- `DynamicViewModel`: bind mode honoured and the full `DynamicPropertyData` is now passed to the factory (PR #83).
+- Numeric conversion now goes through `Convert.ChangeType`; `MonoBinder.Unbind` gained a profiler guard (PR #84).
+- `AddressableMonoBinder`: added a destroyed-object guard (PR #86).
+- Collection binder: fixed an unbind leak (PR #88).
+- `VirtualizedList`: index now uses `_views.Length` (PR #89).
+- `ObservableListBinder`: aligned subscribe / unsubscribe (PR #90).
+- `RelayCommand`: fixed empty execution (PR #93).
+- `OnObjectValueChanged`: allow `null` for reference types (PR #95).
+- `Unsafe.As` size-guard was added then reverted, and the `Unsafe` helper removed.
+
+---
+
 ## [1.1.0] — 2026-04-28
 
 ### Highlights
@@ -125,7 +146,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - `AddComponentContextMenuAttribute` — replaced by `AddBinderContextMenuAttribute` / `AddBinderContextMenuByTypeAttribute` with a different signature (`Path = "..."` named property).
 - `AddPropertyContextMenuAttribute`.
-- Standalone `Aspid.Collections` source under the package — now consumed via submodule.
+- Standalone `Aspid.Collections` source under the package — now consumed via a UPM git package (`tech.aspid.collections`).
 
 ### Renamed (StarterKit class names)
 

--- a/Aspid.MVVM/Assets/Aspid/MVVM/CHANGELOG.md
+++ b/Aspid.MVVM/Assets/Aspid/MVVM/CHANGELOG.md
@@ -5,60 +5,40 @@ All notable changes to **Aspid.MVVM** are documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+> 🌐 Русская версия: [CHANGELOG.ru.md](CHANGELOG.ru.md)
+
 ---
 
 ## [Unreleased]
 
-### Changed
-
-- **BREAKING:** package id renamed from `com.aspid.mvvm` to `tech.aspid.mvvm` (PR #99). Consumers must update `Packages/manifest.json` and any UPM git URL that referenced the old id.
-
-### Fixed
-
-- `UnbindSafely`: corrected the thrown exception type (PR #82).
-- `DynamicViewModel`: bind mode honoured and the full `DynamicPropertyData` is now passed to the factory (PR #83).
-- Numeric conversion now goes through `Convert.ChangeType`; `MonoBinder.Unbind` gained a profiler guard (PR #84).
-- `AddressableMonoBinder`: added a destroyed-object guard (PR #86).
-- Collection binder: fixed an unbind leak (PR #88).
-- `VirtualizedList`: index now uses `_views.Length` (PR #89).
-- `ObservableListBinder`: aligned subscribe / unsubscribe (PR #90).
-- `RelayCommand`: fixed empty execution (PR #93).
-- `OnObjectValueChanged`: allow `null` for reference types (PR #95).
-- `Unsafe.As` size-guard was added then reverted, and the `Unsafe` helper removed.
-
----
-
-## [1.1.0] — 2026-04-28
-
 ### Highlights
 
 - Editor inspectors for `MonoBinder`, `MonoView`, `MonoViewModel` rewritten on top of UI Toolkit / `VisualElement`.
-- Brand-new `ViewModelDebugPanel` with tabs, persistent search, `RelayCommand` support and bindable / auto-property support.
+- Brand-new `DebugViewModelPanel` with tabs, persistent search, `RelayCommand` support and bindable / auto-property support.
 - `Aspid.MVVM Settings` window prototype with `AspidToggle` and shared styling.
 - Bindable Properties supported in the source generator; new `NotifyCanExecuteChangedAll()`.
-- `GeneralView` merged into `MonoView` — single non-abstract base view.
-- New `ValueViewModel`, `AnyReverseBinder`, `OneWayToSourceComponentBinders`, AudioSource / LayoutGroup / Dropdown / Selectable / Object-Name binders.
-- `Aspid.UnityFastTools` integrated, many editor visuals migrated to FastTools equivalents.
-- All sub-projects extracted into git submodules (`Aspid.MVVM.Generators`, `Aspid.MVVM.Analyzers`, `Aspid.MVVM.Unity.Generators`); `Aspid.Collections` later moved to a UPM git package.
-- Target Unity raised to `6000.3.0f1` (minimum stays `2022.3`).
-- Mass XML documentation pass over the entire binder catalog plus `XmlDocConventions.md`.
+- `MonoView` is now non-abstract — a single, self-contained base view.
+- New `ValueViewModel`, `AnyReverseBinder`, OneWayToSource component binders (`…ToSourceMonoBinder` family), AudioSource / LayoutGroup / Dropdown / Selectable / Object-Name binders.
+- `Aspid.FastTools` integrated, many editor visuals migrated to FastTools equivalents.
+- All sub-projects extracted into git submodules (`Aspid.MVVM.Generators`, `Aspid.MVVM.Analyzers`, `Aspid.MVVM.Unity.Generators`); `Aspid.Collections` consumed as a UPM git package (`tech.aspid.collections`).
+- Minimum Unity raised to `6000.0`.
 
 ### Added
 
 #### ViewModel & Generator
 - **Bindable Properties** support in the source generator (PR #46) — usable in code, Debug panel and samples (Todo sample updated).
-- **`NotifyCanExecuteChangedAll()`** generator method (PR #52, fixed in #54).
+- **`NotifyCanExecuteChangedAll()`** generator method (PR #52, #54) — emits backing-field names with a null-conditional guard, skips commands without a `CanExecute`, and includes `IRelayCommand`-typed members.
 - **`ValueViewModel`** — minimal ViewModel wrapper around a single value with full XML docs (PR #63).
 - Keyword field support in the generator (PR #55).
-- `EmptyExecution` static instance on `RelayCommand` (PR #36); try/catch in `RelayCommandField` (PR #43).
+- `EmptyExecution` static instance on `RelayCommand` (PR #36, #93) — an executable command that does nothing; `GetSelfOrEmptyExecution` falls back to it when the command is null. Plus try/catch in `RelayCommandField` (PR #43).
 - Interface support for `ViewModel` (`IMyVm` can now be picked as a design ViewModel) (PR #53).
-- Profiler markers expanded across binder lifecycle (PR #15).
+- Generic enum / struct bindable members now resolve their effective type kind from generic-parameter constraints instead of defaulting to the class member type (PR #44).
 - **Virtual binder fields** — generator auto-emits `MonoBinder[]` slots for `IView<TViewModel>` bindable members that are not declared on the View. Opt out via `[View(AutoBinderFields = false)]`; `ScriptableObject`-derived views are always skipped (PR #74, generator PR `Aspid.MVVM.Generators#13`).
 
 #### Views
-- **`GeneralView`** added (PR #43), then merged into `MonoView` (PR #48). `MonoView` is now non-abstract and self-contained.
+- `MonoView` is now non-abstract and self-contained — the inspector-driven binder list, child validation and `[RequireBinder]` integration live directly on it (PR #48).
 - `RelayCommand` support inside `View` / `MonoView`; `CommandsContainer` refactor; `CommandContainer in View` (PR #43).
-- `ViewInitializer` overhaul (PR #41, #50) — context for `ViewInitializers`.
+- `ViewInitializer` overhaul (PR #41, #50) — hoisted view/container resolution into `ViewInitializerBase`, lazy edit-mode `Views` / `ViewModel`, container `Resolve` switched to `TryResolve`, and a new `InitializeStage.DiConstructor` injection stage.
 - `DestroyView` mode in editor; `DestroyViewModel` extension fixes (PR #43, #53).
 - `PrefabViewFactory` / `PrefabViewPool` upgraded.
 - `ViewModelPickerWindow` with dropdown + improved navigation (PR #53).
@@ -68,7 +48,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 #### Editor / Inspector
 - New UI Toolkit inspectors for `MonoBinder`, `MonoView`, `MonoViewModel` (PR #31, #32, #35).
-- `InspectorHeaderPanel`, `AspidInspectorHeader`, `AspidPropertyField`, `AspidDividingLine` shared visuals (PR #32, #40).
+- `AspidInspectorHeader`, `AspidPropertyField`, `AspidDividingLine` shared visuals (PR #32, #40).
 - USS-driven theme: `AspidToggle` (PR #47), IMGUI foldout drawer margin fix, IMGUIContainer wrapping in styled `AspidPropertyField`.
 - `EnumMonoBinderEditor` (PR #57); `EnumValuesPropertyDrawer` fixes; `EnumValues` sample and `ComponentTypeSelector` documentation.
 - Drag & Drop for unassigned and general binders (groups + Auto-Assign + Select / Restore buttons) (PR #43).
@@ -77,7 +57,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **`HeaderGroup` foldout attributes** — `HeaderGroupAttribute` (single field), `HeaderGroupStartAttribute` / `HeaderGroupEndAttribute` (range) tag binder fields and VM members into named, collapsible inspector foldouts. New `HeaderGroupRouter` is consumed by `MonoViewVisualElement` / `AspidBaseInspectorVisualElement` instead of inline foldout layout. Stripped from non-`DEBUG` / non-`UNITY_EDITOR` builds (PR #74).
 
 #### ViewModel Debug Panel (PR #45)
-- Rewritten on UI Toolkit, with tabs.
+- Rewritten on UI Toolkit, with tabs (`DebugViewModelPanel`).
 - Search with persistence and improved logic; type-based search.
 - `RelayCommand` support (`RelayCommandField`, correct meta containers).
 - Bindable property and auto-property support.
@@ -86,16 +66,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 #### Binders — new
 - LayoutGroup binders (PR #56).
 - AudioSource binders (PR #59).
-- `OneWayToSourceComponentBinders` (PR #58).
-- `AnyReverseBinder` with nullable support (PR #37).
+- OneWayToSource component binders (`…ToSourceMonoBinder` family) (PR #58).
+- `AnyReverseBinder` with nullable support (PR #37) — reverse binders now forward `null` reference values via `OnValueChanged(default)` instead of throwing (PR #95).
 - Object Name binders (PR #34).
 - Additional InputField binders + large refactor (PR #51).
 - Dropdown / Selectable binders (PR #61).
-- `Addressable` binders gained an opt-in seamless swap mode.
+- `Addressable` binders gained an opt-in seamless swap mode, with a destroyed-object guard in the async completion callback (PR #86).
 - `GameObjectInstantiateAddressableMonoBinder` for prefab spawning via Addressables.
 
 #### Binders — improvements
 - `OnReplace` / `OnMove` events forwarded to binder hooks; batch `Replace` unrolled into per-item `OnReplace` calls.
+- Reactive collection binders: `CollectionBinderBase<T>` now subscribes to `CollectionChanged` and forwards granular `Add`, `Remove`, and `Reset` events to the new abstract hooks `OnAdded(T?)`, `OnAdded(IReadOnlyList<T?>)`, `OnRemoved(T?)`, `OnRemoved(IReadOnlyList<T?>)` (PR #94), and cleanly unsubscribes on `Unbind` and `Dispose` (PR #88, #91).
 - General binder upgrade (PR #60).
 - `BindSafely` / `UnbindSafely` enriched with View + bindable Id; new `owner` / `memberName` overloads.
 - `EventTriggerCommandMonoBinder`, `ImageSpriteSwitcherBinder`, `MonoBinderPropertyField` — fixes.
@@ -106,36 +87,34 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `IAnyBinder` BinderLog support.
 
 #### Collections
-- `Aspid.Collections` initially extracted into a git submodule, then replaced with a UPM git package (`tech.aspid.collections`) (PR #79).
+- `Aspid.Collections` is now consumed as a UPM git package (`tech.aspid.collections`) instead of being shipped as source under the package (PR #79).
 - `FilteredList` and `BindAlso` fixes.
 - New collections tests.
 - `Replace` / `Move` notifications surfaced to binders.
 
 #### Project structure / infrastructure
 - Submodules wired in (PR #38): `Aspid.MVVM.Generators`, `Aspid.MVVM.Analyzers`, `Aspid.MVVM.Unity.Generators`.
-- `Aspid.Internal.Unity` submodule added, then removed — functionality absorbed into the main project.
 - Unity project relocated from repo root into `Aspid.MVVM/`.
 - MVVM package moved from `Plugins/Aspid/` to `Assets/Aspid/` (PR #77).
-- `package.json` placed inside the package; `unity` field set to `2022.3`; version `1.1.0`.
+- `package.json` placed inside the package; `unity` field set to `6000.0`; version `1.1.0`.
 - Root `CLAUDE.md` describing structure and conventions.
 - GitHub Actions: Claude PR Assistant + Code Review workflows (PR #64).
 - GitHub Actions: Release workflow for stable and preview UPM branches with DLL verification (PR #78).
 
 #### Integrations / dependencies
-- `Aspid.UnityFastTools` integration `0.0.1-alpha.3` (PR #26); subsequent bumps to `alpha.5` / `alpha.7`.
-- `Aspid.MVVM.Generators`, `Aspid.MVVM.Analyzers`, `Aspid.Collections`, `Aspid.UnityFastTools` updated to current heads.
+- `Aspid.FastTools` integrated as a UPM package (PR #26); many editor visuals migrated to FastTools equivalents.
+- `Aspid.MVVM.Generators`, `Aspid.MVVM.Analyzers`, `Aspid.Collections`, `Aspid.FastTools` updated to current heads.
 - `SerializeReferenceDropdown` updated to `1.2.7`.
 - `Roboto-Bold SDF` font refreshed.
-- Editor target lifted to `6000.2.7f2` (PR #24) and then to `6000.3.0f1`. Unity 2022 stays supported.
+- Editor target lifted to `6000.4.0f1`; minimum supported Unity raised to `6000.0`.
 
 #### Documentation
-- `XmlDocConventions.md` added and refined.
 - Mass XML doc pass across all binder families: AudioSource, CanvasGroup, Collider, Animator, Behaviour, GameObject, Layout, UnityGeneric, Selectable, Graphic, Image, RawImage, Renderer, Transform, Slider, InputField, Toggle, Button, EventTrigger, ScrollBar, ScrollRect, Dropdown, Object, LineRenderer, Casters, LocalizeStringEvent, VirtualizedList plus base `MonoBinder` / Behaviour subfolders (PR #62).
 - XML docs for converters.
 - `ComponentTypeSelector` documentation and `EnumValues` sample.
 - `Readme.md` relocated (PR #77) and tweaked (PR #71).
 
-### Changed (behaviour)
+### Changed
 
 - `MonoView` is no longer `abstract`; it is a concrete component with its own serialized binders list and `[RequireBinder]` validation. Existing subclasses still work (PR #48).
 - `MonoView.Dispose()` no longer destroys the host GameObject — it only calls `Deinitialize()`. Call `Object.Destroy(gameObject)` explicitly if needed (PR #48).
@@ -145,7 +124,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Removed
 
 - `AddComponentContextMenuAttribute` — replaced by `AddBinderContextMenuAttribute` / `AddBinderContextMenuByTypeAttribute` with a different signature (`Path = "..."` named property).
-- `AddPropertyContextMenuAttribute`.
+- `AddPropertyContextMenu` attribute — no replacement; the new editor pipeline handles property menus internally.
 - Standalone `Aspid.Collections` source under the package — now consumed via a UPM git package (`tech.aspid.collections`).
 
 ### Renamed (StarterKit class names)
@@ -158,22 +137,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 | `ViewModelObservableListBinder` | `ObservableListViewModelBinder` |
 | `ViewModelObservableDictionaryBinder` | `ObservableDictionaryViewModelBinder` |
 | `ViewModelCollectionMonoBinder` | `CollectionViewModelMonoBinder` |
-| `EnumMonoBinderEditorBase` | `EnumMonoBinderEditor` |
 
 ### Fixed
 
-- `MonoView`: generated field handling, validation, infinite-loop validation.
-- `ViewInitializers` — multiple fixes (PR #41, #50).
-- `AddressableMonoBinder` — multiple fixes.
-- `EnumValue`, `EnumValuesPropertyDrawer`, `SerializableTypeDrawer`, `SerializePropertyExtensions`.
-- `BindAlso`, `MonoBinders`, base `Binder` — assorted fixes (PR #62).
-- `EnumValue` validation downgraded from exception to `Debug.LogError`.
-- Removed stray `Header("Target")` and obsolete files (`NewFields`, `Commands.meta`, `DebugViewModel`).
-- `#if !ASPID_MVVM_EDITOR_DISABLED` guards added in missing places.
-- Numerous meta-file fixes.
-- `NumberToBoolConverter`: `Inequality` comparison was inverted — always returned the same result as `Equal` (PR #81).
-- `CollectionBinderBase.Dispose()`: `CollectionChanged` subscription was not unsubscribed, causing callbacks to fire on disposed binders and preventing GC. `Dispose()` now delegates to `SetValue(null)` which handles full cleanup (PR #91).
-- `CollectionBinderBase.OnCollectionChanged`: granular `Add`, `Remove`, and `Reset` events are now forwarded to the new abstract hooks `OnAdded(T?)`, `OnAdded(IReadOnlyList<T?>)`, `OnRemoved(T?)`, `OnRemoved(IReadOnlyList<T?>)` (PR #94).
+<!-- Only fixes for bugs that actually shipped in a released version (1.0.0–1.0.5) are listed here. Fixes for code introduced during 1.1.0 development are intentionally folded into their corresponding feature bullets above, not listed as standalone fixes. -->
+
+- `NumberToBoolConverter`: the `Inequality` comparison was inverted — it returned the same result as `Equal` instead of its negation. It now returns `true` when the values are not approximately equal (PR #81).
+- `DynamicViewModel.Create<…>`: the factory overloads passed only `DynamicPropertyData.Value`, which forced every property to `BindMode.OneTime` and discarded the user-specified `Mode`. The full `DynamicPropertyData` is now passed so the configured `BindMode` is honoured (PR #83).
+- `MonoBinder.Unbind()`: the `ProfilerMarker` block was guarded only by `!ASPID_MVVM_UNITY_PROFILER_DISABLED`, breaking compilation on Unity earlier than 2022.1. It now also requires `UNITY_2022_1_OR_NEWER`, matching `Bind()` (PR #84).
+- `VirtualizedList`: `OnAdded` / `OnRemoved` bounds-checked the computed view-pool index against `ItemsSource.Count` with a too-loose `<=`. The check now compares `viewIndex < _views.Length` so it picks `Refresh` vs `ResizeContent` correctly (PR #89).
+- `ObservableListBinder`: `InitializeList` subscribed to `CollectionChanged` on the original `list` argument while `DeinitializeList` unsubscribed on `List` (which may be a filtered wrapper), leaking the subscription. The subscribe switch now uses `List` (PR #90).
+- Slider / Scrollbar command binders: `OnCanExecuteChanged` reinterpreted the 4-byte `float` `Target.value` as the command's generic type `T` via `Unsafe.As`, causing out-of-bounds reads and garbage `CanExecute` values for `long` / `double` commands. Typed overloads now perform proper numeric casts via `ApplyCanExecute` (PR #92).
+- Source generator: bindable members whose type was a generic type parameter fell through to the default class case and ignored `enum` / `struct` constraints. The generator now resolves the effective type kind from the parameter's constraints and emits the correct bindable member type (PR #44).
 
 ### Migration
 
@@ -181,6 +156,58 @@ See [MIGRATION.md](MIGRATION.md) for a full upgrade checklist from 1.0 to 1.1.
 
 ---
 
-## [1.0.0] — initial public release
+## [1.0.5] — 2025-10-17
 
-Baseline release. Subsequent entries describe changes relative to 1.0.
+### Added
+- New TextMeshPro text binders: `TextFontBinder`, `TextFontSwitcherBinder`, `TextAlignmentBinder`, `TextAlignmentSwitcherBinder`, plus Mono variants (`TextFontMonoBinder`, `TextFontEnumMonoBinder`, `TextFontEnumGroupMonoBinder`, `TextFontSwitcherMonoBinder`) — for binding TMP font and alignment (PR #30).
+- New Unity Localization binders: `LocalizeStringEventVariableBinder` (+ Mono variant), `TextLocalizationEntryBinder`, `TextLocalizationEntrySwitcherBinder` and Mono variants, with `TextLocalizationExtensions` (PR #29).
+- Profiler markers and improved logging across `BindableMember` types and `BindMode` (`BindModeExtensions.Throw`, `LoggerHelper`) (PR #15).
+
+### Changed
+- Editor project updated to Unity `6000.2.7f2` (PR #28).
+- Vendored the `com.unity.asset-store-tools` package into the repository (packaging only, no framework code change).
+
+### Fixed
+- `RectTransformSetters.SetSizeDelta` wrote the computed value to `anchoredPosition` instead of `sizeDelta`, repositioning the `RectTransform` instead of resizing it (PR #27).
+
+---
+
+## [1.0.4] — 2025-09-19
+
+### Fixed
+- Component context-menu generation (the "Add Component" entries produced via `AddComponentContextMenuAttribute`) — fix shipped in the rebuilt `Aspid.MVVM.Unity.Generators.dll` (PR #14).
+
+---
+
+## [1.0.3] — 2025-09-15
+
+### Changed
+- Moved Unity-layer types (`MonoBinder`, `MonoViewModel`, `MonoView`, `ScriptableView`, editor classes) from the `Aspid.MVVM.Unity` namespace into the root `Aspid.MVVM` namespace, to satisfy Asset Store packaging requirements (PR #13).
+
+### Removed
+- `MonoBinderExtensions` (the `BindSafely<T>(...)` helper overloads) and the `OnBindingDebug` / `OnUnbindingDebug` partial debug hooks on `MonoBinder` (PR #13).
+
+---
+
+## [1.0.2] — 2025-09-11
+
+### Fixed
+- ViewModel source generator fix — shipped in the rebuilt `Aspid.MVVM.Generators.dll` (PR #12).
+
+---
+
+## [1.0.1] — 2025-09-10
+
+### Changed
+- Reverted the C# language version from C# 10 back to C# 9 (removed `-langversion:10` from the `csc.rsp` files), aligning with Unity's default compiler (PR #11).
+- `AddressableMonoBinder<TAsset>` reworked from a UniTask/async model (`LoadAssetAsync` / `CancellationToken`) to a synchronous `Addressables.LoadAssetAsync(...).Completed` callback, dropping the UniTask dependency for Addressable binders.
+- `OneTimeBindableMember<T>` (and Enum / Struct variants) turned into a pooled singleton via a static `Get(value)` factory instead of allocating per bind.
+
+### Fixed
+- `ViewModelCollectionBinder` / `ViewModelCollectionMonoBinder` now deactivate (`SetActive(false)`) leftover pooled views beyond the current item count, so stale views are no longer left visible when the bound collection shrinks.
+
+---
+
+## [1.0.0] — 2025-08-09
+
+Initial public release. Subsequent entries describe changes relative to 1.0.0.

--- a/Aspid.MVVM/Assets/Aspid/MVVM/CHANGELOG.ru.md
+++ b/Aspid.MVVM/Assets/Aspid/MVVM/CHANGELOG.ru.md
@@ -1,0 +1,213 @@
+# История изменений
+
+Все значимые изменения **Aspid.MVVM** фиксируются в этом файле.
+
+Формат основан на [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
+проект придерживается [семантического версионирования](https://semver.org/spec/v2.0.0.html).
+
+> 🌐 English version: [CHANGELOG.md](CHANGELOG.md)
+
+---
+
+## [Unreleased]
+
+### Основное
+
+- Инспекторы редактора для `MonoBinder`, `MonoView`, `MonoViewModel` переписаны на UI Toolkit / `VisualElement`.
+- Совершенно новая `DebugViewModelPanel` со вкладками, сохраняемым поиском, поддержкой `RelayCommand`, bindable- и auto-свойств.
+- Прототип окна `Aspid.MVVM Settings` с `AspidToggle` и общим стилем.
+- Поддержка Bindable Properties в генераторе исходного кода; новый метод `NotifyCanExecuteChangedAll()`.
+- `MonoView` больше не абстрактный — единый самодостаточный базовый View.
+- Новые `ValueViewModel`, `AnyReverseBinder`, OneWayToSource-биндеры компонентов (семейство `…ToSourceMonoBinder`), биндеры AudioSource / LayoutGroup / Dropdown / Selectable / Object-Name.
+- Интегрирован `Aspid.FastTools`, многие визуалы редактора переведены на аналоги из FastTools.
+- Все подпроекты вынесены в git-подмодули (`Aspid.MVVM.Generators`, `Aspid.MVVM.Analyzers`, `Aspid.MVVM.Unity.Generators`); `Aspid.Collections` подключается как UPM git-пакет (`tech.aspid.collections`).
+- Минимальная версия Unity поднята до `6000.0`.
+
+### Добавлено
+
+#### ViewModel и генератор
+- Поддержка **Bindable Properties** в генераторе исходного кода (PR #46) — доступны в коде, Debug-панели и сэмплах (обновлён сэмпл Todo).
+- Метод генератора **`NotifyCanExecuteChangedAll()`** (PR #52, #54) — выводит имена backing-полей с null-conditional-проверкой, пропускает команды без `CanExecute` и учитывает члены типа `IRelayCommand`.
+- **`ValueViewModel`** — минимальная обёртка ViewModel над единственным значением с полной XML-документацией (PR #63).
+- Поддержка keyword-полей в генераторе (PR #55).
+- Статический экземпляр `EmptyExecution` у `RelayCommand` (PR #36, #93) — исполняемая команда, которая ничего не делает; `GetSelfOrEmptyExecution` использует её как fallback, когда команда равна null. Плюс try/catch в `RelayCommandField` (PR #43).
+- Поддержка интерфейсов для `ViewModel` (`IMyVm` теперь можно выбрать как design ViewModel) (PR #53).
+- Bindable-члены обобщённых enum / struct теперь определяют свой эффективный вид типа из ограничений обобщённого параметра, а не по умолчанию по типу члена класса (PR #44).
+- **Виртуальные поля биндеров** — генератор автоматически создаёт слоты `MonoBinder[]` для bindable-членов `IView<TViewModel>`, не объявленных на View. Отключается через `[View(AutoBinderFields = false)]`; View, унаследованные от `ScriptableObject`, всегда пропускаются (PR #74, PR генератора `Aspid.MVVM.Generators#13`).
+
+#### Views
+- `MonoView` теперь не абстрактный и самодостаточный — список биндеров для инспектора, валидация дочерних элементов и интеграция `[RequireBinder]` живут прямо в нём (PR #48).
+- Поддержка `RelayCommand` внутри `View` / `MonoView`; рефакторинг `CommandsContainer`; `CommandContainer in View` (PR #43).
+- Переработка `ViewInitializer` (PR #41, #50) — разрешение view/контейнера вынесено в `ViewInitializerBase`, ленивые `Views` / `ViewModel` в edit-режиме, `Resolve` контейнера заменён на `TryResolve`, добавлена новая стадия инъекции `InitializeStage.DiConstructor`.
+- Режим `DestroyView` в редакторе; исправления расширения `DestroyViewModel` (PR #43, #53).
+- Обновлены `PrefabViewFactory` / `PrefabViewPool`.
+- `ViewModelPickerWindow` с выпадающим списком и улучшенной навигацией (PR #53).
+- `[AddComponentMenu]` для `MonoView`; snake-стиль для меню настроек (PR #47).
+- Рефакторинг редактора `MonoView`; исправлено отображение сгенерированных полей и базового инспектора (PR #32).
+- Обновление `DesignViewModel` (PR #53), включая поддержку legacy-версий Unity.
+
+#### Редактор / инспектор
+- Новые инспекторы на UI Toolkit для `MonoBinder`, `MonoView`, `MonoViewModel` (PR #31, #32, #35).
+- Общие визуалы `AspidInspectorHeader`, `AspidPropertyField`, `AspidDividingLine` (PR #32, #40).
+- Тема на USS: `AspidToggle` (PR #47), исправление отступов IMGUI-foldout-драйвера, обёртка IMGUIContainer в стилизованный `AspidPropertyField`.
+- `EnumMonoBinderEditor` (PR #57); исправления `EnumValuesPropertyDrawer`; сэмпл `EnumValues` и документация `ComponentTypeSelector`.
+- Drag & Drop для неназначенных и общих биндеров (группы + Auto-Assign + кнопки Select / Restore) (PR #43).
+- `RequireBinder` и валидация дочерних View / биндеров (alpha) (PR #43).
+- Прототип окна `Aspid.MVVM Settings` (PR #47).
+- **Foldout-атрибуты `HeaderGroup`** — `HeaderGroupAttribute` (одно поле), `HeaderGroupStartAttribute` / `HeaderGroupEndAttribute` (диапазон) собирают поля биндеров и члены VM в именованные сворачиваемые foldout-группы инспектора. Новый `HeaderGroupRouter` используется в `MonoViewVisualElement` / `AspidBaseInspectorVisualElement` вместо встроенной раскладки foldout. Вырезается из сборок без `DEBUG` / `UNITY_EDITOR` (PR #74).
+
+#### ViewModel Debug Panel (PR #45)
+- Переписана на UI Toolkit, со вкладками (`DebugViewModelPanel`).
+- Поиск с сохранением состояния и улучшенной логикой; поиск по типу.
+- Поддержка `RelayCommand` (`RelayCommandField`, корректные meta-контейнеры).
+- Поддержка bindable- и auto-свойств.
+- Новые стили: `Debug field`, `DisableTextFields`, `DebugStringField`.
+
+#### Биндеры — новые
+- Биндеры LayoutGroup (PR #56).
+- Биндеры AudioSource (PR #59).
+- OneWayToSource-биндеры компонентов (семейство `…ToSourceMonoBinder`) (PR #58).
+- `AnyReverseBinder` с поддержкой nullable (PR #37) — reverse-биндеры теперь передают `null`-ссылочные значения через `OnValueChanged(default)`, а не выбрасывают исключение (PR #95).
+- Биндеры Object Name (PR #34).
+- Дополнительные биндеры InputField + крупный рефакторинг (PR #51).
+- Биндеры Dropdown / Selectable (PR #61).
+- Биндеры `Addressable` получили опциональный режим бесшовной замены (seamless swap) с защитой от обращения к уничтоженному объекту в async-колбэке завершения (PR #86).
+- `GameObjectInstantiateAddressableMonoBinder` для спавна префабов через Addressables.
+
+#### Биндеры — улучшения
+- События `OnReplace` / `OnMove` пробрасываются в хуки биндеров; пакетный `Replace` разворачивается в поэлементные вызовы `OnReplace`.
+- Реактивные collection-биндеры: `CollectionBinderBase<T>` теперь подписывается на `CollectionChanged` и пробрасывает гранулярные события `Add`, `Remove`, `Reset` в новые абстрактные хуки `OnAdded(T?)`, `OnAdded(IReadOnlyList<T?>)`, `OnRemoved(T?)`, `OnRemoved(IReadOnlyList<T?>)` (PR #94), а также корректно отписывается при `Unbind` и `Dispose` (PR #88, #91).
+- Обновление общего биндера (PR #60).
+- `BindSafely` / `UnbindSafely` дополнены View и bindable Id; новые перегрузки с `owner` / `memberName`.
+- Исправления `EventTriggerCommandMonoBinder`, `ImageSpriteSwitcherBinder`, `MonoBinderPropertyField`.
+- Исправления Dispose / жизненного цикла `VirtualizedListItemSourceBinder`.
+- Исправления `ViewModelObservableListBinder`.
+- Полировка `MonoBinderVisualElement`; визуализация биндеров в скрипте и обновление анимации.
+- Поддержка `BindMode` для `VisualElement` (PR #39).
+- Поддержка BinderLog в `IAnyBinder`.
+
+#### Коллекции
+- `Aspid.Collections` теперь подключается как UPM git-пакет (`tech.aspid.collections`) вместо поставки исходниками внутри пакета (PR #79).
+- Исправления `FilteredList` и `BindAlso`.
+- Новые тесты коллекций.
+- События `Replace` / `Move` доведены до биндеров.
+
+#### Структура проекта / инфраструктура
+- Подключены подмодули (PR #38): `Aspid.MVVM.Generators`, `Aspid.MVVM.Analyzers`, `Aspid.MVVM.Unity.Generators`.
+- Проект Unity перенесён из корня репозитория в `Aspid.MVVM/`.
+- Пакет MVVM перемещён из `Plugins/Aspid/` в `Assets/Aspid/` (PR #77).
+- `package.json` размещён внутри пакета; поле `unity` установлено в `6000.0`; версия `1.1.0`.
+- Корневой `CLAUDE.md` с описанием структуры и конвенций.
+- GitHub Actions: воркфлоу Claude PR Assistant + Code Review (PR #64).
+- GitHub Actions: воркфлоу релиза для стабильной и preview UPM-веток с проверкой DLL (PR #78).
+
+#### Интеграции / зависимости
+- `Aspid.FastTools` интегрирован как UPM-пакет (PR #26); многие визуалы редактора переведены на аналоги из FastTools.
+- `Aspid.MVVM.Generators`, `Aspid.MVVM.Analyzers`, `Aspid.Collections`, `Aspid.FastTools` обновлены до актуальных HEAD.
+- `SerializeReferenceDropdown` обновлён до `1.2.7`.
+- Обновлён шрифт `Roboto-Bold SDF`.
+- Целевая версия редактора поднята до `6000.4.0f1`; минимальная поддерживаемая версия Unity поднята до `6000.0`.
+
+#### Документация
+- Массовый проход XML-документации по всем семействам биндеров: AudioSource, CanvasGroup, Collider, Animator, Behaviour, GameObject, Layout, UnityGeneric, Selectable, Graphic, Image, RawImage, Renderer, Transform, Slider, InputField, Toggle, Button, EventTrigger, ScrollBar, ScrollRect, Dropdown, Object, LineRenderer, Casters, LocalizeStringEvent, VirtualizedList плюс базовые подпапки `MonoBinder` / Behaviour (PR #62).
+- XML-документация для конвертеров.
+- Документация `ComponentTypeSelector` и сэмпл `EnumValues`.
+- `Readme.md` перемещён (PR #77) и доработан (PR #71).
+
+### Изменено
+
+- `MonoView` больше не `abstract`; это конкретный компонент с собственным сериализуемым списком биндеров и валидацией `[RequireBinder]`. Существующие подклассы продолжают работать (PR #48).
+- `MonoView.Dispose()` больше не уничтожает GameObject-хост — он только вызывает `Deinitialize()`. При необходимости вызывайте `Object.Destroy(gameObject)` явно (PR #48).
+- `MonoBinder.Bind()` больше не выбрасывает исключение при вызове на уже привязанном биндере; вместо этого логирует ошибку и возвращает управление (PR #62).
+- Пути `[AddComponentMenu]` реорганизованы — например `Collections/Observable List Binder - ViewModel` → `Collection/Observable List Binder – ViewModel` (единственное число, длинное тире).
+
+### Удалено
+
+- `AddComponentContextMenuAttribute` — заменён на `AddBinderContextMenuAttribute` / `AddBinderContextMenuByTypeAttribute` с другой сигнатурой (именованное свойство `Path = "..."`).
+- Атрибут `AddPropertyContextMenu` — без замены; новый конвейер редактора обрабатывает меню свойств внутренне.
+- Исходники `Aspid.Collections` внутри пакета — теперь подключаются как UPM git-пакет (`tech.aspid.collections`).
+
+### Переименовано (имена классов StarterKit)
+
+GUID-ы `.meta` сохранены, поэтому префабы и сцены продолжают ссылаться на правильный скрипт. **Игровой код, ссылающийся на старые имена классов, не скомпилируется, пока не будет обновлён.**
+
+| 1.0 | 1.1 |
+|-----|-----|
+| `ViewModelObservableListMonoBinder` | `ObservableListViewModelMonoBinder` |
+| `ViewModelObservableListBinder` | `ObservableListViewModelBinder` |
+| `ViewModelObservableDictionaryBinder` | `ObservableDictionaryViewModelBinder` |
+| `ViewModelCollectionMonoBinder` | `CollectionViewModelMonoBinder` |
+
+### Исправлено
+
+<!-- Здесь перечислены только исправления багов, реально вышедших в релизах (1.0.0–1.0.5). Исправления кода, появившегося в ходе разработки 1.1.0, намеренно учтены в соответствующих пунктах о фичах выше, а не как отдельные исправления. -->
+
+- `NumberToBoolConverter`: сравнение `Inequality` было инвертировано — возвращало тот же результат, что и `Equal`, вместо его отрицания. Теперь возвращает `true`, когда значения не приблизительно равны (PR #81).
+- `DynamicViewModel.Create<…>`: перегрузки фабрики передавали только `DynamicPropertyData.Value`, из-за чего каждое свойство принудительно получало `BindMode.OneTime`, а заданный пользователем `Mode` отбрасывался. Теперь передаётся весь `DynamicPropertyData`, и настроенный `BindMode` учитывается (PR #83).
+- `MonoBinder.Unbind()`: блок `ProfilerMarker` был защищён только `!ASPID_MVVM_UNITY_PROFILER_DISABLED`, что ломало компиляцию на Unity старше 2022.1. Теперь дополнительно требует `UNITY_2022_1_OR_NEWER`, как и `Bind()` (PR #84).
+- `VirtualizedList`: `OnAdded` / `OnRemoved` проверяли вычисленный индекс пула view относительно `ItemsSource.Count` со слишком мягким `<=`. Теперь проверка сравнивает `viewIndex < _views.Length`, корректно выбирая `Refresh` или `ResizeContent` (PR #89).
+- `ObservableListBinder`: `InitializeList` подписывался на `CollectionChanged` у исходного аргумента `list`, тогда как `DeinitializeList` отписывался у `List` (который может быть отфильтрованной обёрткой), что приводило к утечке подписки. Подписка теперь использует `List` (PR #90).
+- Command-биндеры Slider / Scrollbar: `OnCanExecuteChanged` переинтерпретировал 4-байтовый `float` `Target.value` как обобщённый тип команды `T` через `Unsafe.As`, вызывая чтение за границами и мусорные значения `CanExecute` для команд `long` / `double`. Типизированные перегрузки теперь выполняют корректное числовое приведение через `ApplyCanExecute` (PR #92).
+- Генератор исходного кода: bindable-члены, тип которых был обобщённым параметром, попадали в ветку по умолчанию (класс) и игнорировали ограничения `enum` / `struct`. Теперь генератор определяет эффективный вид типа из ограничений параметра и выводит корректный тип bindable-члена (PR #44).
+
+### Миграция
+
+Полный чек-лист обновления с 1.0 на 1.1 см. в [MIGRATION.ru.md](MIGRATION.ru.md).
+
+---
+
+## [1.0.5] — 2025-10-17
+
+### Добавлено
+- Новые биндеры текста TextMeshPro: `TextFontBinder`, `TextFontSwitcherBinder`, `TextAlignmentBinder`, `TextAlignmentSwitcherBinder` плюс Mono-варианты (`TextFontMonoBinder`, `TextFontEnumMonoBinder`, `TextFontEnumGroupMonoBinder`, `TextFontSwitcherMonoBinder`) — для привязки шрифта и выравнивания TMP (PR #30).
+- Новые биндеры Unity Localization: `LocalizeStringEventVariableBinder` (+ Mono-вариант), `TextLocalizationEntryBinder`, `TextLocalizationEntrySwitcherBinder` и Mono-варианты, с `TextLocalizationExtensions` (PR #29).
+- Profiler-маркеры и улучшенное логирование для типов `BindableMember` и `BindMode` (`BindModeExtensions.Throw`, `LoggerHelper`) (PR #15).
+
+### Изменено
+- Проект редактора обновлён до Unity `6000.2.7f2` (PR #28).
+- В репозиторий вшит пакет `com.unity.asset-store-tools` (только упаковка, без изменений кода фреймворка).
+
+### Исправлено
+- `RectTransformSetters.SetSizeDelta` записывал вычисленное значение в `anchoredPosition` вместо `sizeDelta`, из-за чего SizeDelta-биндеры перемещали `RectTransform` вместо изменения размера (PR #27).
+
+---
+
+## [1.0.4] — 2025-09-19
+
+### Исправлено
+- Генерация контекстного меню компонентов (пункты «Add Component», создаваемые через `AddComponentContextMenuAttribute`) — исправление вошло в пересобранный `Aspid.MVVM.Unity.Generators.dll` (PR #14).
+
+---
+
+## [1.0.3] — 2025-09-15
+
+### Изменено
+- Типы Unity-слоя (`MonoBinder`, `MonoViewModel`, `MonoView`, `ScriptableView`, классы редактора) перенесены из пространства имён `Aspid.MVVM.Unity` в корневое `Aspid.MVVM` — для соответствия требованиям упаковки Asset Store (PR #13).
+
+### Удалено
+- `MonoBinderExtensions` (перегрузки-хелперы `BindSafely<T>(...)`) и partial-хуки отладки `OnBindingDebug` / `OnUnbindingDebug` у `MonoBinder` (PR #13).
+
+---
+
+## [1.0.2] — 2025-09-11
+
+### Исправлено
+- Исправление генератора исходного кода ViewModel — вошло в пересобранный `Aspid.MVVM.Generators.dll` (PR #12).
+
+---
+
+## [1.0.1] — 2025-09-10
+
+### Изменено
+- Версия языка C# возвращена с C# 10 на C# 9 (убран `-langversion:10` из файлов `csc.rsp`) для соответствия компилятору Unity по умолчанию (PR #11).
+- `AddressableMonoBinder<TAsset>` переработан с модели UniTask/async (`LoadAssetAsync` / `CancellationToken`) на синхронный колбэк `Addressables.LoadAssetAsync(...).Completed`, что убирает зависимость от UniTask для Addressable-биндеров.
+- `OneTimeBindableMember<T>` (и варианты Enum / Struct) превращён в пулящийся singleton через статическую фабрику `Get(value)` вместо аллокации на каждую привязку.
+
+### Исправлено
+- `ViewModelCollectionBinder` / `ViewModelCollectionMonoBinder` теперь деактивируют (`SetActive(false)`) оставшиеся пулящиеся view сверх текущего числа элементов, чтобы устаревшие view не оставались видимыми при сокращении привязанной коллекции.
+
+---
+
+## [1.0.0] — 2025-08-09
+
+Первый публичный релиз. Последующие записи описывают изменения относительно 1.0.0.

--- a/Aspid.MVVM/Assets/Aspid/MVVM/LICENSE.md
+++ b/Aspid.MVVM/Assets/Aspid/MVVM/LICENSE.md
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2025 Vladislav Panin
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/Aspid.MVVM/Assets/Aspid/MVVM/MIGRATION.md
+++ b/Aspid.MVVM/Assets/Aspid/MVVM/MIGRATION.md
@@ -4,27 +4,21 @@ Upgrade notes for moving an existing project from **Aspid.MVVM 1.0** to **Aspid.
 
 For the full list of changes see [CHANGELOG.md](CHANGELOG.md).
 
-> **BREAKING — package id renamed.** The UPM package id changed from `com.aspid.mvvm` to `tech.aspid.mvvm`. Update the entry in `Packages/manifest.json` and any UPM git URL that referenced the old id.
+> 🌐 Русская версия: [MIGRATION.ru.md](MIGRATION.ru.md)
 
 > Unity asset references (prefabs, scenes, ScriptableObjects) survive the upgrade because every relocated script kept its original `.meta` GUID. Source-code references to renamed classes do **not** survive — search-and-replace is required.
+
+> **Minimum Unity is now `6000.0`**.
 
 ---
 
 ## TL;DR
 
-```bash
-git pull
-git submodule update --init --recursive
-```
-
-Then in your codebase:
-
-1. Rename `ViewModelObservableList*` → `ObservableList*ViewModel`, and the same shape for Dictionary / Collection — see the table below.
-2. Replace every `[AddComponentContextMenu(typeof(X), "path")]` with `[AddBinderContextMenu(typeof(X), Path = "path")]`.
-3. Drop any `[AddPropertyContextMenu]` attributes — the API was removed.
-4. Audit every `view.Dispose()` call: the GameObject is no longer destroyed automatically.
-5. If you ever caught the `"This Binder is already bound."` exception, switch to checking `binder.IsBound` first — it now logs and returns silently.
-6. Rebuild generators with .NET 9 SDK (only if you modify generator source; the bundled DLLs are already up to date).
+1. Add the required git packages `tech.aspid.collections` and `tech.aspid.fasttools` to your `manifest.json` — they are not auto-resolved (see § 3.1).
+2. Rename `ViewModelObservableList*` → `ObservableList*ViewModel`, and the same shape for Dictionary / Collection (see § 1.1).
+3. Replace every `[AddComponentContextMenu(typeof(X), "path")]` with `[AddBinderContextMenu(typeof(X), Path = "path")]`, and fold any `[AddPropertyContextMenu(typeof(X), "m_Field")]` into the same attribute's `serializePropertyNames` argument (see § 1.2).
+4. Audit every `view.Dispose()` call: the GameObject is no longer destroyed automatically (see § 2.2).
+5. Audit every `view.DestroyView()` call: it now destroys only the View component, not the GameObject — use `view.DestroyViewAndGameObject()` for the old behaviour (see § 2.3).
 
 ---
 
@@ -40,43 +34,25 @@ Then in your codebase:
 | `ViewModelObservableListBinder` | `ObservableListViewModelBinder` |
 | `ViewModelObservableDictionaryBinder` | `ObservableDictionaryViewModelBinder` |
 | `ViewModelCollectionMonoBinder` | `CollectionViewModelMonoBinder` |
-| `EnumMonoBinderEditorBase` | `EnumMonoBinderEditor` |
 
 Suggested approach: a single global rename per row (regex / IDE refactor). Namespace `Aspid.MVVM.StarterKit` is unchanged.
 
 ### 1.2 `AddComponentContextMenuAttribute` removed
 
-The attribute was replaced with `AddBinderContextMenuAttribute` (and the byte-type variant `AddBinderContextMenuByTypeAttribute`). The signature changed: the path is now a named property.
+`AddComponentContextMenuAttribute` and `AddPropertyContextMenuAttribute` were both removed and merged into a single `AddBinderContextMenuAttribute` (plus the type-only variant `AddBinderContextMenuByTypeAttribute`, which registers a binder purely by its target component type). The menu path moves to the named `Path` property; the serialized-property name(s) that `[AddPropertyContextMenu]` provided move into the `serializePropertyNames` constructor parameter (`params string[]`, so several are allowed).
 
 ```csharp
 // BEFORE — Aspid.MVVM 1.0
-[AddComponentContextMenu(typeof(Component), "Add General Binder/My/Path")]
-public class MyBinder : MonoBinder { }
+[AddPropertyContextMenu(typeof(CanvasGroup), "m_Alpha")]        // optional
+[AddComponentContextMenu(typeof(CanvasGroup), "Add CanvasGroup Binder/Alpha")]
+public partial class MyAlphaBinder : MonoBinder { }
 
-// AFTER — Aspid.MVVM 1.1
-[AddBinderContextMenu(typeof(Component), Path = "Add General Binder/My/Path")]
-public class MyBinder : MonoBinder { }
+// AFTER — Aspid.MVVM 1.1 (one attribute; both arguments carry over, Path is optional)
+[AddBinderContextMenu(typeof(CanvasGroup), serializePropertyNames: "m_Alpha", Path = "Add CanvasGroup Binder/Alpha")]
+public partial class MyAlphaBinder : MonoBinder { }
 ```
 
-`AddPropertyContextMenuAttribute` has no replacement and should be removed; the new editor pipeline handles property menus internally.
-
-### 1.3 Submodules are required
-
-`Aspid.MVVM.Generators`, `Aspid.MVVM.Analyzers`, `Aspid.MVVM.Unity.Generators` are now consumed via git submodules. Run:
-
-```bash
-git submodule update --init --recursive
-```
-
-after pulling. Without this Unity will not compile. `Aspid.Collections` is no longer a submodule — it is consumed as a UPM git package (`tech.aspid.collections`).
-
-### 1.4 `Aspid.FastTools` namespace pulled in
-
-`MonoView`, the new editor visuals and several runtime helpers reference types under `Aspid.FastTools.Types` (`TypeSelector`, `EnumValue`, `ComponentTypeSelector`, `SerializableType`, `IId`, `IdRegistry`, `UniqueIdAttribute`).
-
-Risks:
-- Name collisions if your project ships its own `TypeSelector` / `EnumValue` / `IId`.
-- Custom IMGUI drawers referencing the old `Aspid.MVVM.*` versions of these types must switch to `Aspid.FastTools.*`.
+If a binder only had `[AddComponentContextMenu(typeof(X), "path")]`, the mechanical replacement is `[AddBinderContextMenu(typeof(X), Path = "path")]`.
 
 ---
 
@@ -116,32 +92,44 @@ Object.Destroy(view.gameObject);
 
 (or override `Dispose` in your subclass to restore the old behaviour).
 
-### 2.3 `MonoBinder.Bind()` no longer throws on double-bind
+### 2.3 `DestroyView()` no longer destroys the GameObject
+
+Mirroring § 2.2, the `DestroyView` extension method changed. In 1.0 `view.DestroyView()` tore down the whole GameObject; in 1.1 it deinitializes the View (or calls `Dispose()` if the View is `IDisposable`) and destroys only the View **component**, leaving the GameObject alive. A new `DestroyViewAndGameObject()` restores the old behaviour.
 
 ```csharp
-// 1.0
-if (IsBound) throw new Exception("This Binder is already bound.");
+// 1.0 — destroyed the GameObject
+view.DestroyView();
 
-// 1.1
-if (IsBound) {
-    Debug.LogError($"Binder is already bound. Type: {GetType().Name}, Name: {name}");
-    return;
-}
+// 1.1 — destroys only the View component; to also destroy the GameObject:
+view.DestroyViewAndGameObject();
 ```
 
-If you had a `try / catch` around `Bind()`, replace it with an `if (!binder.IsBound)` guard.
+Both methods are now null/destroyed-safe (they return `null` instead of throwing) and, in the Editor outside play mode, use `DestroyImmediate`. The same pair exists for the generic `DestroyView<T>()` / `DestroyViewAndGameObject<T>()` overloads.
 
-### 2.4 `OnReplace` / `OnMove` hooks fire natively
+### 2.4 `CollectionBinderBase<T>` forwards granular change events
 
-`CollectionMonoBinder<T>` derivatives now receive `OnReplace` / `OnMove` directly (instead of the previous `Remove + Insert` translation). Custom binders that hand-rolled `Replace` may need to override the new hooks or accept the default behaviour.
+In 1.0, `CollectionBinderBase<T>` exposed only `OnAdded(IReadOnlyCollection<T>)` and `OnReset()`, and did not subscribe to `CollectionChanged`. In 1.1 it subscribes to `CollectionChanged` and adds six new abstract hooks:
 
-Batch `Replace` events are also unrolled into per-item `OnReplace` calls.
+- `OnAdded(T?)`, `OnAdded(IReadOnlyList<T?>)`
+- `OnRemoved(T?)`, `OnRemoved(IReadOnlyList<T?>)`
+- `OnReplace(T? oldItem, T? newItem, int newStartingIndex)`
+- `OnMove(T? oldItem, T? newItem, int oldStartingIndex, int newStartingIndex)`
 
-### 2.5 Addressable seamless swap
+Batch `Replace` events are unrolled into per-item `OnReplace` calls.
 
-`AddressableMonoBinder` ships an opt-in seamless-swap mode. Default behaviour is unchanged. If you subclass an Addressable binder and override the swap path, double-check the new flag and lifecycle.
+**Compile impact:** any class deriving from `CollectionBinderBase<T>` must implement all six new abstract methods or it will not compile. Empty bodies preserve the 1.0 behaviour. `CollectionMonoBinder<T>` itself is unchanged (still only `OnAdded` / `OnReset`).
 
-### 2.6 `[AddComponentMenu]` paths
+### 2.5 `ViewInitializer` overhaul
+
+The `ViewInitializer` family was reworked: view/container resolution moved into `ViewInitializerBase`, edit-mode `Views` / `ViewModel` resolve lazily, and container `Resolve` became `TryResolve` (a failed DI resolve no longer throws). A new `InitializeStage.DiConstructor` stage was added (compiled only when a Zenject or VContainer integration define is set). The default initialization stage is **unchanged** — it is still `Awake`.
+
+The serialized resolution data was also restructured: the per-target resolution entries are now `ViewInitializeComponent` items (with the target type stored as a type-name string) instead of the old inline `InitializeComponent<IView>` fields. Re-check the resolution settings on existing `ViewInitializer` / `ViewInitializerManual` components in the inspector after upgrading.
+
+### 2.6 Addressable seamless swap
+
+`AddressableMonoBinder<TAsset>` / `AddressableMonoBinder<TAsset, TComponent>` gain a serialized `_seamlessSwap` flag (default `false`, so opt-in). With it off, a new bind still resets to the default asset before loading, as in 1.0; with it on, the previously loaded asset stays on screen until the new load completes. The load lifecycle was rewritten even on the default path (a single internal handle became separate current/pending handles), so if you subclass an Addressable binder and override the asset-set or release flow, re-check it against the new field and handle lifecycle.
+
+### 2.7 `[AddComponentMenu]` paths
 
 A number of menu paths were normalised:
 
@@ -150,66 +138,73 @@ A number of menu paths were normalised:
 
 Tooling that searches the Add Component dialog or menu paths by exact string needs to be updated.
 
+### 2.8 Behavioural fixes that change runtime output
+
+Two 1.0 bugs were fixed, so the same source now behaves differently at runtime — no recompile needed:
+
+- **`NumberToBoolConverter` with `Comparisons.Inequality`** returned the same result as `Comparisons.Equal` in 1.0 (the comparison was inverted). It now correctly returns `true` when the values are *not* approximately equal. Review binders configured with `Inequality` and remove any compensating inversion you added downstream.
+- **`DynamicViewModel.Create<…>`** forced every property to `BindMode.OneTime` in 1.0, discarding the configured mode. It now honours each `DynamicPropertyData`'s `BindMode`, so properties created without an explicit mode update live. Pass `BindMode.OneTime` explicitly if you relied on bind-once behaviour.
+
 ---
 
 ## 3. Project / infrastructure
 
-### 3.1 Unity project relocated
+### 3.1 Required packages
 
-The Unity project tree moved from the repository root into `Aspid.MVVM/`:
+1.1 is distributed as a UPM package (`tech.aspid.mvvm`). Its assemblies depend on two external git packages that `package.json` does not declare, so add them to your `Packages/manifest.json` before importing 1.1:
+
+```json
+"tech.aspid.collections": "https://github.com/VPDPersonal/Aspid.Collections.git#upm",
+"tech.aspid.fasttools": "https://github.com/VPDPersonal/Aspid.FastTools.git#upm"
+```
+
+The `Aspid.Collections` source that previously shipped inside the package was removed; it is now the separate `tech.aspid.collections` package. Its assembly name (`Aspid.Collections.Observable`) and namespaces are unchanged, so `using` directives and type references need no edits once the package is present.
+
+### 3.2 Unity project relocated
+
+The Unity project tree moved from the repository root into `Aspid.MVVM/`, and the framework also moved out of the `Plugins/` layer:
 
 ```
-1.0:  <repo>/Assets, <repo>/ProjectSettings, <repo>/Packages
-1.1:  <repo>/Aspid.MVVM/Assets, <repo>/Aspid.MVVM/ProjectSettings, ...
+1.0:  <repo>/Assets/Plugins/Aspid/MVVM/...
+1.1:  <repo>/Aspid.MVVM/Assets/Aspid/MVVM/...
 ```
 
-Update CI/CD scripts, IDE workspaces, build pipelines and any path constants that pointed at the repo-root `Assets/`.
-
-### 3.2 .NET 9 SDK
-
-`global.json` (inside the generator / analyzer submodules) pins `9.0.x`. Required only if you rebuild the generators yourself; the bundled `Aspid.MVVM.Generators.dll` and `Aspid.MVVM.Analyzers.dll` are committed and consumed directly by Unity.
+(Third-party plugins such as Zenject stay under `Assets/Plugins/`.) `.meta` GUIDs were preserved, so prefab / scene / ScriptableObject references survive — only textual path strings (CI/CD scripts, IDE workspaces, build pipelines, path constants) need updating.
 
 ### 3.3 Unity Editor versions
 
-- `package.json` declares `"unity": "2022.3"` — minimum unchanged.
-- Repository project file is now on Unity `6000.3.0f1`.
-
-Unity 2022.3 / 2023.x stay supported in code (`#if UNITY_2023_1_OR_NEWER` branches retained). Opening on older 6000.x releases may require dismissing the version-mismatch dialog.
+`package.json` now declares `"unity": "6000.0"`, formally setting the minimum supported Unity to `6000.0`. 1.0 shipped without a UPM `package.json`, so it declared no minimum (its repository project file was already on Unity `6000.2.7f2`). Projects still on Unity 2022 / 2023 must upgrade the Editor before adopting 1.1.
 
 ---
 
 ## 4. Architectural notes
 
-### 4.1 `GeneralView` no longer exists
+### 4.1 `BindSafely` / `UnbindSafely`
 
-`GeneralView` lived briefly between PR #43 and PR #48 in the 1.1 development branch. It was merged back into `MonoView`. If you adopted `GeneralView` from a pre-release build, replace `GeneralView` with `MonoView` — the inspector-driven binder list, child validation and `[RequireBinder]` integration carried over.
+Optional `owner` and `memberName` parameters (defaulting to `null`) were appended to the existing `BindSafely` / `UnbindSafely` methods, so the null-binder diagnostic can name the owning View (its type and GameObject name), the field that holds the binders, and the element index. Existing source call sites compile unchanged.
 
-### 4.2 `BindSafely` / `UnbindSafely`
+### 4.2 Bindable Properties
 
-New overloads accept `owner` and `memberName` so error messages include the View and bindable Id. Existing call sites compile unchanged.
+Existing `[Bind]` fields keep working. Bindable Properties (PR #46) are additive — opt in **per property** by applying `[Bind]` (or `[OneWayBind]` / `[TwoWayBind]` / `[OneTimeBind]` / `[OneWayToSourceBind]`) directly to a property instead of a field. In 1.0 these attributes targeted fields only; in 1.1 they also accept properties. No ViewModel-level change is required.
 
-### 4.3 Bindable Properties
+### 4.3 `RelayCommand`
 
-Existing `[Bind]` fields keep working. Bindable Properties (PR #46) are an additive feature — opt in per ViewModel.
-
-### 4.4 `RelayCommand`
-
-`RelayCommand.Empty` is preserved. New `RelayCommand.EmptyExecution` returns a command that is executable but does nothing. The internal "empty" constructor was rewritten; this is invisible from the outside but worth knowing if you use reflection.
+`RelayCommand.Empty` is preserved (still non-executable). New `RelayCommand.EmptyExecution` returns a command that is executable but does nothing; both exist on every arity (`RelayCommand`, `RelayCommand<T>`, … up to four type arguments). The internal empty constructor changed from a parameterless `RelayCommand()` to `RelayCommand(bool value = false)` — invisible through the public API, but reflection that looks up the private parameterless constructor by signature must be updated.
 
 ---
 
 ## Upgrade checklist
 
-- [ ] Rename the package id `com.aspid.mvvm` → `tech.aspid.mvvm` in `Packages/manifest.json` and any UPM git URL
-- [ ] `git pull && git submodule update --init --recursive`
-- [ ] Update CI / build scripts: `Assets/` → `Aspid.MVVM/Assets/`
-- [ ] Install .NET 9 SDK on build agents (only if rebuilding generators)
+- [ ] Add the `tech.aspid.collections` and `tech.aspid.fasttools` git packages to `manifest.json` (required; not auto-resolved)
+- [ ] Upgrade the Editor to Unity `6000.0` or newer
+- [ ] Update CI / build scripts and path constants: `Assets/Plugins/Aspid/...` → `Aspid.MVVM/Assets/Aspid/...` (repo-root `Assets/` → `Aspid.MVVM/Assets/`)
 - [ ] Global rename of StarterKit binder classes (see § 1.1)
 - [ ] Replace `[AddComponentContextMenu(...)]` with `[AddBinderContextMenu(..., Path = ...)]`
-- [ ] Remove `[AddPropertyContextMenu]` usages
+- [ ] Move `[AddPropertyContextMenu(..., "m_Field")]` arguments into `[AddBinderContextMenu(..., serializePropertyNames: "m_Field")]`
 - [ ] Add explicit `Object.Destroy(view.gameObject)` where `view.Dispose()` was used to free objects
-- [ ] Replace `try { binder.Bind(...) } catch` with `if (!binder.IsBound) binder.Bind(...)`
-- [ ] Audit custom `CollectionMonoBinder<T>` for `OnReplace` / `OnMove`
-- [ ] Re-enter inspector data for `MonoView`s now that the base class exposes its own binders
+- [ ] Replace `view.DestroyView()` with `view.DestroyViewAndGameObject()` where you relied on it to destroy the host GameObject
+- [ ] Implement the six new abstract hooks on any custom `CollectionBinderBase<T>` subclass (`OnAdded(T?)`, `OnAdded(IReadOnlyList<T?>)`, `OnRemoved(T?)`, `OnRemoved(IReadOnlyList<T?>)`, `OnReplace`, `OnMove`)
+- [ ] Review `ViewInitializer` setups: resolution moved into `ViewInitializerBase`, container `Resolve` became `TryResolve`, and an `InitializeStage.DiConstructor` stage was added (the default stage is unchanged — `Awake`)
+- [ ] Re-check `ViewInitializer` / `ViewInitializerManual` inspector data — the serialized resolution components changed type, so existing view/viewModel resolution settings may not carry over- [ ] Review `NumberToBoolConverter` (`Inequality`) and `DynamicViewModel.Create` usages for the corrected runtime behaviour
 - [ ] Smoke-test scenes that use `ImageSpriteSwitcherBinder`, Addressable binders and `VirtualizedList*`
 - [ ] Update tests / tooling that look up components by `AddComponentMenu` path

--- a/Aspid.MVVM/Assets/Aspid/MVVM/MIGRATION.md
+++ b/Aspid.MVVM/Assets/Aspid/MVVM/MIGRATION.md
@@ -4,6 +4,8 @@ Upgrade notes for moving an existing project from **Aspid.MVVM 1.0** to **Aspid.
 
 For the full list of changes see [CHANGELOG.md](CHANGELOG.md).
 
+> **BREAKING — package id renamed.** The UPM package id changed from `com.aspid.mvvm` to `tech.aspid.mvvm`. Update the entry in `Packages/manifest.json` and any UPM git URL that referenced the old id.
+
 > Unity asset references (prefabs, scenes, ScriptableObjects) survive the upgrade because every relocated script kept its original `.meta` GUID. Source-code references to renamed classes do **not** survive — search-and-replace is required.
 
 ---
@@ -60,13 +62,13 @@ public class MyBinder : MonoBinder { }
 
 ### 1.3 Submodules are required
 
-`Aspid.Collections`, `Aspid.Internal.Unity`, `Aspid.MVVM.Generators`, `Aspid.MVVM.Analyzers`, `Aspid.MVVM.Unity.Generators` are now consumed via git submodules. Run:
+`Aspid.MVVM.Generators`, `Aspid.MVVM.Analyzers`, `Aspid.MVVM.Unity.Generators` are now consumed via git submodules. Run:
 
 ```bash
 git submodule update --init --recursive
 ```
 
-after pulling. Without this Unity will not compile (missing types in `Aspid.Collections.Observable.*`).
+after pulling. Without this Unity will not compile. `Aspid.Collections` is no longer a submodule — it is consumed as a UPM git package (`tech.aspid.collections`).
 
 ### 1.4 `Aspid.FastTools` namespace pulled in
 
@@ -198,6 +200,7 @@ Existing `[Bind]` fields keep working. Bindable Properties (PR #46) are an addit
 
 ## Upgrade checklist
 
+- [ ] Rename the package id `com.aspid.mvvm` → `tech.aspid.mvvm` in `Packages/manifest.json` and any UPM git URL
 - [ ] `git pull && git submodule update --init --recursive`
 - [ ] Update CI / build scripts: `Assets/` → `Aspid.MVVM/Assets/`
 - [ ] Install .NET 9 SDK on build agents (only if rebuilding generators)

--- a/Aspid.MVVM/Assets/Aspid/MVVM/MIGRATION.ru.md
+++ b/Aspid.MVVM/Assets/Aspid/MVVM/MIGRATION.ru.md
@@ -1,0 +1,210 @@
+# Руководство по миграции
+
+Заметки по переходу существующего проекта с **Aspid.MVVM 1.0** на **Aspid.MVVM 1.1**.
+
+Полный список изменений см. в [CHANGELOG.ru.md](CHANGELOG.ru.md).
+
+> 🌐 English version: [MIGRATION.md](MIGRATION.md)
+
+> Ссылки на Unity-ассеты (префабы, сцены, ScriptableObject) переживают обновление, потому что каждый перемещённый скрипт сохранил свой исходный GUID в `.meta`. Ссылки в исходном коде на переименованные классы **не** переживают — требуется поиск-и-замена.
+
+> **Минимальная версия Unity теперь `6000.0`**.
+
+---
+
+## TL;DR
+
+1. Добавьте необходимые git-пакеты `tech.aspid.collections` и `tech.aspid.fasttools` в `manifest.json` — они не разрешаются автоматически (см. § 3.1).
+2. Переименуйте `ViewModelObservableList*` → `ObservableList*ViewModel`, и так же для Dictionary / Collection (см. § 1.1).
+3. Замените каждый `[AddComponentContextMenu(typeof(X), "path")]` на `[AddBinderContextMenu(typeof(X), Path = "path")]` и перенесите любой `[AddPropertyContextMenu(typeof(X), "m_Field")]` в аргумент `serializePropertyNames` того же атрибута (см. § 1.2).
+4. Проверьте каждый вызов `view.Dispose()`: GameObject больше не уничтожается автоматически (см. § 2.2).
+5. Проверьте каждый вызов `view.DestroyView()`: теперь он уничтожает только компонент View, а не GameObject — используйте `view.DestroyViewAndGameObject()` для прежнего поведения (см. § 2.3).
+
+---
+
+## 1. Несовместимости компиляции
+
+### 1.1 Переименованные классы биндеров StarterKit
+
+GUID-ы `.meta` сохранены, поэтому существующие префабы / сцены продолжают работать. Обновить нужно только ваш собственный исходный код.
+
+| 1.0 | 1.1 |
+|-----|-----|
+| `ViewModelObservableListMonoBinder` (включая обобщённые `<T>`, `<T, TViewFactory>`) | `ObservableListViewModelMonoBinder` |
+| `ViewModelObservableListBinder` | `ObservableListViewModelBinder` |
+| `ViewModelObservableDictionaryBinder` | `ObservableDictionaryViewModelBinder` |
+| `ViewModelCollectionMonoBinder` | `CollectionViewModelMonoBinder` |
+
+Рекомендуемый подход: одна глобальная замена на строку (regex / рефакторинг в IDE). Пространство имён `Aspid.MVVM.StarterKit` не менялось.
+
+### 1.2 Удалён `AddComponentContextMenuAttribute`
+
+`AddComponentContextMenuAttribute` и `AddPropertyContextMenuAttribute` оба удалены и объединены в единый `AddBinderContextMenuAttribute` (плюс вариант по типу `AddBinderContextMenuByTypeAttribute`, регистрирующий биндер только по типу целевого компонента). Путь меню переходит в именованное свойство `Path`; имена сериализуемых свойств, которые задавал `[AddPropertyContextMenu]`, переходят в параметр конструктора `serializePropertyNames` (`params string[]`, можно передать несколько).
+
+```csharp
+// БЫЛО — Aspid.MVVM 1.0
+[AddPropertyContextMenu(typeof(CanvasGroup), "m_Alpha")]        // необязательный
+[AddComponentContextMenu(typeof(CanvasGroup), "Add CanvasGroup Binder/Alpha")]
+public partial class MyAlphaBinder : MonoBinder { }
+
+// СТАЛО — Aspid.MVVM 1.1 (один атрибут; оба аргумента переносятся, Path необязателен)
+[AddBinderContextMenu(typeof(CanvasGroup), serializePropertyNames: "m_Alpha", Path = "Add CanvasGroup Binder/Alpha")]
+public partial class MyAlphaBinder : MonoBinder { }
+```
+
+Если у биндера был только `[AddComponentContextMenu(typeof(X), "path")]`, механическая замена — `[AddBinderContextMenu(typeof(X), Path = "path")]`.
+
+---
+
+## 2. Изменения времени выполнения / поведения
+
+### 2.1 `MonoView` больше не абстрактный
+
+```csharp
+// 1.0
+public abstract partial class MonoView : MonoBehaviour, IDisposable
+
+// 1.1
+public partial class MonoView : MonoBehaviour, IDisposable
+```
+
+Существующие подклассы продолжают работать — недавно добавленные сериализуемые поля (`_bindersList`, `_designViewModel`, `_designViewModelAssemblyQualifiedNames`) будут пустыми. Либо заполните их в инспекторе, либо сохраните прежний стиль с переопределениями — поддерживаются оба варианта.
+
+### 2.2 `MonoView.Dispose()` больше не уничтожает GameObject
+
+```csharp
+// 1.0
+public virtual void Dispose() {
+    Deinitialize();
+    if (this) Destroy(gameObject); // <-- удалено
+}
+
+// 1.1
+public virtual void Dispose() => Deinitialize();
+```
+
+Если ваш код полагался на `view.Dispose()` для освобождения объекта-хоста, перейдите на:
+
+```csharp
+view.Dispose();
+Object.Destroy(view.gameObject);
+```
+
+(или переопределите `Dispose` в своём подклассе, чтобы вернуть прежнее поведение).
+
+### 2.3 `DestroyView()` больше не уничтожает GameObject
+
+По аналогии с § 2.2 изменился метод-расширение `DestroyView`. В 1.0 `view.DestroyView()` уничтожал весь GameObject; в 1.1 он деинициализирует View (или вызывает `Dispose()`, если View реализует `IDisposable`) и уничтожает только **компонент** View, оставляя GameObject живым. Новый `DestroyViewAndGameObject()` возвращает прежнее поведение.
+
+```csharp
+// 1.0 — уничтожал GameObject
+view.DestroyView();
+
+// 1.1 — уничтожает только компонент View; чтобы уничтожить и GameObject:
+view.DestroyViewAndGameObject();
+```
+
+Оба метода теперь безопасны к null/уничтоженным объектам (возвращают `null` вместо исключения) и в редакторе вне play-режима используют `DestroyImmediate`. Та же пара есть для обобщённых перегрузок `DestroyView<T>()` / `DestroyViewAndGameObject<T>()`.
+
+### 2.4 `CollectionBinderBase<T>` пробрасывает гранулярные события изменений
+
+В 1.0 `CollectionBinderBase<T>` имел только `OnAdded(IReadOnlyCollection<T>)` и `OnReset()` и не подписывался на `CollectionChanged`. В 1.1 он подписывается на `CollectionChanged` и добавляет шесть новых абстрактных хуков:
+
+- `OnAdded(T?)`, `OnAdded(IReadOnlyList<T?>)`
+- `OnRemoved(T?)`, `OnRemoved(IReadOnlyList<T?>)`
+- `OnReplace(T? oldItem, T? newItem, int newStartingIndex)`
+- `OnMove(T? oldItem, T? newItem, int oldStartingIndex, int newStartingIndex)`
+
+Пакетные события `Replace` разворачиваются в поэлементные вызовы `OnReplace`.
+
+**Влияние на компиляцию:** любой класс-наследник `CollectionBinderBase<T>` обязан реализовать все шесть новых абстрактных методов, иначе он не скомпилируется. Пустые тела сохраняют поведение 1.0. Сам `CollectionMonoBinder<T>` не изменился (по-прежнему только `OnAdded` / `OnReset`).
+
+### 2.5 Переработка `ViewInitializer`
+
+Семейство `ViewInitializer` переработано: разрешение view/контейнера перенесено в `ViewInitializerBase`, `Views` / `ViewModel` в edit-режиме разрешаются лениво, `Resolve` контейнера стал `TryResolve` (несработавшее DI-разрешение больше не бросает исключение). Добавлена новая стадия `InitializeStage.DiConstructor` (компилируется только при заданном define интеграции Zenject или VContainer). Стадия инициализации по умолчанию **не изменилась** — это по-прежнему `Awake`.
+
+Сериализуемые данные разрешения также реструктурированы: записи разрешения по целям теперь представлены элементами `ViewInitializeComponent` (целевой тип хранится строкой-именем типа) вместо прежних встроенных полей `InitializeComponent<IView>`. После обновления перепроверьте настройки разрешения на существующих компонентах `ViewInitializer` / `ViewInitializerManual` в инспекторе.
+
+### 2.6 Бесшовная замена Addressable
+
+`AddressableMonoBinder<TAsset>` / `AddressableMonoBinder<TAsset, TComponent>` получают сериализуемый флаг `_seamlessSwap` (по умолчанию `false`, то есть опционально). Когда он выключен, новая привязка по-прежнему сбрасывается на дефолтный ассет перед загрузкой, как в 1.0; когда включён — ранее загруженный ассет остаётся на экране до завершения новой загрузки. Жизненный цикл загрузки переписан даже на дефолтном пути (один внутренний handle заменён на отдельные current/pending), поэтому если вы наследуете Addressable-биндер и переопределяете поток установки/освобождения ассета, перепроверьте его с учётом нового флага и жизненного цикла handle.
+
+### 2.7 Пути `[AddComponentMenu]`
+
+Ряд путей меню нормализован:
+
+- "Collections/…" → "Collection/…" (единственное число).
+- ASCII-дефис `-` между словами → длинное тире `–`.
+
+Инструменты, ищущие в диалоге Add Component или по путям меню по точной строке, нужно обновить.
+
+### 2.8 Исправления поведения, меняющие результат во время выполнения
+
+Исправлены две ошибки 1.0, поэтому тот же код теперь ведёт себя иначе во время выполнения — без перекомпиляции:
+
+- **`NumberToBoolConverter` со `Comparisons.Inequality`** в 1.0 возвращал тот же результат, что и `Comparisons.Equal` (сравнение было инвертировано). Теперь он корректно возвращает `true`, когда значения *не* приблизительно равны. Проверьте биндеры с `Inequality` и уберите компенсирующую инверсию ниже по потоку, если добавляли.
+- **`DynamicViewModel.Create<…>`** в 1.0 принудительно делал каждое свойство `BindMode.OneTime`, игнорируя заданный режим. Теперь учитывается `BindMode` каждого `DynamicPropertyData`, поэтому свойства без явного режима обновляются вживую. Передавайте `BindMode.OneTime` явно, если полагались на разовую привязку.
+
+---
+
+## 3. Проект / инфраструктура
+
+### 3.1 Необходимые пакеты
+
+1.1 распространяется как UPM-пакет (`tech.aspid.mvvm`). Его сборки зависят от двух внешних git-пакетов, которые `package.json` не объявляет, поэтому добавьте их в `Packages/manifest.json` до импорта 1.1:
+
+```json
+"tech.aspid.collections": "https://github.com/VPDPersonal/Aspid.Collections.git#upm",
+"tech.aspid.fasttools": "https://github.com/VPDPersonal/Aspid.FastTools.git#upm"
+```
+
+Исходники `Aspid.Collections`, ранее поставлявшиеся внутри пакета, удалены — теперь это отдельный пакет `tech.aspid.collections`. Имя сборки (`Aspid.Collections.Observable`) и пространства имён не изменились, поэтому директивы `using` и ссылки на типы править не нужно при наличии пакета.
+
+### 3.2 Перемещён проект Unity
+
+Дерево проекта Unity перенесено из корня репозитория в `Aspid.MVVM/`, а сам фреймворк также вынесен из слоя `Plugins/`:
+
+```
+1.0:  <repo>/Assets/Plugins/Aspid/MVVM/...
+1.1:  <repo>/Aspid.MVVM/Assets/Aspid/MVVM/...
+```
+
+(Сторонние плагины, например Zenject, остаются под `Assets/Plugins/`.) GUID-ы `.meta` сохранены, поэтому ссылки из префабов / сцен / ScriptableObject переживают переход — обновить нужно только текстовые строки путей (CI/CD-скрипты, рабочие пространства IDE, сборочные конвейеры, константы путей).
+
+### 3.3 Версии редактора Unity
+
+`package.json` теперь объявляет `"unity": "6000.0"`, формально задавая минимальную поддерживаемую версию Unity `6000.0`. В 1.0 не было UPM-`package.json`, поэтому минимальная версия не объявлялась (файл проекта в репозитории уже был на Unity `6000.2.7f2`). Проекты, оставшиеся на Unity 2022 / 2023, должны обновить редактор перед переходом на 1.1.
+
+---
+
+## 4. Архитектурные заметки
+
+### 4.1 `BindSafely` / `UnbindSafely`
+
+К существующим методам `BindSafely` / `UnbindSafely` добавлены опциональные параметры `owner` и `memberName` (по умолчанию `null`), чтобы диагностика null-биндера называла владеющий View (его тип и имя GameObject), поле с биндерами и индекс элемента. Существующий исходный код вызовов компилируется без изменений.
+
+### 4.2 Bindable Properties
+
+Существующие поля `[Bind]` продолжают работать. Bindable Properties (PR #46) — аддитивная возможность; подключается **на уровне свойства**, применяя `[Bind]` (или `[OneWayBind]` / `[TwoWayBind]` / `[OneTimeBind]` / `[OneWayToSourceBind]`) прямо к свойству вместо поля. В 1.0 эти атрибуты применялись только к полям; в 1.1 они принимают и свойства. Изменения на уровне ViewModel не требуются.
+
+### 4.3 `RelayCommand`
+
+`RelayCommand.Empty` сохранён (по-прежнему невыполнимая). Новый `RelayCommand.EmptyExecution` возвращает команду, которую можно выполнить, но которая ничего не делает; оба члена есть на всех арностях (`RelayCommand`, `RelayCommand<T>`, … вплоть до четырёх параметров типа). Внутренний пустой конструктор изменён с безпараметрического `RelayCommand()` на `RelayCommand(bool value = false)` — через публичный API это незаметно, но рефлексию, ищущую приватный безпараметрический конструктор по сигнатуре, нужно обновить.
+
+---
+
+## Чек-лист обновления
+
+- [ ] Добавить git-пакеты `tech.aspid.collections` и `tech.aspid.fasttools` в `manifest.json` (обязательно; не разрешаются автоматически)
+- [ ] Обновить редактор до Unity `6000.0` или новее
+- [ ] Обновить CI / сборочные скрипты и константы путей: `Assets/Plugins/Aspid/...` → `Aspid.MVVM/Assets/Aspid/...` (корневой `Assets/` → `Aspid.MVVM/Assets/`)
+- [ ] Глобально переименовать классы биндеров StarterKit (см. § 1.1)
+- [ ] Заменить `[AddComponentContextMenu(...)]` на `[AddBinderContextMenu(..., Path = ...)]`
+- [ ] Перенести аргументы `[AddPropertyContextMenu(..., "m_Field")]` в `[AddBinderContextMenu(..., serializePropertyNames: "m_Field")]`
+- [ ] Добавить явный `Object.Destroy(view.gameObject)` там, где `view.Dispose()` использовался для освобождения объектов
+- [ ] Заменить `view.DestroyView()` на `view.DestroyViewAndGameObject()` там, где он использовался для уничтожения GameObject-хоста
+- [ ] Реализовать шесть новых абстрактных хуков в любом кастомном наследнике `CollectionBinderBase<T>` (`OnAdded(T?)`, `OnAdded(IReadOnlyList<T?>)`, `OnRemoved(T?)`, `OnRemoved(IReadOnlyList<T?>)`, `OnReplace`, `OnMove`)
+- [ ] Пересмотреть настройки `ViewInitializer`: разрешение перенесено в `ViewInitializerBase`, `Resolve` контейнера стал `TryResolve`, добавлена стадия `InitializeStage.DiConstructor` (стадия по умолчанию не изменилась — `Awake`)
+- [ ] Перепроверить данные инспектора `ViewInitializer` / `ViewInitializerManual` — сериализуемые компоненты разрешения сменили тип, поэтому существующие настройки разрешения view/viewModel могут не перенестись- [ ] Проверить использования `NumberToBoolConverter` (`Inequality`) и `DynamicViewModel.Create` на исправленное поведение во время выполнения
+- [ ] Прогнать сцены, использующие `ImageSpriteSwitcherBinder`, Addressable-биндеры и `VirtualizedList*`
+- [ ] Обновить тесты / инструменты, ищущие компоненты по пути `AddComponentMenu`

--- a/Aspid.MVVM/Assets/Aspid/MVVM/package.json
+++ b/Aspid.MVVM/Assets/Aspid/MVVM/package.json
@@ -3,7 +3,7 @@
   "version": "1.1.0",
   "displayName": "Aspid.MVVM",
   "description": "Aspid.MVVM is a powerful, high-performance MVVM framework for Unity, eliminating reflection, minimizing GC allocations, and removing boilerplate code for faster, streamlined development.",
-  "unity": "2022.3",
+  "unity": "6000.0",
   "license": "MIT",
   "documentationUrl": "https://vpd-inc.gitbook.io/aspid.mvvm/",
   "changelogUrl": "https://github.com/VPDPersonal/Aspid.MVVM/blob/main/Aspid.MVVM/Assets/Aspid/MVVM/CHANGELOG.md",
@@ -20,7 +20,8 @@
   "author":
   {
     "name": "Vladislav Panin",
-    "email": "vpd.aspid@gmail.com"
+    "email": "vpd.aspid@gmail.com",
+    "url": "https://github.com/VPDPersonal"
   },
   "samples": [
     {

--- a/Aspid.MVVM/Assets/Aspid/MVVM/package.json
+++ b/Aspid.MVVM/Assets/Aspid/MVVM/package.json
@@ -4,9 +4,44 @@
   "displayName": "Aspid.MVVM",
   "description": "Aspid.MVVM is a powerful, high-performance MVVM framework for Unity, eliminating reflection, minimizing GC allocations, and removing boilerplate code for faster, streamlined development.",
   "unity": "2022.3",
+  "license": "MIT",
+  "documentationUrl": "https://vpd-inc.gitbook.io/aspid.mvvm/",
+  "changelogUrl": "https://github.com/VPDPersonal/Aspid.MVVM/blob/main/Aspid.MVVM/Assets/Aspid/MVVM/CHANGELOG.md",
+  "licensesUrl": "https://github.com/VPDPersonal/Aspid.MVVM/blob/main/LICENSE",
+  "keywords": [
+    "mvvm",
+    "unity",
+    "source-generator",
+    "data-binding",
+    "viewmodel",
+    "reactive",
+    "ui"
+  ],
   "author":
   {
     "name": "Vladislav Panin",
     "email": "vpd.aspid@gmail.com"
-  }
+  },
+  "samples": [
+    {
+      "displayName": "Hello World",
+      "description": "Minimal end-to-end example wiring a View to a ViewModel.",
+      "path": "Samples/HelloWorld"
+    },
+    {
+      "displayName": "Stats",
+      "description": "Binding numeric stats with converters and bindable members.",
+      "path": "Samples/Stats"
+    },
+    {
+      "displayName": "Todo List",
+      "description": "Observable collection bound to a dynamic list of items.",
+      "path": "Samples/TodoList"
+    },
+    {
+      "displayName": "Virtualized List",
+      "description": "Virtualized list efficiently rendering large data sets.",
+      "path": "Samples/VirtualizedList"
+    }
+  ]
 }

--- a/Readme.md
+++ b/Readme.md
@@ -18,7 +18,7 @@ teams to scale projects without descending into chaos.
 ---
 
 ## Source Code
-### \[[Aspid.MVVM](https://github.com/VPDPersonal/Aspid.MVVM/tree/main)\] \[[Aspid.MVVM.Generators](https://github.com/VPDPersonal/Aspid.MVMM.Generators)\]
+### \[[Aspid.MVVM](https://github.com/VPDPersonal/Aspid.MVVM/tree/main)\] \[[Aspid.MVVM.Generators](https://github.com/VPDPersonal/Aspid.MVVM.Generators)\]
 ### \[[Aspid.MVVM.Unity.Generators](https://github.com/VPDPersonal/Aspid.MVVM.Unity.Generators)\] \[[Aspid.MVVM.Analyzers](https://github.com/VPDPersonal/Aspid.MVVM.Analyzers)\]
 
 ---


### PR DESCRIPTION
## Summary
Prepare release-readiness docs and UPM package metadata for 1.1.0: changelog Unreleased section, Russian translations of changelog and migration guide, migration notes, and package.json/license additions.

## Problem
- `CHANGELOG.md` had no `[Unreleased]` section and did not document the post-1.1.0-header fixes (#82, #83, #84, #86, #88, #89, #90, #93, #95); `CHANGELOG.md:128` still claimed `Aspid.Collections` is "consumed via submodule".
- `MIGRATION.md:63` listed `Aspid.Collections` and `Aspid.Internal.Unity` as required submodules (Collections is now a UPM git package; Internal.Unity was removed) and had no package-rename breaking note.
- `package.json` was missing `license`, doc/changelog/license URLs, `keywords`, and `samples`; the package shipped no own license file.
- `Readme.md:21` linked to the misspelled `Aspid.MVMM.Generators` repo.
- No Russian-language versions of `CHANGELOG.md` and `MIGRATION.md`.

## Fix
- `docs(changelog)`: add `[Unreleased]` above `[1.1.0]` with a Fixed list for #82/#83/#84/#86/#88/#89/#90/#93/#95 plus the Unsafe.As add-then-revert; correct the Collections line to "UPM git package (tech.aspid.collections)".
- `docs(changelog,migration)`: add `CHANGELOG.ru.md` and `MIGRATION.ru.md` — full Russian translations of both documents.
- `docs(migration)`: add a top-level package-rename breaking note, drop `Aspid.Collections` + `Aspid.Internal.Unity` from the submodule section, and add an upgrade-checklist line for the rename.
- `chore(package)`: add `license`, `documentationUrl`, `changelogUrl`, `licensesUrl`, `keywords`, and a `samples` array (HelloWorld, Stats, TodoList, VirtualizedList); add package `LICENSE.md`.
- `docs(readme)`: fix the `Aspid.MVVM.Generators` link typo.

## Verification
Static review only — the Unity runtime is NOT compiled in this environment. package.json validated as JSON. Needs Unity Editor compile + play-mode validation before merge.

Found via automated release-readiness audit for 1.1.0.