### PR TITLE
fix(editor): add binder component instead of abstract target type

### DIFF
--- a/Aspid.MVVM/Packages/tech.aspid.mvvm/Unity/Editor/Scripts/Binders/AddBinderContextMenu.cs
+++ b/Aspid.MVVM/Packages/tech.aspid.mvvm/Unity/Editor/Scripts/Binders/AddBinderContextMenu.cs
@@ -53,20 +53,25 @@ namespace Aspid.MVVM
 
         private static void OnContextualPropertyMenu(GenericMenu menu, SerializedProperty property)
         {
-            menu.AddSeparator(path: "/");
             var target = property.serializedObject.targetObject;
+
+            // Binders are added via AddComponent, which requires a GameObject; skip non-Component
+            // targets (e.g. ScriptableObject assets) so the menu never shows a dead entry.
+            if (target is not Component component)
+                return;
+
             var results = FindTypesWithTargetPropertyTypeAttribute(target, property);
+            if (results.Count == 0)
+                return;
+
+            menu.AddSeparator(path: "/");
 
             foreach (var item in results)
             {
-                foreach (var type in item.Types)
-                {
-                    menu.AddItem(new GUIContent(text: $"{AddBinderText}/{item.Name}"), false, () =>
-                    {
-                        if (target is Component component)
-                            component.gameObject.AddComponent(type);
-                    }); 
-                }
+                var binderType = item.Type;
+
+                menu.AddItem(new GUIContent(text: $"{AddBinderText}/{item.Name}"), false, () =>
+                    component.gameObject.AddComponent(binderType));
             }
         }
 
@@ -83,26 +88,19 @@ namespace Aspid.MVVM
 
             foreach (var context in _contexts)
             {
-                var name = context.Name;
-                var types = new List<Type>();
-                
-                foreach (var contextMenu in context.ContextMenus)
-                {
-                    foreach (var serializePropertyName in contextMenu.SerializePropertyNames)
-                    {
-                        if (string.IsNullOrWhiteSpace(serializePropertyName)) continue;
-                        if (serializePropertyName != propertyName) continue;
-                        if (!contextMenu.Type.IsAssignableFrom(targetType)) continue;
-                            
-                        types.Add(contextMenu.Type);
-                    }
-                }
+                // Match against the attribute's target/value type, but never add that type:
+                // the menu must add the binder itself (context.Type). The property-type scan is
+                // only reached when the target-property match fails, thanks to || short-circuiting.
+                var matches = context.ContextMenus.Any(contextMenu =>
+                        contextMenu.Type.IsAssignableFrom(targetType) &&
+                        contextMenu.SerializePropertyNames.Any(serializePropertyName =>
+                            !string.IsNullOrWhiteSpace(serializePropertyName) &&
+                            serializePropertyName == propertyName))
+                    || context.ContextMenuByTypes.Any(contextMenu =>
+                        contextMenu.Type.IsAssignableFrom(propertyType));
 
-                types.AddRange(collection: context.ContextMenuByTypes
-                    .Select(c => c.Type)
-                    .Where(type => type.IsAssignableFrom(propertyType)));
-
-                results.Add(new Result(name, types));
+                if (matches)
+                    results.Add(new Result(context.Name, context.Type));
             }
 
             return results;
@@ -111,12 +109,12 @@ namespace Aspid.MVVM
         private readonly struct Result
         {
             public readonly string Name;
-            public readonly IReadOnlyList<Type> Types;
-            
-            public Result(string name, IReadOnlyList<Type> types)
+            public readonly Type Type;
+
+            public Result(string name, Type type)
             {
                 Name = name;
-                Types = types;
+                Type = type;
             }
         }
         
