### PR TITLE
fix(editor): guard reflection type load and fix property drawer children

### DIFF
--- a/Aspid.MVVM/Assets/Aspid/MVVM/StarterKit/Unity/Editor/Views/Initializers/InitializeComponentPropertyDrawer.cs
+++ b/Aspid.MVVM/Assets/Aspid/MVVM/StarterKit/Unity/Editor/Views/Initializers/InitializeComponentPropertyDrawer.cs
@@ -18,7 +18,7 @@ namespace Aspid.MVVM.StarterKit
                 EditorGUI.PropertyField(position, properties.resolve);
 
                 position.y += EditorGUIUtility.singleLineHeight + EditorGUIUtility.standardVerticalSpacing;
-                EditorGUI.PropertyField(position, properties.component);
+                EditorGUI.PropertyField(position, properties.component, true);
             }
             EditorGUI.EndProperty();
         }

--- a/Aspid.MVVM/Assets/Aspid/MVVM/Unity/Editor/Scripts/Binders/AddBinderContextMenu.cs
+++ b/Aspid.MVVM/Assets/Aspid/MVVM/Unity/Editor/Scripts/Binders/AddBinderContextMenu.cs
@@ -30,7 +30,7 @@ namespace Aspid.MVVM
         
             _contexts = AppDomain.CurrentDomain
                 .GetAssemblies()
-                .SelectMany(assembly => assembly.GetTypes())
+                .SelectMany(SafeGetTypes)
                 .Where(Context.IsValid)
                 .Select(type => new Context(type))
                 .ToArray();
@@ -38,7 +38,19 @@ namespace Aspid.MVVM
             EditorApplication.contextualPropertyMenu -= OnContextualPropertyMenu;
             EditorApplication.contextualPropertyMenu += OnContextualPropertyMenu;
         }
-    
+
+        private static IEnumerable<Type> SafeGetTypes(Assembly assembly)
+        {
+            try
+            {
+                return assembly.GetTypes();
+            }
+            catch (ReflectionTypeLoadException ex)
+            {
+                return ex.Types.Where(type => type != null);
+            }
+        }
+
         private static void OnContextualPropertyMenu(GenericMenu menu, SerializedProperty property)
         {
             menu.AddSeparator(path: "/");


### PR DESCRIPTION
## Summary
Fix two Unity Editor defects in the binder context menu and the InitializeComponent property drawer.

## Problem
- `Aspid.MVVM/Assets/Aspid/MVVM/Unity/Editor/Scripts/Binders/AddBinderContextMenu.cs:33` — `Initialize` calls `assembly.GetTypes()` over every domain assembly with no `ReflectionTypeLoadException` handling. A single bad assembly in the domain throws and disables the whole "Add Binder" context menu project-wide.
- `Aspid.MVVM/Assets/Aspid/MVVM/StarterKit/Unity/Editor/Views/Initializers/InitializeComponentPropertyDrawer.cs:21,32` — `GetPropertyHeight` reserves height WITH children (`GetPropertyHeight(..., true)`), but `OnGUI` draws the component field WITHOUT children (`PropertyField` default `includeChildren: false`). The mismatch leaves SerializeReference children unrendered and non-editable.

## Fix
- Commit 1: wrap the per-assembly `GetTypes()` call in a local `SafeGetTypes` helper that catches `ReflectionTypeLoadException` and returns the successfully-loaded types (`ex.Types.Where(type => type != null)`); `SelectMany` now uses it.
- Commit 2: pass `includeChildren: true` in the component `PropertyField` draw call so it matches the height already reserved by `GetPropertyHeight`.

## Verification
Static review only — Unity runtime is NOT compiled in this environment; needs Unity Editor compile + play-mode validation.

Found via automated release-readiness audit for 1.1.0.