### PR TITLE
ci(release): add preview badge, fix workflow paths, refresh changelog

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -18,8 +18,8 @@ on:
         type: string
 
 env:
-  PACKAGE_PATH: Aspid.MVVM/Assets/Aspid/MVVM
-  CHANGELOG_PATH: Aspid.MVVM/Assets/Aspid/MVVM/CHANGELOG.md
+  PACKAGE_PATH: Aspid.MVVM/Packages/tech.aspid.mvvm
+  CHANGELOG_PATH: Aspid.MVVM/Packages/tech.aspid.mvvm/CHANGELOG.md
   STABLE_BRANCH: upm
   PREVIEW_BRANCH: upm-preview
 

--- a/Aspid.MVVM/Packages/tech.aspid.mvvm/CHANGELOG.md
+++ b/Aspid.MVVM/Packages/tech.aspid.mvvm/CHANGELOG.md
@@ -11,6 +11,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.1.0-beta.1] — 2026-06-06
+
+First preview cut of `1.1.0`, published to the `upm-preview` channel. The API is largely stabilised but may still change before the final `1.1.0` release.
+
 ### Highlights
 
 - Editor inspectors for `MonoBinder`, `MonoView`, `MonoViewModel` rewritten on top of UI Toolkit / `VisualElement`.