@@ -124,12 +122,14 @@ namespace Aspid.MVVM
         {
             private const bool Inherit = true;
             
+            public readonly Type Type;
             public readonly string Name;
             public readonly IReadOnlyList<ContextMenu> ContextMenus;
             public readonly IReadOnlyList<ContextMenuByType> ContextMenuByTypes;
-            
+
             public Context(Type type)
             {
+                Type = type;
                 Name = GetName(type);
                 
                 ContextMenus = type
@@ -159,7 +159,12 @@ namespace Aspid.MVVM
 
             public static bool IsValid(Type type)
             {
-                return type.IsDefined(typeof(AddBinderContextMenuAttribute), Inherit) 
+                // The menu adds the type via AddComponent, which only succeeds for a concrete,
+                // non-generic MonoBehaviour. Skip anything else so a click can never fail at runtime.
+                if (type.IsAbstract || type.IsGenericTypeDefinition || !typeof(MonoBehaviour).IsAssignableFrom(type))
+                    return false;
+
+                return type.IsDefined(typeof(AddBinderContextMenuAttribute), Inherit)
                     || type.IsDefined(typeof(AddBinderContextMenuByTypeAttribute), Inherit);
             }
         }


### PR DESCRIPTION
## Summary

Fixes #124 (ASP-40). The **Add Binder** context menu passed the attribute's *target* type to `GameObject.AddComponent`, so adding a binder for a TextMeshPro field threw at click time:

```text
Can't add script behaviour 'TMP_Text'. The script class can't be abstract!
```

The menu now adds the **binder component itself** instead of the target type.

> Root cause diagnosed by @weixudong1983 in #124.

| | Before | After |
|---|---|---|
| Type passed to `AddComponent` | attribute target type — `contextMenu.Type` (e.g. abstract `TMP_Text`) | binder type — `context.Type` (e.g. `TextMonoBinder`) |
| Result of clicking the entry | throws on abstract / non-instantiable type | the binder is added |

`Result` / `Context` were reworked to carry a single binder `Type` so the menu action can add `context.Type` directly.

## Additional hardening

Guards found while fixing the root cause — editor-only, same file (`AddBinderContextMenu.cs`):

| Issue | Fix |
|---|---|
| `Add Binder/<name>` appeared for non-`Component` targets (e.g. `ScriptableObject` fields), yet clicking it did nothing | Early return for non-`Component` targets — the entry is no longer shown |
| A binder type could still be abstract / open-generic / non-`MonoBehaviour` | `Context.IsValid` now requires a concrete `MonoBehaviour` |
| The menu separator was added unconditionally, cluttering every property's right-click menu | Separator added only when at least one binder matches |
| The `ContextMenuByTypes` scan ran even after the target-property match succeeded | Both predicates inlined into the `if` — `\|\|` short-circuits the scan |

## Notes for review

- Unrelated environment noise (`packages-lock.json` Hot Reload entry + three Zenject `*.csproj.meta` deletions) was reverted, so the PR contains only the fix.

## Credits

Thanks to @weixudong1983 for reporting #124 and pinpointing the exact root cause and fix.

## Linked issues

- Closes #124
- Closes ASP-40

<details>
<summary>🇷🇺 Описание на русском</summary>

## Summary

Контекстное меню **Add Binder** передавало в `GameObject.AddComponent` *целевой* тип атрибута, поэтому добавление биндера для поля TextMeshPro падало прямо при клике:

```text
Can't add script behaviour 'TMP_Text'. The script class can't be abstract!
```

Теперь меню добавляет **сам компонент биндера**, а не целевой тип.

> Корневую причину диагностировал @weixudong1983.

| | До | После |
|---|---|---|
| Тип, передаваемый в `AddComponent` | целевой тип атрибута — `contextMenu.Type` (например, абстрактный `TMP_Text`) | тип биндера — `context.Type` (например, `TextMonoBinder`) |
| Результат клика по пункту | исключение на абстрактном / неинстанцируемом типе | биндер добавляется |

`Result` / `Context` переработаны так, чтобы нести единственный `Type` биндера, — action меню добавляет `context.Type` напрямую.

## Дополнительное усиление

Гарды, найденные по ходу фикса, — editor-only, тот же файл (`AddBinderContextMenu.cs`):

| Проблема | Фикс |
|---|---|
| `Add Binder/<name>` показывался для не-`Component` целей (например, полей `ScriptableObject`), но клик ничего не делал | Ранний выход для не-`Component` целей — пункт больше не показывается |
| Тип биндера всё ещё мог быть абстрактным / open-generic / не-`MonoBehaviour` | `Context.IsValid` теперь требует конкретный `MonoBehaviour` |
| Разделитель меню добавлялся безусловно, засоряя контекстное меню каждого свойства | Разделитель добавляется, только если нашёлся хотя бы один биндер |
| Скан `ContextMenuByTypes` выполнялся даже после успешного матча по target-property | Оба предиката инлайнены в `if` — `\|\|` обрывает скан |

## Notes for review

- Посторонний шум окружения (запись Hot Reload в `packages-lock.json` + удаление трёх Zenject `*.csproj.meta`) откачен — PR содержит только фикс.

## Благодарности

Спасибо @weixudong1983 за репорт и точное указание корневой причины и фикса.

</details>
