### PR TITLE
fix(binders): use consistent culture for InputField numeric parse/format

### DIFF
--- a/Aspid.MVVM/Assets/Aspid/MVVM/StarterKit/Runtime/Converters/Strings/Extensions/ToCultureStringExtensions.cs
+++ b/Aspid.MVVM/Assets/Aspid/MVVM/StarterKit/Runtime/Converters/Strings/Extensions/ToCultureStringExtensions.cs
@@ -6,6 +6,17 @@ namespace Aspid.MVVM.StarterKit
 {
     public static class ToCultureStringExtensions
     {
+        public static CultureInfo ToCultureInfo(this CultureInfoMode mode) => mode switch
+        {
+            CultureInfoMode.CurrentCulture => CultureInfo.CurrentCulture,
+            CultureInfoMode.CurrentUICulture => CultureInfo.CurrentUICulture,
+            CultureInfoMode.InvariantCulture => CultureInfo.InvariantCulture,
+            CultureInfoMode.InstalledUICulture => CultureInfo.InstalledUICulture,
+            CultureInfoMode.DefaultThreadCurrentCulture => CultureInfo.DefaultThreadCurrentCulture,
+            CultureInfoMode.DefaultThreadCurrentUICulture => CultureInfo.DefaultThreadCurrentUICulture,
+            _ => throw new ArgumentOutOfRangeException(nameof(mode), mode, null)
+        };
+
         public static string ToCultureString(this int number, CultureInfoMode mode) => mode switch
         {
             CultureInfoMode.CurrentCulture => number.ToString(CultureInfo.CurrentCulture),

--- a/Aspid.MVVM/Assets/Aspid/MVVM/StarterKit/Unity/Runtime/Binders/InputFields/Text/InputFieldBinder.cs
+++ b/Aspid.MVVM/Assets/Aspid/MVVM/StarterKit/Unity/Runtime/Binders/InputFields/Text/InputFieldBinder.cs
@@ -3,6 +3,7 @@
 using TMPro;
 using System;
 using UnityEngine;
+using System.Globalization;
 #if UNITY_2023_1_OR_NEWER
 using Converter = Aspid.MVVM.StarterKit.IConverter<string?, string?>;
 #else
@@ -165,7 +166,7 @@ namespace Aspid.MVVM.StarterKit
            
             if (IntValueChanged != null || LongValueChanged != null)
             {
-                if (!long.TryParse(value, out var integerValue)) return;
+                if (!long.TryParse(value, NumberStyles.Any, _cultureInfoMode.ToCultureInfo(), out var integerValue)) return;
 
                 if (integerValue is <= int.MaxValue and >= int.MinValue)
                     IntValueChanged?.Invoke((int)integerValue);
@@ -175,7 +176,7 @@ namespace Aspid.MVVM.StarterKit
             
             if (FloatValueChanged != null || DoubleValueChanged != null)
             {
-                if (!double.TryParse(value, out var decimalValue)) return;
+                if (!double.TryParse(value, NumberStyles.Any, _cultureInfoMode.ToCultureInfo(), out var decimalValue)) return;
                 
                 if (decimalValue is <= float.MaxValue and >= float.MinValue)
                     FloatValueChanged?.Invoke((float)decimalValue);

--- a/Aspid.MVVM/Assets/Aspid/MVVM/StarterKit/Unity/Runtime/Binders/InputFields/Text/Mono/InputFieldMonoBinder.cs
+++ b/Aspid.MVVM/Assets/Aspid/MVVM/StarterKit/Unity/Runtime/Binders/InputFields/Text/Mono/InputFieldMonoBinder.cs
@@ -2,6 +2,7 @@
 using TMPro;
 using System;
 using UnityEngine;
+using System.Globalization;
 #if UNITY_2023_1_OR_NEWER
 using Converter = Aspid.MVVM.StarterKit.IConverter<string, string>;
 #else
@@ -182,7 +183,7 @@ namespace Aspid.MVVM.StarterKit
            
             if (IntValueChanged != null || LongValueChanged != null)
             {
-                if (!long.TryParse(value, out var integerValue)) return;
+                if (!long.TryParse(value, NumberStyles.Any, _cultureInfoMode.ToCultureInfo(), out var integerValue)) return;
 
                 if (integerValue is <= int.MaxValue and >= int.MinValue)
                     IntValueChanged?.Invoke((int)integerValue);
@@ -192,7 +193,7 @@ namespace Aspid.MVVM.StarterKit
             
             if (FloatValueChanged != null || DoubleValueChanged != null)
             {
-                if (!double.TryParse(value, out var decimalValue)) return;
+                if (!double.TryParse(value, NumberStyles.Any, _cultureInfoMode.ToCultureInfo(), out var decimalValue)) return;
                 
                 if (decimalValue is <= float.MaxValue and >= float.MinValue)
                     FloatValueChanged?.Invoke((float)decimalValue);


### PR DESCRIPTION
## Summary
Parse InputField numeric values with the same culture used to format them, fixing TwoWay round-trip corruption.

## Problem
In the InputField text binders, numbers are formatted using a `CultureInfo` derived from `_cultureInfoMode` (via `ToCultureString`), but parsed back using `CurrentCulture` (default `long.TryParse`/`double.TryParse`). When `_cultureInfoMode` differs from the current culture, decimal/group separators mismatch and TwoWay numeric round-trips lose or corrupt values.

- `StarterKit/Unity/Runtime/Binders/InputFields/Text/InputFieldBinder.cs` lines 168, 178
- `StarterKit/Unity/Runtime/Binders/InputFields/Text/Mono/InputFieldMonoBinder.cs` lines 185, 195

## Fix
- `StarterKit/Runtime/Converters/Strings/Extensions/ToCultureStringExtensions.cs`: add `ToCultureInfo(this CultureInfoMode mode)` returning the same `CultureInfo` the formatting switch already maps each mode to (single source of truth).
- Commit 1 (`InputFieldBinder`): parse with `NumberStyles.Any` and `_cultureInfoMode.ToCultureInfo()` in both `long.TryParse` and `double.TryParse`; add the shared helper.
- Commit 2 (`InputFieldMonoBinder`): apply the identical parse fix to the Mono sibling.

## Verification
Static review only — Unity runtime is NOT compiled in this environment; needs Unity Editor compile + play-mode validation (set `_cultureInfoMode` to a culture with a different decimal separator, e.g. InvariantCulture vs a comma-decimal current culture, and confirm TwoWay numeric round-trips preserve values).

Found via automated release-readiness audit for 1.1.0.