### PR TITLE
build(tooling): migrate Unity Editor automation from UniCli to Unity CLI

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,6 +1,5 @@
 {
   "enabledPlugins": {
-    "unicli@unicli": true,
     "codspeed@claude-plugins-official": true
   }
 }

--- a/.mcp.json
+++ b/.mcp.json
@@ -1,0 +1,10 @@
+{
+  "mcpServers": {
+    "unity-editor": {
+      "type": "stdio",
+      "command": "unity",
+      "args": ["mcp", "--project-path", "./Aspid.MVVM"],
+      "env": {}
+    }
+  }
+}

--- a/Aspid.MVVM/Packages/manifest.json
+++ b/Aspid.MVVM/Packages/manifest.json
@@ -9,6 +9,7 @@
     "com.unity.inputsystem": "1.19.0",
     "com.unity.localization": "1.5.8",
     "com.unity.memoryprofiler": "1.1.11",
+    "com.unity.pipeline": "0.4.0-exp.1",
     "com.unity.recorder": "5.1.5",
     "com.unity.render-pipelines.universal": "17.4.0",
     "com.unity.timeline": "1.8.11",
@@ -48,7 +49,6 @@
     "com.unity.modules.video": "1.0.0",
     "com.unity.modules.vr": "1.0.0",
     "com.unity.modules.wind": "1.0.0",
-    "com.unity.modules.xr": "1.0.0",
-    "com.yucchiy.unicli-server": "https://github.com/yucchiy/UniCli.git?path=src/UniCli.Unity/Packages/com.yucchiy.unicli-server#v1.3.2"
+    "com.unity.modules.xr": "1.0.0"
   }
 }

--- a/Aspid.MVVM/Packages/packages-lock.json
+++ b/Aspid.MVVM/Packages/packages-lock.json
@@ -170,6 +170,20 @@
       "dependencies": {},
       "url": "https://packages.unity.com"
     },
+    "com.unity.pipeline": {
+      "version": "0.4.0-exp.1",
+      "depth": 0,
+      "source": "registry",
+      "dependencies": {
+        "com.unity.test-framework": "1.1.33",
+        "com.unity.nuget.mono-cecil": "1.11.6",
+        "com.unity.modules.uielements": "1.0.0",
+        "com.unity.modules.jsonserialize": "1.0.0",
+        "com.unity.modules.screencapture": "1.0.0",
+        "com.unity.nuget.newtonsoft-json": "3.0.2"
+      },
+      "url": "https://packages.unity.com"
+    },
     "com.unity.profiling.core": {
       "version": "1.0.3",
       "depth": 1,
@@ -285,13 +299,6 @@
         "com.unity.modules.ui": "1.0.0",
         "com.unity.modules.imgui": "1.0.0"
       }
-    },
-    "com.yucchiy.unicli-server": {
-      "version": "https://github.com/yucchiy/UniCli.git?path=src/UniCli.Unity/Packages/com.yucchiy.unicli-server#v1.3.2",
-      "depth": 0,
-      "source": "git",
-      "dependencies": {},
-      "hash": "be0abbd15c319e1fd6c1843f4d57acbe90eedfce"
     },
     "jp.hadashikick.vcontainer": {
       "version": "https://github.com/hadashiA/VContainer.git?path=VContainer/Assets/VContainer#1.16.0",

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -109,7 +109,31 @@ dotnet test Aspid.MVVM.Generators/Aspid.MVVM.Generators/Aspid.MVVM.Generators.Te
 dotnet test Aspid.MVVM.Analyzers/Aspid.MVVM.Analyzers/Aspid.MVVM.Analyzers.Tests/
 ```
 
-The Unity project is opened via the Unity Editor (2022.3+); there is no CLI build script.
+### Unity Editor automation (Unity CLI)
+
+Editor automation goes through the official **Unity CLI** (`unity`) and the `com.unity.pipeline`
+package, which is declared in `Aspid.MVVM/Packages/manifest.json`. A running Editor exposes ~140
+commands over its Pipeline server:
+
+```bash
+# Open the project and check that the Pipeline server is up
+unity open Aspid.MVVM
+unity status --json
+
+# Discover / run Editor commands
+unity command                                  # list every command the Editor exposes
+unity command recompile --json                 # compile check after C# edits
+unity command package_resolve --json           # re-resolve packages after a manifest change
+unity command get_console_logs --json          # read the Editor console
+unity command run_tests --mode EditMode --json # Unity Test Framework run
+unity command eval --code 'return Application.unityVersion;'
+```
+
+When several Unity Editors are open, add `--project-path ./Aspid.MVVM` — otherwise the CLI can't
+pick an instance and errors out.
+
+AI agents can consume the same command surface as MCP tools: the repo ships `.mcp.json` with a
+`unity-editor` stdio server (`unity mcp --project-path ./Aspid.MVVM`).
 
 ## Gotchas
 


### PR DESCRIPTION
## Summary

Replaces the third-party UniCli bridge (added in #126) with Unity's **official Unity CLI** (`unity`) and its `com.unity.pipeline` package, which covers the same Editor automation surface and adds a built-in MCP server.

- **Packages** — drop `com.yucchiy.unicli-server` (git dep), add `com.unity.pipeline` `0.4.0-exp.1` from the Unity registry; `packages-lock.json` updated accordingly.
- **`.mcp.json`** (new) — registers the `unity-editor` stdio MCP server (`unity mcp --project-path ./Aspid.MVVM`) so agents get the Editor commands as MCP tools.
- **`.claude/settings.json`** — drop the now-unused `unicli` plugin.
- **`CLAUDE.md`** — replace the outdated "there is no CLI build script" line with a documented Unity CLI automation workflow.

## Capability mapping

| UniCli | Unity CLI |
|---|---|
| `unicli eval '<expr>'` | `unity command eval --code '<expr>'` |
| `unicli exec Compile` | `unity command recompile` / `recompile_status` |
| test runs | `unity command run_tests --mode EditMode` / `list_tests` / `test_status` |
| console readout | `unity command get_console_logs` / `clear_console` |
| asset & package ops | `import_asset`, `create_asset`, `package_add/remove/resolve`, … |
| — | 140 commands total, plus `unity mcp`, `unity open`, `unity build`, `unity test` |

## Verification

Run against a live `6000.4.0f1` Editor on this branch:

- `unity status` → Pipeline server `ready` on port 7800.
- `unity command` → **140** commands exposed.
- `unity command recompile` → `up_to_date`; `get_console_logs` → **0** entries (no errors/warnings).
- `com.yucchiy.unicli-server` removed via `unity command package_remove`; Editor survived the domain reload and reconnected.
- MCP handshake (`initialize` + `tools/list`) against `.mcp.json`'s command line → server `unity-mcp 1.0.0-beta.3`, **140** tools.
- `unity command run_tests --mode EditMode` → **419/419 passed** (18.7 s).

## Notes for review

`com.unity.pipeline` is an experimental (`-exp.1`) Unity package — that is the only channel it ships on today; `unity pipeline upgrade` bumps it when a newer version lands.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Qw7niQJYBGx26EcYMWup4u