### PR TITLE
fix(virtualized-list): guard null views/coroutine and fix listener leak

### DIFF
--- a/Aspid.MVVM/Assets/Aspid/MVVM/StarterKit/Unity/Runtime/Components/UI/VirtualizedList.cs
+++ b/Aspid.MVVM/Assets/Aspid/MVVM/StarterKit/Unity/Runtime/Components/UI/VirtualizedList.cs
@@ -124,8 +124,12 @@ namespace Aspid.MVVM.StarterKit
         private void Deinitialize()
         {
             if (ItemsSource is null) return;
-            StopCoroutine(_initializing);
-            _initializing = null;
+
+            if (_initializing is not null)
+            {
+                StopCoroutine(_initializing);
+                _initializing = null;
+            }
 
             if (_views is not null)
             {

--- a/Aspid.MVVM/Assets/Aspid/MVVM/StarterKit/Unity/Runtime/Components/UI/VirtualizedList.cs
+++ b/Aspid.MVVM/Assets/Aspid/MVVM/StarterKit/Unity/Runtime/Components/UI/VirtualizedList.cs
@@ -263,6 +263,7 @@ namespace Aspid.MVVM.StarterKit
         
         protected virtual void OnAdded(IViewModel newItem, int newStartingIndex)
         {
+            if (_views is null) return;
             var viewIndex = newStartingIndex - _previousViewModelTopIndex;
 
             if (viewIndex < 0 || viewIndex < _views.Length) Refresh();
@@ -277,6 +278,7 @@ namespace Aspid.MVVM.StarterKit
 
         protected virtual void OnRemoved(IViewModel oldItem, int oldStartingIndex)
         {
+            if (_views is null) return;
             var viewIndex = oldStartingIndex - _previousViewModelTopIndex;
 
             if (viewIndex < 0 || viewIndex < _views.Length) Refresh();
@@ -297,6 +299,7 @@ namespace Aspid.MVVM.StarterKit
 
         protected virtual void OnMove(IViewModel oldItem, IViewModel newItem, int oldStartingIndex, int newStartingIndex)
         {
+            if (_views is null) return;
             var oldViewIndex = oldStartingIndex - _previousViewModelTopIndex;
             var newViewIndex = newStartingIndex - _previousViewModelTopIndex;
 

--- a/Aspid.MVVM/Assets/Aspid/MVVM/StarterKit/Unity/Runtime/Components/UI/VirtualizedList.cs
+++ b/Aspid.MVVM/Assets/Aspid/MVVM/StarterKit/Unity/Runtime/Components/UI/VirtualizedList.cs
@@ -80,6 +80,12 @@ namespace Aspid.MVVM.StarterKit
 		    }
 	    }
 
+	    protected override void OnDisable()
+	    {
+		    onValueChanged.RemoveListener(OnScrollValueChanged);
+		    base.OnDisable();
+	    }
+
 	    private void Initialize()
         {
             switch (ItemsSource)
@@ -112,6 +118,7 @@ namespace Aspid.MVVM.StarterKit
                 _views[i] = new Element(view, Direction);
             }
             
+            onValueChanged.RemoveListener(OnScrollValueChanged);
             onValueChanged.AddListener(OnScrollValueChanged);
             Refresh();
             


### PR DESCRIPTION
## Summary
Fix three independent lifecycle defects in `VirtualizedList` that cause NullReferenceExceptions and a scroll-listener leak.

## Problem
File: `Aspid.MVVM/Assets/Aspid/MVVM/StarterKit/Unity/Runtime/Components/UI/VirtualizedList.cs`

- **A — null `_views` in granular collection callbacks (lines ~264-305).** `OnAdded(IViewModel, int)`, `OnRemoved(IViewModel, int)`, and `OnMove(...)` dereference `_views.Length` directly. If the source collection mutates in the same frame as initialization (before the `InitializeAsync` coroutine allocates `_views`), these throw a NullReferenceException.
- **B — `StopCoroutine` on a null handle (lines ~124-128).** `Deinitialize()` calls `StopCoroutine(_initializing)` unconditionally. When the GameObject was never active, `Initialize()` skips `StartCoroutine`, leaving `_initializing` null and tripping a NullReferenceException.
- **C — scroll listener leak (lines ~73-122).** `onValueChanged.AddListener(OnScrollValueChanged)` is added in `InitializeAsync` (re-run on each `OnEnable`) but only removed in `Deinitialize`. There was no `OnDisable` override, so the listener duplicates/leaks across OnEnable/OnDisable cycles.

## Fix
- **A** (commit `673abc81`): no-op `OnAdded(IViewModel, int)`, `OnRemoved(IViewModel, int)`, and `OnMove(...)` when `_views is null`. The list-based and reset callbacks already route through `Refresh()`, which is null-guarded.
- **B** (commit `68eeea7d`): guard `_initializing is not null` before `StopCoroutine`.
- **C** (commit `e1c310c3`): add an `OnDisable` override that removes the scroll listener symmetrically, and make the add idempotent by removing before adding in `InitializeAsync`.

## Verification
Static review only — the Unity runtime is NOT compiled in this environment. Needs Unity Editor compile + play-mode validation (mutate the source collection in the same frame as init; toggle the GameObject active/inactive repeatedly to confirm no listener duplication and no NRE on deinitialize).

Found via automated release-readiness audit for 1.1.0.