### PR TITLE
fix(binders): material color, sprite leak and layout dirty in visual binders

### DIFF
--- a/Aspid.MVVM/Assets/Aspid/MVVM/StarterKit/Unity/Runtime/Binders/Images/Sprite/ImageSpriteBinder.cs
+++ b/Aspid.MVVM/Assets/Aspid/MVVM/StarterKit/Unity/Runtime/Binders/Images/Sprite/ImageSpriteBinder.cs
@@ -17,6 +17,8 @@ namespace Aspid.MVVM.StarterKit
         [Tooltip("When enabled, disables the Image component when the bound sprite is null.")]
         [SerializeField] private bool _disabledWhenNull;
 
+        private Sprite? _createdSprite;
+
         protected sealed override Sprite? Property
         {
             get => Target.sprite;
@@ -41,11 +43,13 @@ namespace Aspid.MVVM.StarterKit
         /// <param name="value">The <see cref="Texture2D"/> to convert into a sprite, or <see langword="null"/> to clear the sprite.</param>
         public void SetValue(Texture2D? value)
         {
-            var sprite = !value
+            if (_createdSprite) UnityEngine.Object.Destroy(_createdSprite);
+
+            _createdSprite = !value
                 ? null
                 : Sprite.Create(value, new Rect(0, 0, value!.width, value.height), new Vector2(0.5f, 0.5f));
 
-            SetValue(sprite);
+            SetValue(_createdSprite);
         }
     }
 }

--- a/Aspid.MVVM/Assets/Aspid/MVVM/StarterKit/Unity/Runtime/Binders/Images/Sprite/ImageSpriteBinder.cs
+++ b/Aspid.MVVM/Assets/Aspid/MVVM/StarterKit/Unity/Runtime/Binders/Images/Sprite/ImageSpriteBinder.cs
@@ -51,5 +51,12 @@ namespace Aspid.MVVM.StarterKit
 
             SetValue(_createdSprite);
         }
+
+        /// <inheritdoc/>
+        protected override void OnUnbound()
+        {
+            if (_createdSprite) UnityEngine.Object.Destroy(_createdSprite);
+            _createdSprite = null;
+        }
     }
 }

--- a/Aspid.MVVM/Assets/Aspid/MVVM/StarterKit/Unity/Runtime/Binders/Images/Sprite/Mono/ImageSpriteMonoBinder.cs
+++ b/Aspid.MVVM/Assets/Aspid/MVVM/StarterKit/Unity/Runtime/Binders/Images/Sprite/Mono/ImageSpriteMonoBinder.cs
@@ -18,7 +18,9 @@ namespace Aspid.MVVM.StarterKit
     {
         [Tooltip("When enabled, disables the Image component when the bound sprite is null.")]
         [SerializeField] private bool _disabledWhenNull = true;
-        
+
+        private Sprite _createdSprite;
+
         protected sealed override Sprite Property
         {
             get => CachedComponent.sprite;
@@ -36,11 +38,13 @@ namespace Aspid.MVVM.StarterKit
         [BinderLog]
         public void SetValue(Texture2D value)
         {
-            var sprite = !value 
-                ? null 
+            if (_createdSprite) Object.Destroy(_createdSprite);
+
+            _createdSprite = !value
+                ? null
                 : Sprite.Create(value, new Rect(0, 0, value.width, value.height), new Vector2(0.5f, 0.5f));
-            
-            SetValue(sprite);
+
+            SetValue(_createdSprite);
         }
     }
 }

--- a/Aspid.MVVM/Assets/Aspid/MVVM/StarterKit/Unity/Runtime/Binders/Images/Sprite/Mono/ImageSpriteMonoBinder.cs
+++ b/Aspid.MVVM/Assets/Aspid/MVVM/StarterKit/Unity/Runtime/Binders/Images/Sprite/Mono/ImageSpriteMonoBinder.cs
@@ -46,5 +46,12 @@ namespace Aspid.MVVM.StarterKit
 
             SetValue(_createdSprite);
         }
+
+        /// <inheritdoc/>
+        protected override void OnUnbound()
+        {
+            if (_createdSprite) Object.Destroy(_createdSprite);
+            _createdSprite = null;
+        }
     }
 }

--- a/Aspid.MVVM/Assets/Aspid/MVVM/StarterKit/Unity/Runtime/Binders/Layouts/Extensions/LayoutSetters.cs
+++ b/Aspid.MVVM/Assets/Aspid/MVVM/StarterKit/Unity/Runtime/Binders/Layouts/Extensions/LayoutSetters.cs
@@ -1,4 +1,5 @@
 using System;
+using UnityEngine;
 using UnityEngine.UI;
 using System.Runtime.CompilerServices;
 
@@ -41,6 +42,8 @@ namespace Aspid.MVVM.StarterKit
                 
                 default: throw new ArgumentOutOfRangeException();
             }
+
+            LayoutRebuilder.MarkLayoutForRebuild(layout.transform as RectTransform);
         }
     }
 }

--- a/Aspid.MVVM/Assets/Aspid/MVVM/StarterKit/Unity/Runtime/Binders/Renderers/MaterialsColor/RendererMaterialColorSwitcherBinder.cs
+++ b/Aspid.MVVM/Assets/Aspid/MVVM/StarterKit/Unity/Runtime/Binders/Renderers/MaterialsColor/RendererMaterialColorSwitcherBinder.cs
@@ -45,11 +45,12 @@ namespace Aspid.MVVM.StarterKit
 
         /// <summary>
         /// Called when applying the selected value to the material color property.
-        /// Sets the named color property on the first Renderer material.
+        /// Sets the named color property on all Renderer materials.
         /// </summary>
         protected override void SetValue(Color value)
         {
-            Target.material.SetColor(ColorPropertyId, value);
+            foreach (var material in Target.materials)
+                material.SetColor(ColorPropertyId, value);
         }
     }
 }


### PR DESCRIPTION
## Summary
Fix three independent correctness defects in visual binders found during the 1.1.0 release audit.

## Problem
- RendererMaterialColorSwitcherBinder.SetValue (RendererMaterialColorSwitcherBinder.cs:50-53) set the color on only the FIRST material via `Target.material`, which also clones the material, contradicting its documented "all materials" contract.
- ImageSpriteBinder.SetValue (ImageSpriteBinder.cs:42-49) and its sibling ImageSpriteMonoBinder.SetValue (ImageSpriteMonoBinder.cs:37-44) called `Sprite.Create` on every Texture2D update without destroying the previously created Sprite, leaking a Sprite each update.
- LayoutSetters.SetPadding (LayoutSetters.cs:26-44) mutated the `RectOffset` fields in place, so Unity's change detection never fired and the layout was never rebuilt.

## Fix
- Commit `fix(binders): apply switcher color to all renderer materials` — iterate `Target.materials` and set the color property on every material, matching the sibling RendererMaterialColorBinder.
- Commit `fix(binders): destroy generated sprite to prevent leak` — track the last Sprite each binder created in a private field and `Object.Destroy` it before creating the next; only binder-created sprites are destroyed, never externally-provided ones.
- Commit `fix(binders): mark layout for rebuild after padding change` — call `LayoutRebuilder.MarkLayoutForRebuild` after mutating padding so the change takes effect.

## Verification
Static review only — the Unity runtime is NOT compiled in this environment; needs Unity Editor compile + play-mode validation.

Found via automated release-readiness audit for 1.1.0.