### PR TITLE
fix(editor): align the binder help box with the inspector header

### DIFF
--- a/Aspid.MVVM/Packages/tech.aspid.mvvm/Unity/Editor/Resources/Styles/Aspid-MVVM-MonoBinder.uss
+++ b/Aspid.MVVM/Packages/tech.aspid.mvvm/Unity/Editor/Resources/Styles/Aspid-MVVM-MonoBinder.uss
@@ -90,6 +90,33 @@
     margin-top: 1px;
 }
 
+/* The FastTools help box paints its error state with the palette's `light` fill and a `shade-lightness` border, which
+   shouts louder than the AspidInspectorHeader right above it — the header keeps to the far darker `darkness` tone on
+   hover. Pull the surface down to `dark` and the border to `shade-light` so the two sit on the same scale.
+   The base sheet also flattens the title and the message to the same `text-lightness`, erasing the header's
+   Text/Subtext hierarchy, so the message is dropped a step to `text-light` while the title keeps the bright tone.
+   Every selector is qualified with the id-selector container class, otherwise it only ties the base
+   `:root.aspid-fasttools-status--error` rules on specificity and loses on sheet order — the help box attaches its own
+   sheet to itself, which resolves after this one. Scoped to this help box only: the rest of the FastTools help boxes
+   keep the package's own look. */
+.aspid-mono-binder-id-selector .aspid-mono-binder-id-selector-help-box.aspid-fasttools-status--error
+{
+    background-color: var(--aspid-colors-status-error-dark);
+    border-color: var(--aspid-colors-status-error-shade-light);
+}
+
+.aspid-mono-binder-id-selector .aspid-mono-binder-id-selector-help-box.aspid-fasttools-status--error AspidLabel > Label
+{
+    color: var(--aspid-colors-status-error-text-light);
+}
+
+.aspid-mono-binder-id-selector
+    .aspid-mono-binder-id-selector-help-box.aspid-fasttools-status--error
+    .aspid-fasttools-help-box__title > Label
+{
+    color: var(--aspid-colors-status-error-text-lightness);
+}
+
 .aspid-mono-binder-id-selector-dropdown--previous VisualElement
 {
     background-color: var(--aspid-colors-status-error-dark);

--- a/Aspid.MVVM/Packages/tech.aspid.mvvm/Unity/Editor/Scripts/Binders/MonoBinderVisualElement.cs
+++ b/Aspid.MVVM/Packages/tech.aspid.mvvm/Unity/Editor/Scripts/Binders/MonoBinderVisualElement.cs
@@ -138,6 +138,7 @@ namespace Aspid.MVVM
                      title: "Incomplete Binder Configuration",
                      message: "Both the View and the binding ID must be set for this binder to resolve at runtime. Select a View above and choose an ID exposed by its ViewModel.",
                      AspidHelpBoxPreset.Default.SetMessageType(HelpBoxMessageType.Error))
+                 .AddClass("aspid-mono-binder-id-selector-help-box")
                  .SetMargin(top: 5, bottom: 5)
                  .SetDisplay(_editor.HasBinderId ? DisplayStyle.None : DisplayStyle.Flex);
 


### PR DESCRIPTION
🎨 The binder's "Incomplete Binder Configuration" help box was painted with the FastTools default error state — a saturated `status-error-light` fill (`#7D2323`) with a bright `shade-lightness` border — which read louder than the `AspidInspectorHeader` sitting right above it. This scopes a quieter palette to that one help box.

- 🎨 Surface drops to `status-error-dark` (`#551414`) with a `shade-light` border, putting the box on the same tonal scale as the header.
- 🐛 Title and message get separate colors again. The base FastTools sheet flattens both labels to `text-lightness`, so the header's Text/Subtext hierarchy was lost — the message now sits a step down at `text-light`.
- 🔧 Every rule is scoped through a new `aspid-mono-binder-id-selector-help-box` class. Other FastTools help boxes — view initializers, unassigned binders, delegate fields, package windows — keep the package's own look.

**Notes for review** — each selector is deliberately qualified with the `aspid-mono-binder-id-selector` container class. Without it the override only ties the base `:root.aspid-fasttools-status--error` rules on specificity, and loses on sheet order, since the help box attaches its own stylesheet to itself. Verified in a live Editor: resolved styles come out as `bg #551414`, `border #874141`, title `#FFAFAF`, message `#EB5F5F`.

<details>
<summary>🇷🇺 Описание на русском</summary>

🎨 Хелпбокс биндера «Incomplete Binder Configuration» использовал дефолтное error-состояние FastTools — насыщенную заливку `status-error-light` (`#7D2323`) со светлой рамкой `shade-lightness` — и кричал громче, чем `AspidInspectorHeader` прямо над ним. PR приглушает палитру только для этого хелпбокса.

- 🎨 Фон опускается до `status-error-dark` (`#551414`), рамка — до `shade-light`, так что плашка и заголовок оказываются на одной тональной шкале.
- 🐛 Заголовок и сообщение снова разного цвета. Базовый лист FastTools красит оба лейбла в `text-lightness`, из-за чего терялась иерархия Text/Subtext заголовка инспектора — сообщение теперь на шаг тише, в `text-light`.
- 🔧 Все правила ограничены новым классом `aspid-mono-binder-id-selector-help-box`. Остальные хелпбоксы FastTools — инициализаторы View, неназначенные биндеры, delegate-поля, окна пакета — сохраняют вид пакета.

**Заметки для ревью** — каждый селектор намеренно квалифицирован классом контейнера `aspid-mono-binder-id-selector`. Без него override лишь сравнивается по специфичности с базовыми правилами `:root.aspid-fasttools-status--error` и проигрывает по порядку листов: хелпбокс подключает свой лист сам на себя. Проверено в живом редакторе: резолвнутые стили — `bg #551414`, `border #874141`, заголовок `#FFAFAF`, сообщение `#EB5F5F`.

</details>