@@ -95,14 +99,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 #### Project structure / infrastructure
 - Submodules wired in (PR #38): `Aspid.MVVM.Generators`, `Aspid.MVVM.Analyzers`, `Aspid.MVVM.Unity.Generators`.
 - Unity project relocated from repo root into `Aspid.MVVM/`.
-- MVVM package moved from `Plugins/Aspid/` to `Assets/Aspid/` (PR #77).
-- `package.json` placed inside the package; `unity` field set to `6000.0`; version `1.1.0`.
+- MVVM package moved from `Plugins/Aspid/` to `Assets/Aspid/` (PR #77), then promoted to an embedded local UPM package under `Packages/tech.aspid.mvvm` (PR #117).
+- `package.json` placed inside the package; `unity` field set to `6000.0`, `unityRelease` pinned; version `1.1.0-beta.1`.
+- Samples shipped under `Samples~` and registered in `package.json`: HelloWorld, Stats, TodoList, VirtualizedList, plus the Counter / Greeter walkthroughs.
 - Root `CLAUDE.md` describing structure and conventions.
 - GitHub Actions: Claude PR Assistant + Code Review workflows (PR #64).
-- GitHub Actions: Release workflow for stable and preview UPM branches with DLL verification (PR #78).
+- GitHub Actions: Release workflow publishing stable (`upm`) and preview (`upm-preview`) UPM subtrees with immutable `upm/<version>` tags, generator-DLL drift verification and CHANGELOG-driven release notes (PR #78); the Readme gained matching Stable / Preview version badges.
 
 #### Integrations / dependencies
-- `Aspid.FastTools` integrated as a UPM package (PR #26); many editor visuals migrated to FastTools equivalents.
+- `Aspid.FastTools` integrated (PR #26) and later embedded as a local UPM package under `Packages/tech.aspid.fasttools`; many editor visuals migrated to FastTools equivalents.
 - `Aspid.MVVM.Generators`, `Aspid.MVVM.Analyzers`, `Aspid.Collections`, `Aspid.FastTools` updated to current heads.
 - `SerializeReferenceDropdown` updated to `1.2.7`.
 - `Roboto-Bold SDF` font refreshed.

--- a/Aspid.MVVM/Packages/tech.aspid.mvvm/CHANGELOG.ru.md
+++ b/Aspid.MVVM/Packages/tech.aspid.mvvm/CHANGELOG.ru.md
@@ -11,6 +11,10 @@
 
 ## [Unreleased]
 
+## [1.1.0-beta.1] — 2026-06-06
+
+Первый preview-срез `1.1.0`, опубликованный в канал `upm-preview`. API в основном стабилизирован, но может ещё измениться до финального релиза `1.1.0`.
+
 ### Основное
 
 - Инспекторы редактора для `MonoBinder`, `MonoView`, `MonoViewModel` переписаны на UI Toolkit / `VisualElement`.
@@ -95,14 +99,15 @@
 #### Структура проекта / инфраструктура
 - Подключены подмодули (PR #38): `Aspid.MVVM.Generators`, `Aspid.MVVM.Analyzers`, `Aspid.MVVM.Unity.Generators`.
 - Проект Unity перенесён из корня репозитория в `Aspid.MVVM/`.
-- Пакет MVVM перемещён из `Plugins/Aspid/` в `Assets/Aspid/` (PR #77).
-- `package.json` размещён внутри пакета; поле `unity` установлено в `6000.0`; версия `1.1.0`.
+- Пакет MVVM перемещён из `Plugins/Aspid/` в `Assets/Aspid/` (PR #77), затем переведён во встроенный локальный UPM-пакет в `Packages/tech.aspid.mvvm` (PR #117).
+- `package.json` размещён внутри пакета; поле `unity` установлено в `6000.0`, `unityRelease` зафиксирован; версия `1.1.0-beta.1`.
+- Сэмплы поставляются в `Samples~` и зарегистрированы в `package.json`: HelloWorld, Stats, TodoList, VirtualizedList, а также пошаговые Counter / Greeter.
 - Корневой `CLAUDE.md` с описанием структуры и конвенций.
 - GitHub Actions: воркфлоу Claude PR Assistant + Code Review (PR #64).
-- GitHub Actions: воркфлоу релиза для стабильной и preview UPM-веток с проверкой DLL (PR #78).
+- GitHub Actions: воркфлоу релиза публикует стабильный (`upm`) и preview (`upm-preview`) UPM-сабтри с неизменяемыми тегами `upm/<версия>`, проверкой дрейфа DLL генераторов и заметками о релизе из CHANGELOG (PR #78); в Readme добавлены соответствующие бейджи версий Stable / Preview.
 
 #### Интеграции / зависимости
-- `Aspid.FastTools` интегрирован как UPM-пакет (PR #26); многие визуалы редактора переведены на аналоги из FastTools.
+- `Aspid.FastTools` интегрирован (PR #26) и позже встроен как локальный UPM-пакет в `Packages/tech.aspid.fasttools`; многие визуалы редактора переведены на аналоги из FastTools.
 - `Aspid.MVVM.Generators`, `Aspid.MVVM.Analyzers`, `Aspid.Collections`, `Aspid.FastTools` обновлены до актуальных HEAD.
 - `SerializeReferenceDropdown` обновлён до `1.2.7`.
 - Обновлён шрифт `Roboto-Bold SDF`.

--- a/Readme.md
+++ b/Readme.md
@@ -1,6 +1,7 @@
 ![Aspid.MVVMHeaderImage.png](Aspid.MVVM/Packages/tech.aspid.mvvm/Documentation/Images/Aspid.MVVMHeaderImage.png)
 ![](https://img.shields.io/badge/2022.3%2B-000000?style=flat&logo=unity&logoColor=white&color=4fa35d)
-[![Releases](https://img.shields.io/github/v/release/VPDPersonal/Aspid.MVVM?label=Release&labelColor=254d2c&color=4fa35d)](https://github.com/VPDPersonal/Aspid.MVVM/releases)
+[![Stable](https://img.shields.io/github/package-json/v/VPDPersonal/Aspid.MVVM/upm?label=Stable&labelColor=254d2c&color=4fa35d)](https://github.com/VPDPersonal/Aspid.MVVM/releases)
+[![Preview](https://img.shields.io/github/package-json/v/VPDPersonal/Aspid.MVVM/upm-preview?label=Preview&labelColor=4d4425&color=a3923d)](https://github.com/VPDPersonal/Aspid.MVVM/releases)
 [![License](https://img.shields.io/github/license/VPDPersonal/Aspid.MVVM?label=License&labelColor=254d2c&color=4fa35d)](LICENSE)
 
 # Introduction


### PR DESCRIPTION
## Summary

- **Readme**: replace the single `Releases` badge with **Stable** (`upm`) and **Preview** (`upm-preview`) `package-json/v` badges, matching the Aspid.FastTools layout so the preview channel is surfaced.
- **release.yml**: point `PACKAGE_PATH` / `CHANGELOG_PATH` at the embedded `Packages/tech.aspid.mvvm` location — they still referenced the stale `Assets/Aspid/MVVM` path from before the embedded-UPM move (#117), which would have failed the `package.json` validation step.
- **CHANGELOG (EN + RU)**: stamp the accumulated `1.1.0` work as `## [1.1.0-beta.1] — 2026-06-06` (with a fresh empty `[Unreleased]`), so the release workflow can extract notes by exact version match. Also corrected the now-stale entries: package promoted to embedded UPM under `Packages/tech.aspid.mvvm`, FastTools embedded as a local package, `Samples~` registration, and the new Stable/Preview badges.

## Notes for review

- The Stable/Preview badges will read as "invalid" until the first successful release run creates the `upm` / `upm-preview` branches — expected, they populate after the first publish.
- `package.json` is `1.1.0-beta.1`, so a release run routes to the **preview** channel (`upm-preview`); verified the workflow's awk extraction captures the full `1.1.0-beta.1` section locally.
- The existing `release.yml` is already a superset of FastTools' workflow (submodule init, UPM-tag dedup checks, 3 generator builds + tests, DLL drift verification); only the stale paths needed fixing.