### PR TITLE
fix(editor): repair inspector spacing and the inflated Logs box

### DIFF
--- a/Aspid.MVVM/Packages/tech.aspid.mvvm/Unity/Editor/Scripts/Binders/MonoBinderVisualElement.cs
+++ b/Aspid.MVVM/Packages/tech.aspid.mvvm/Unity/Editor/Scripts/Binders/MonoBinderVisualElement.cs
@@ -246,21 +246,29 @@ namespace Aspid.MVVM
         }
 
         private AspidBaseInspectorVisualElement BuildBaseInspector() =>
-            new(SerializedObject, "Parameters", PropertiesExcluding.ToArray());
+            new AspidBaseInspectorVisualElement(SerializedObject, "Parameters", PropertiesExcluding.ToArray())
+                .SetMargin(top: 5);
 
         protected virtual VisualElement BuildLogsContainer()
         {
             if (_editor.LogsProperty is null || _editor.IsDebugProperty is null) 
                 return new VisualElement();
             
-            var isDebugPropertyField = new PropertyField(_editor.IsDebugProperty);
+            // The toggle is docked into the title row of an AspidLabel, whose style sheet forces
+            // `white-space: normal` and `flex-grow: 1` onto every Label beneath it. A field that kept its own
+            // label would therefore be squeezed to zero width by the title next to it and wrap that label one
+            // character per line, stretching the whole Logs box to the height of the wrapped text. An empty
+            // label drops the element outright, and flex-shrink 0 keeps the checkmark at its natural width.
+            var isDebugPropertyField = new PropertyField(_editor.IsDebugProperty, label: string.Empty)
+                .SetFlexShrink(0);
             isDebugPropertyField.Bind(_editor.serializedObject);
-            
+
             var title = new AspidLabel(text: "Logs").SetMarginBottom(5);
             var titleLabel = title[0];
             title.RemoveAt(0);
             title.Insert(index: 0, new VisualElement()
                 .SetFlexDirection(FlexDirection.Row)
+                .SetAlignItems(Align.Center)
                 .SetJustifyContent(Justify.SpaceBetween)
                 .AddChild(titleLabel)
                 .AddChild(isDebugPropertyField));

--- a/Aspid.MVVM/Packages/tech.aspid.mvvm/Unity/Editor/Scripts/ViewModels/VisualElements/ViewModelVisualElement.cs
+++ b/Aspid.MVVM/Packages/tech.aspid.mvvm/Unity/Editor/Scripts/ViewModels/VisualElements/ViewModelVisualElement.cs
@@ -96,7 +96,8 @@ namespace Aspid.MVVM
         protected virtual VisualElement? OnBuiltHeader() => null;
 
         private AspidBaseInspectorVisualElement BuildBaseInspector() =>
-            new(SerializedObject, null, PropertiesExcluding.ToArray());
+            new AspidBaseInspectorVisualElement(SerializedObject, null, PropertiesExcluding.ToArray())
+                .SetMargin(top: 5);
 
         protected virtual VisualElement? OnBuiltBaseInspector() => null;
 


### PR DESCRIPTION
Two layout defects in the binder inspector, both measured against the live UIElements tree of an `AnimatorSetFloatMonoBinder` in a 6000.4.0f1 Editor.

## Summary

- 🐛 The **Parameters** box carried no top margin, so it sat flush against the ID selector while every other section is spaced by 5px. `ViewModelVisualElement` had the same omission — `ViewVisualElement` already set it.
- 🐛 The **Logs** box rendered **155px** tall instead of ~50px, with the debug checkmark floating in the middle of the empty space.

## Why the Logs box inflated

The `_isDebug` toggle is docked into the title row of an `AspidLabel`, and that style sheet forces `white-space: normal` and `flex-grow: 1` onto **every** `Label` in its subtree — not just its own. So the title claimed the whole row, the toggle shrank to 15px, and the toggle's own label, now zero width, wrapped one character per line: 8 lines × ~15px = the 119px that stretched the box.

Suppressing that label drops the element from the hierarchy outright; `flex-shrink: 0` keeps the checkmark at its natural width, and centering the row aligns it with the title text.

| | before | after |
|---|---|---|
| `Parameters` margin-top | `0` | `5` ✅ |
| `Logs` box height | `155px` | `50px` ✅ |
| checkmark | centered in 119px of void | `14×14`, aligned with the title ✅ |

## Notes for review

⚠️ The root cause lives in Aspid.FastTools: the bare `Label { … }` selector in `Aspid-FastTools-AspidLabel.uss` applies to the whole subtree rather than the label's own text element, so any control nested into an `AspidLabel` inherits text wrapping it never asked for. Narrowing it to `:root > Label` would fix the class of bug — that is a separate repository, so this PR only works around it at the call site.

<details>
<summary>🇷🇺 Описание на русском</summary>

Два дефекта вёрстки в инспекторе биндера — оба замерены по живому дереву UIElements для `AnimatorSetFloatMonoBinder` в редакторе 6000.4.0f1.

## Кратко

- 🐛 У блока **Parameters** не было верхнего отступа: он прилипал к селектору ID, тогда как все остальные секции разделены 5px. В `ViewModelVisualElement` тот же пропуск — в `ViewVisualElement` отступ уже стоял.
- 🐛 Блок **Logs** занимал **155px** вместо ~50px, а чекбокс debug висел посреди пустоты.

## Почему раздувался Logs

Тоггл `_isDebug` вставляется в строку заголовка `AspidLabel`, а её USS навязывает `white-space: normal` и `flex-grow: 1` **всем** `Label` в поддереве, а не только собственному. Заголовок забирал всю ширину строки, тоггл сжимался до 15px, и его собственный лейбл — уже нулевой ширины — переносился по одному символу в строку: 8 строк × ~15px и дали те самые 119px, растянувшие блок.

Пустой лейбл Unity выкидывает из иерархии целиком; `flex-shrink: 0` не даёт сжать чекмарк, а центрирование строки выравнивает его по заголовку.

| | было | стало |
|---|---|---|
| `Parameters` margin-top | `0` | `5` ✅ |
| высота `Logs` | `155px` | `50px` ✅ |
| чекмарк | по центру 119px пустоты | `14×14`, по заголовку ✅ |

## Что учесть на ревью

⚠️ Корень проблемы — в Aspid.FastTools: голый селектор `Label { … }` в `Aspid-FastTools-AspidLabel.uss` бьёт по всему поддереву, а не по собственному текстовому элементу, поэтому любой вложенный в `AspidLabel` контрол наследует перенос текста, о котором не просил. Сузить до `:root > Label` — и класс багов закрыт, но это отдельный репозиторий, так что здесь только обход на стороне вызова.

</details>
