### PR TITLE
build(deps): add com.yucchiy.unicli-server package

### DIFF
--- a/Aspid.MVVM/Packages/manifest.json
+++ b/Aspid.MVVM/Packages/manifest.json
@@ -48,6 +48,7 @@
     "com.unity.modules.video": "1.0.0",
     "com.unity.modules.vr": "1.0.0",
     "com.unity.modules.wind": "1.0.0",
-    "com.unity.modules.xr": "1.0.0"
+    "com.unity.modules.xr": "1.0.0",
+    "com.yucchiy.unicli-server": "https://github.com/yucchiy/UniCli.git?path=src/UniCli.Unity/Packages/com.yucchiy.unicli-server#v1.3.2"
   }
 }

--- a/Aspid.MVVM/Packages/packages-lock.json
+++ b/Aspid.MVVM/Packages/packages-lock.json
@@ -286,6 +286,13 @@
         "com.unity.modules.imgui": "1.0.0"
       }
     },
+    "com.yucchiy.unicli-server": {
+      "version": "https://github.com/yucchiy/UniCli.git?path=src/UniCli.Unity/Packages/com.yucchiy.unicli-server#v1.3.2",
+      "depth": 0,
+      "source": "git",
+      "dependencies": {},
+      "hash": "be0abbd15c319e1fd6c1843f4d57acbe90eedfce"
+    },
     "jp.hadashikick.vcontainer": {
       "version": "https://github.com/hadashiA/VContainer.git?path=VContainer/Assets/VContainer#1.16.0",
       "depth": 0,


### PR DESCRIPTION
## Summary

- Adds `com.yucchiy.unicli-server` (git dependency, `v1.3.2`) to `manifest.json`, with the matching `packages-lock.json` entry.
- Enables Unity Editor automation (`unicli exec` / `unicli eval`) for this project.

## Notes for review

Split out of `fix/sample-import-paths`, where this dependency had accidentally accumulated as an unrelated local change.