### PR TITLE
fix(samples): point package samples to Samples~ directory

### DIFF
--- a/Aspid.MVVM/Packages/tech.aspid.mvvm/package.json
+++ b/Aspid.MVVM/Packages/tech.aspid.mvvm/package.json
@@ -26,22 +26,22 @@
     {
       "displayName": "Hello World",
       "description": "Minimal end-to-end example wiring a View to a ViewModel.",
-      "path": "Samples/HelloWorld"
+      "path": "Samples~/HelloWorld"
     },
     {
       "displayName": "Stats",
       "description": "Binding numeric stats with converters and bindable members.",
-      "path": "Samples/Stats"
+      "path": "Samples~/Stats"
     },
     {
       "displayName": "Todo List",
       "description": "Observable collection bound to a dynamic list of items.",
-      "path": "Samples/TodoList"
+      "path": "Samples~/TodoList"
     },
     {
       "displayName": "Virtualized List",
       "description": "Virtualized list efficiently rendering large data sets.",
-      "path": "Samples/VirtualizedList"
+      "path": "Samples~/VirtualizedList"
     }
   ],
   "unityRelease": "0f1"


### PR DESCRIPTION
## Summary

- Unity Package Manager copies each sample from the path declared in `package.json`; all four sample entries pointed to a non-existent `Samples/` folder, so importing any sample produced an empty result.
- Repointed all four sample paths (`HelloWorld`, `Stats`, `TodoList`, `VirtualizedList`) to the real `Samples~/` location so they import correctly.

## Notes for review

The working tree currently carries unrelated local changes (UniCli-server dependency in `manifest.json`/`packages-lock.json`, an editor-only auto-upgrade of `ProjectSettings.asset`, an in-progress `BinderAutoAssigner.cs`, and a leftover `docs/` wiki checkout). None of these are committed to this branch — this PR contains only the single `package.json` fix.