### PR TITLE
ci(pr-labels): remove needs-review label on PR close

### DIFF
--- a/.github/workflows/pr-ready-labels.yml
+++ b/.github/workflows/pr-ready-labels.yml
@@ -2,7 +2,7 @@ name: PR Ready Labels
 
 on:
   pull_request_target:
-    types: [ready_for_review, converted_to_draft]
+    types: [ready_for_review, converted_to_draft, closed]
 
 permissions:
   pull-requests: write
@@ -34,3 +34,14 @@ jobs:
               await github.rest.issues.removeLabel({ owner, repo, issue_number, name: 'status: needs-review' });
             } catch {}
             await github.rest.issues.addLabels({ owner, repo, issue_number, labels: ['status: work-in-progress'] });
+
+      - name: Closed
+        if: github.event.action == 'closed'
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const { owner, repo } = context.repo;
+            const issue_number = context.payload.pull_request.number;
+            try {
+              await github.rest.issues.removeLabel({ owner, repo, issue_number, name: 'status: needs-review' });
+            } catch {}


### PR DESCRIPTION
## Summary

- Mirror the workflow improvement already in **Aspid.FastTools** into this repo's `PR Ready Labels` workflow.
- Subscribe `pull_request_target` to the `closed` action (covers both merge and plain close).
- Add a `Closed` step that removes the `status: needs-review` label so closed/merged PRs no longer linger as "needs review".

## Notes for review

The added `Closed` step is a no-op when the PR never had `status: needs-review` (the `removeLabel` call is wrapped in `try/catch`). The file is now identical to the FastTools version.