### PR TITLE
test(starterkit): add a converter regression harness

### DIFF
--- a/Aspid.MVVM/Packages/tech.aspid.mvvm/Tests.meta
+++ b/Aspid.MVVM/Packages/tech.aspid.mvvm/Tests.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 0f1922133a8914697a8e88b44adcd9a2
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Aspid.MVVM/Packages/tech.aspid.mvvm/Tests/Editor.meta
+++ b/Aspid.MVVM/Packages/tech.aspid.mvvm/Tests/Editor.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 662548664689c4d77abee4c755676e1a
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Aspid.MVVM/Packages/tech.aspid.mvvm/Tests/Editor/Aspid.MVVM.StarterKit.Tests.asmdef
+++ b/Aspid.MVVM/Packages/tech.aspid.mvvm/Tests/Editor/Aspid.MVVM.StarterKit.Tests.asmdef
@@ -1,0 +1,26 @@
+{
+    "name": "Aspid.MVVM.StarterKit.Tests",
+    "rootNamespace": "",
+    "references": [
+        "UnityEngine.TestRunner",
+        "UnityEditor.TestRunner",
+        "Aspid.MVVM",
+        "Aspid.MVVM.StarterKit",
+        "Aspid.MVVM.StarterKit.Unity"
+    ],
+    "includePlatforms": [
+        "Editor"
+    ],
+    "excludePlatforms": [],
+    "allowUnsafeCode": false,
+    "overrideReferences": true,
+    "precompiledReferences": [
+        "nunit.framework.dll"
+    ],
+    "autoReferenced": false,
+    "defineConstraints": [
+        "UNITY_INCLUDE_TESTS"
+    ],
+    "versionDefines": [],
+    "noEngineReferences": false
+}

--- a/Aspid.MVVM/Packages/tech.aspid.mvvm/Tests/Editor/Aspid.MVVM.StarterKit.Tests.asmdef.meta
+++ b/Aspid.MVVM/Packages/tech.aspid.mvvm/Tests/Editor/Aspid.MVVM.StarterKit.Tests.asmdef.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: e0cbcbdd5ce404c02bc09897235dda6c
+AssemblyDefinitionImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Aspid.MVVM/Packages/tech.aspid.mvvm/Tests/Editor/Converters.meta
+++ b/Aspid.MVVM/Packages/tech.aspid.mvvm/Tests/Editor/Converters.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 68a7b78a9f86848409a32e9209396046
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Aspid.MVVM/Packages/tech.aspid.mvvm/Tests/Editor/Converters/Bools.meta
+++ b/Aspid.MVVM/Packages/tech.aspid.mvvm/Tests/Editor/Converters/Bools.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: ef1522f75fcc34496975defde9f0977c
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Aspid.MVVM/Packages/tech.aspid.mvvm/Tests/Editor/Converters/Bools/NumberToBoolConverterTests.cs
+++ b/Aspid.MVVM/Packages/tech.aspid.mvvm/Tests/Editor/Converters/Bools/NumberToBoolConverterTests.cs
@@ -1,0 +1,88 @@
+using NUnit.Framework;
+
+namespace Aspid.MVVM.StarterKit.Tests
+{
+    /// <summary>
+    /// Coverage for <see cref="NumberToBoolConverter"/> across all six <see cref="Comparisons"/>
+    /// and all four numeric overloads.
+    /// </summary>
+    /// <remarks>
+    /// <see cref="Comparisons.Equal"/> and <see cref="Comparisons.Inequality"/> are deliberately
+    /// fuzzy — they route through a relative 1e-6 tolerance rather than <c>==</c>. The magnitude
+    /// cases at the bottom pin that behaviour down as it stands today; they are characterisation,
+    /// not endorsement.
+    /// </remarks>
+    [TestFixture]
+    internal sealed class NumberToBoolConverterTests
+    {
+        [TestCase(Comparisons.LessThan, 5f, true)]
+        [TestCase(Comparisons.LessThan, 10f, false)]
+        [TestCase(Comparisons.LessThan, 15f, false)]
+        [TestCase(Comparisons.GreaterThan, 5f, false)]
+        [TestCase(Comparisons.GreaterThan, 10f, false)]
+        [TestCase(Comparisons.GreaterThan, 15f, true)]
+        [TestCase(Comparisons.LessThanOrEqual, 5f, true)]
+        [TestCase(Comparisons.LessThanOrEqual, 10f, true)]
+        [TestCase(Comparisons.LessThanOrEqual, 15f, false)]
+        [TestCase(Comparisons.GreaterThanOrEqual, 5f, false)]
+        [TestCase(Comparisons.GreaterThanOrEqual, 10f, true)]
+        [TestCase(Comparisons.GreaterThanOrEqual, 15f, true)]
+        [TestCase(Comparisons.Equal, 5f, false)]
+        [TestCase(Comparisons.Equal, 10f, true)]
+        [TestCase(Comparisons.Equal, 15f, false)]
+        [TestCase(Comparisons.Inequality, 5f, true)]
+        [TestCase(Comparisons.Inequality, 10f, false)]
+        [TestCase(Comparisons.Inequality, 15f, true)]
+        public void Convert_Float_MatchesTheComparison(Comparisons comparison, float value, bool expected) =>
+            Assert.AreEqual(expected, new NumberToBoolConverter(comparison, value: 10f).Convert(value));
+
+        [TestCase(Comparisons.LessThan, 5, true)]
+        [TestCase(Comparisons.GreaterThan, 15, true)]
+        [TestCase(Comparisons.Equal, 10, true)]
+        [TestCase(Comparisons.Inequality, 11, true)]
+        public void Convert_Int_MatchesTheComparison(Comparisons comparison, int value, bool expected) =>
+            Assert.AreEqual(expected, new NumberToBoolConverter(comparison, value: 10f).Convert(value));
+
+        [TestCase(Comparisons.LessThan, 5L, true)]
+        [TestCase(Comparisons.GreaterThan, 15L, true)]
+        [TestCase(Comparisons.Equal, 10L, true)]
+        [TestCase(Comparisons.Inequality, 11L, true)]
+        public void Convert_Long_MatchesTheComparison(Comparisons comparison, long value, bool expected) =>
+            Assert.AreEqual(expected, new NumberToBoolConverter(comparison, value: 10f).Convert(value));
+
+        [TestCase(Comparisons.LessThan, 5d, true)]
+        [TestCase(Comparisons.GreaterThan, 15d, true)]
+        [TestCase(Comparisons.Equal, 10d, true)]
+        [TestCase(Comparisons.Inequality, 11d, true)]
+        public void Convert_Double_MatchesTheComparison(Comparisons comparison, double value, bool expected) =>
+            Assert.AreEqual(expected, new NumberToBoolConverter(comparison, value: 10f).Convert(value));
+
+        [Test]
+        public void Convert_DefaultConstructed_ComparesAgainstZeroWithEqual() =>
+            Assert.IsTrue(new NumberToBoolConverter().Convert(0f));
+
+        // Characterisation of a known defect, not a desired contract: the relative tolerance is
+        // 1e-6 * magnitude, so at 2e6 anything within ~2.0 reads as equal. Tracked in the audit
+        // as a LOW finding; deliberately left alone by the Phase 0 batch.
+        [Test]
+        public void Convert_Equal_LargeMagnitudes_AreWithinTheRelativeTolerance() =>
+            Assert.IsTrue(new NumberToBoolConverter(Comparisons.Equal, value: 2_000_000f).Convert(2_000_001f));
+
+        [Test]
+        public void Convert_Inequality_LargeMagnitudes_AreWithinTheRelativeTolerance() =>
+            Assert.IsFalse(new NumberToBoolConverter(Comparisons.Inequality, value: 2_000_000f).Convert(2_000_001f));
+
+        // The tolerance applies to Equal/Inequality only, so the predicate set is mutually
+        // inconsistent at the boundary: a value can be "equal to" and "greater than" at once.
+        [Test]
+        public void Convert_ToleranceIsNotAppliedToOrderingComparisons()
+        {
+            const float target = 2_000_000f;
+            const float value = 2_000_001f;
+
+            Assert.IsTrue(new NumberToBoolConverter(Comparisons.Equal, target).Convert(value));
+            Assert.IsTrue(new NumberToBoolConverter(Comparisons.GreaterThan, target).Convert(value));
+            Assert.IsFalse(new NumberToBoolConverter(Comparisons.LessThanOrEqual, target).Convert(value));
+        }
+    }
+}

--- a/Aspid.MVVM/Packages/tech.aspid.mvvm/Tests/Editor/Converters/Bools/NumberToBoolConverterTests.cs.meta
+++ b/Aspid.MVVM/Packages/tech.aspid.mvvm/Tests/Editor/Converters/Bools/NumberToBoolConverterTests.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: c7e209324e30d446b86a30df4e7ebc86

--- a/Aspid.MVVM/Packages/tech.aspid.mvvm/Tests/Editor/Converters/Numbers.meta
+++ b/Aspid.MVVM/Packages/tech.aspid.mvvm/Tests/Editor/Converters/Numbers.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 71c6b17f2d4b04b89bde8a31ee69fcdf
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Aspid.MVVM/Packages/tech.aspid.mvvm/Tests/Editor/Converters/Numbers/ArithmeticNumberConverterTests.cs
+++ b/Aspid.MVVM/Packages/tech.aspid.mvvm/Tests/Editor/Converters/Numbers/ArithmeticNumberConverterTests.cs
@@ -1,0 +1,94 @@
+using UnityEngine;
+using NUnit.Framework;
+using UnityEngine.TestTools;
+using System.Text.RegularExpressions;
+
+namespace Aspid.MVVM.StarterKit.Tests
+{
+    /// <summary>
+    /// Coverage for <see cref="ArithmeticNumberConverter"/> — the four
+    /// <see cref="NumberOperation"/> branches, the divide-by-zero fallback, and the narrowing
+    /// behaviour of the twelve cross-type overloads.
+    /// </summary>
+    /// <remarks>
+    /// Every conversion runs through the single <c>IConverter&lt;double, double&gt;</c>
+    /// implementation and is then cast to the declared return type, so the int/long overloads
+    /// truncate toward zero rather than round. All sixteen interfaces are implemented explicitly,
+    /// which is why every call below goes through a cast.
+    /// </remarks>
+    [TestFixture]
+    internal sealed class ArithmeticNumberConverterTests
+    {
+        [TestCase(NumberOperation.Plus, 5d)]
+        [TestCase(NumberOperation.Minus, 1d)]
+        [TestCase(NumberOperation.Multiply, 6d)]
+        [TestCase(NumberOperation.Division, 1.5d)]
+        public void Convert_Double_AppliesTheOperation(NumberOperation operation, double expected) =>
+            Assert.AreEqual(expected, Double(operation, coefficient: 2).Convert(3d), delta: 1e-12);
+
+        [Test]
+        public void Convert_DefaultConstructed_IsAnIdentityForPlus() =>
+            Assert.AreEqual(3d, Double(NumberOperation.Plus, coefficient: 0).Convert(3d), delta: 1e-12);
+
+        [Test]
+        public void Convert_Division_ByZeroCoefficient_LogsOnceAndReturnsTheInput()
+        {
+            LogAssert.Expect(LogType.Error, new Regex("division by zero coefficient"));
+
+            Assert.AreEqual(7d, Double(NumberOperation.Division, coefficient: 0).Convert(7d), delta: 1e-12);
+        }
+
+        [Test]
+        public void Convert_WidensIntToDouble() =>
+            Assert.AreEqual(5d, Widen(NumberOperation.Plus, coefficient: 2).Convert(3), delta: 1e-12);
+
+        [TestCase(5d, 2)]
+        [TestCase(-5d, -2)]
+        public void Convert_NarrowsToInt_TruncatingTowardZero(double value, int expected) =>
+            Assert.AreEqual(expected, Narrow(NumberOperation.Multiply, coefficient: 0.5).Convert(value));
+
+        [TestCase(5d, 2L)]
+        [TestCase(-5d, -2L)]
+        public void Convert_NarrowsToLong_TruncatingTowardZero(double value, long expected) =>
+            Assert.AreEqual(expected, NarrowLong(NumberOperation.Multiply, coefficient: 0.5).Convert(value));
+
+        [Test]
+        public void Convert_NarrowsToFloat_KeepingTheDoubleResult() =>
+            Assert.AreEqual(1.5f, NarrowFloat(NumberOperation.Division, coefficient: 2).Convert(3d), delta: 1e-6f);
+
+        // The double pipeline cannot represent every long, so a long round-trip is lossy above
+        // 2^53 even when the operation is an identity. Tracked in the audit; the exact result of
+        // an out-of-range or NaN narrowing is platform-dependent and therefore not asserted here.
+        [Test]
+        public void Convert_Long_LosesPrecisionAboveTwoToTheFiftyThree() =>
+            Assert.AreEqual(9007199254740992L, Long(NumberOperation.Plus, coefficient: 0).Convert(9007199254740993L));
+
+        [Test]
+        [Ignore("Fixed in audit Phase 2 — narrowing is unchecked, so NaN and overflow are platform-dependent.")]
+        public void Convert_NarrowsNaNToZero() =>
+            Assert.AreEqual(0, Narrow(NumberOperation.Plus, coefficient: 0).Convert(double.NaN));
+
+        [Test]
+        [Ignore("Fixed in audit Phase 2 — narrowing is unchecked, so overflow saturates differently per runtime.")]
+        public void Convert_NarrowsOverflowToIntMaxValue() =>
+            Assert.AreEqual(int.MaxValue, Narrow(NumberOperation.Plus, coefficient: 0).Convert(1e20d));
+
+        private static IConverter<double, double> Double(NumberOperation operation, double coefficient) =>
+            new ArithmeticNumberConverter(operation, coefficient);
+
+        private static IConverter<int, double> Widen(NumberOperation operation, double coefficient) =>
+            new ArithmeticNumberConverter(operation, coefficient);
+
+        private static IConverter<double, int> Narrow(NumberOperation operation, double coefficient) =>
+            new ArithmeticNumberConverter(operation, coefficient);
+
+        private static IConverter<double, long> NarrowLong(NumberOperation operation, double coefficient) =>
+            new ArithmeticNumberConverter(operation, coefficient);
+
+        private static IConverter<double, float> NarrowFloat(NumberOperation operation, double coefficient) =>
+            new ArithmeticNumberConverter(operation, coefficient);
+
+        private static IConverter<long, long> Long(NumberOperation operation, double coefficient) =>
+            new ArithmeticNumberConverter(operation, coefficient);
+    }
+}

--- a/Aspid.MVVM/Packages/tech.aspid.mvvm/Tests/Editor/Converters/Numbers/ArithmeticNumberConverterTests.cs.meta
+++ b/Aspid.MVVM/Packages/tech.aspid.mvvm/Tests/Editor/Converters/Numbers/ArithmeticNumberConverterTests.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: a67509df512bb4ee29b03081bbc9da8e

--- a/Aspid.MVVM/Packages/tech.aspid.mvvm/Tests/Editor/Converters/SequenceConvertersTests.cs
+++ b/Aspid.MVVM/Packages/tech.aspid.mvvm/Tests/Editor/Converters/SequenceConvertersTests.cs
@@ -1,0 +1,71 @@
+using System;
+using NUnit.Framework;
+
+namespace Aspid.MVVM.StarterKit.Tests
+{
+    /// <summary>
+    /// Coverage for <see cref="SequenceConverters{T}"/> — the only composition primitive the
+    /// StarterKit ships, and the one an Inspector chain is built from.
+    /// </summary>
+    /// <remarks>
+    /// The empty-slot and unconstructed cases are the ones that matter: the Inspector's
+    /// <c>&lt;None&gt;</c> entry is a valid selection, and the type picker builds instances without
+    /// running a constructor. Both are marked <c>[Ignore]</c> here and asserted for real once the
+    /// guards land.
+    /// </remarks>
+    [TestFixture]
+    internal sealed class SequenceConvertersTests
+    {
+        [Test]
+        public void Convert_AppliesConvertersInDeclarationOrder() =>
+            Assert.AreEqual(8, new SequenceConverters<int>(new Add(1), new Multiply(2)).Convert(3));
+
+        [Test]
+        public void Convert_OrderMatters() =>
+            Assert.AreEqual(7, new SequenceConverters<int>(new Multiply(2), new Add(1)).Convert(3));
+
+        [Test]
+        public void Convert_EmptyChain_ReturnsInputUnchanged() =>
+            Assert.AreEqual(3, new SequenceConverters<int>().Convert(3));
+
+        [Test]
+        public void Convert_SingleConverter_BehavesLikeThatConverter() =>
+            Assert.AreEqual(4, new SequenceConverters<int>(new Add(1)).Convert(3));
+
+        [Test]
+        [Ignore("Fixed in PR 2 — null-guards. An empty picker slot serialises as a null element.")]
+        public void Convert_NullElement_IsSkipped() =>
+            Assert.AreEqual(4, new SequenceConverters<int>(new Add(1), null).Convert(3));
+
+        [Test]
+        [Ignore("Fixed in PR 2 — null-guards.")]
+        public void Convert_NullArray_ReturnsInputUnchanged() =>
+            Assert.AreEqual(3, new SequenceConverters<int>(null).Convert(3));
+
+        [Test]
+        [Ignore("Fixed in PR 2 — null-guards. The type picker needs a parameterless constructor.")]
+        public void ParameterlessConstructor_ProducesAUsableConverter()
+        {
+            var converter = (SequenceConverters<int>)Activator.CreateInstance(typeof(SequenceConverters<int>));
+            Assert.AreEqual(3, converter.Convert(3));
+        }
+
+        private sealed class Add : IConverter<int, int>
+        {
+            private readonly int _amount;
+
+            public Add(int amount) => _amount = amount;
+
+            public int Convert(int value) => value + _amount;
+        }
+
+        private sealed class Multiply : IConverter<int, int>
+        {
+            private readonly int _factor;
+
+            public Multiply(int factor) => _factor = factor;
+
+            public int Convert(int value) => value * _factor;
+        }
+    }
+}

--- a/Aspid.MVVM/Packages/tech.aspid.mvvm/Tests/Editor/Converters/SequenceConvertersTests.cs.meta
+++ b/Aspid.MVVM/Packages/tech.aspid.mvvm/Tests/Editor/Converters/SequenceConvertersTests.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 2181a312feb8d45869df20a5de2bec63

--- a/Aspid.MVVM/Packages/tech.aspid.mvvm/Tests/Editor/Converters/Strings.meta
+++ b/Aspid.MVVM/Packages/tech.aspid.mvvm/Tests/Editor/Converters/Strings.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: a6f17e7ec4c0d4afdbdd77f7b16618a0
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Aspid.MVVM/Packages/tech.aspid.mvvm/Tests/Editor/Converters/Strings/GenericToStringTests.cs
+++ b/Aspid.MVVM/Packages/tech.aspid.mvvm/Tests/Editor/Converters/Strings/GenericToStringTests.cs
@@ -1,0 +1,78 @@
+using System;
+using NUnit.Framework;
+
+namespace Aspid.MVVM.StarterKit.Tests
+{
+    /// <summary>
+    /// Coverage for <see cref="GenericToString{TFrom}"/> and its two sealed specialisations,
+    /// <see cref="ObjectToStringConverter"/> and <see cref="TimeSpanToStringConverter"/>.
+    /// </summary>
+    /// <remarks>
+    /// The format is a <b>composite</b> format string handed to <see cref="string.Format(string, object)"/>,
+    /// not a plain format specifier — <c>"F2"</c> is a literal, and a <see cref="TimeSpan"/> pattern has
+    /// to be wrapped as <c>{0:…}</c>. Both traps are pinned below because nothing in the API tells the
+    /// caller. Assertions stay culture-independent so the suite does not depend on the editor locale.
+    /// </remarks>
+    [TestFixture]
+    internal sealed class GenericToStringTests
+    {
+        [Test]
+        public void Convert_Null_ReturnsNull() =>
+            Assert.IsNull(new GenericToString<string>("{0}").Convert(null));
+
+        [Test]
+        public void Convert_NoFormat_FallsBackToToString() =>
+            Assert.AreEqual("42", new GenericToString<int>().Convert(42));
+
+        [TestCase("")]
+        [TestCase(" ")]
+        [TestCase("\t")]
+        public void Convert_BlankFormat_FallsBackToToString(string format) =>
+            Assert.AreEqual("42", new GenericToString<int>(format).Convert(42));
+
+        [Test]
+        public void Convert_NullFormat_FallsBackToToString() =>
+            Assert.AreEqual("42", new GenericToString<int>(null).Convert(42));
+
+        [Test]
+        public void Convert_Format_IsAppliedToTheTypedValue() =>
+            Assert.AreEqual("HP: 42", new GenericToString<int>("HP: {0}").Convert(42));
+
+        // A format specifier without a placeholder is a literal, not a specifier.
+        [Test]
+        public void Convert_FormatWithoutPlaceholder_ReturnsTheFormatVerbatim() =>
+            Assert.AreEqual("F2", new GenericToString<float>("F2").Convert(3.5f));
+
+        [Test]
+        [Ignore("Fixed in PR 4 — strings. An Inspector-authored format must not throw into the dispatch.")]
+        public void Convert_BrokenFormat_FallsBackToToStringInsteadOfThrowing() =>
+            Assert.AreEqual("42", new GenericToString<int>("{0}/{1}").Convert(42));
+
+        [Test]
+        [Ignore("Fixed in PR 4 — strings.")]
+        public void Convert_UnbalancedBrace_FallsBackToToStringInsteadOfThrowing() =>
+            Assert.AreEqual("42", new GenericToString<int>("HP: {0} {").Convert(42));
+
+        [Test]
+        public void ObjectToStringConverter_NoFormat_FallsBackToToString() =>
+            Assert.AreEqual("42", new ObjectToStringConverter().Convert(42));
+
+        [Test]
+        public void ObjectToStringConverter_Format_IsApplied() =>
+            Assert.AreEqual("HP: 42", new ObjectToStringConverter("HP: {0}").Convert(42));
+
+        [Test]
+        public void ObjectToStringConverter_Null_ReturnsNull() =>
+            Assert.IsNull(new ObjectToStringConverter("HP: {0}").Convert(null));
+
+        [Test]
+        public void TimeSpanToStringConverter_CompositeFormat_IsApplied() =>
+            Assert.AreEqual("05:05", new TimeSpanToStringConverter("{0:mm\\:ss}").Convert(TimeSpan.FromSeconds(305)));
+
+        // The obvious spelling — the one a TimeSpan.ToString() user reaches for — silently
+        // returns the pattern itself, because there is no placeholder to substitute into.
+        [Test]
+        public void TimeSpanToStringConverter_BareTimeSpanPattern_ReturnsThePatternVerbatim() =>
+            Assert.AreEqual("mm\\:ss", new TimeSpanToStringConverter("mm\\:ss").Convert(TimeSpan.FromSeconds(305)));
+    }
+}

--- a/Aspid.MVVM/Packages/tech.aspid.mvvm/Tests/Editor/Converters/Strings/GenericToStringTests.cs.meta
+++ b/Aspid.MVVM/Packages/tech.aspid.mvvm/Tests/Editor/Converters/Strings/GenericToStringTests.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: f4d953e8875ac4ebb8c2a1c9d27bdb8b

--- a/Aspid.MVVM/Packages/tech.aspid.mvvm/Tests/Editor/Converters/Strings/StringFormatConverterTests.cs
+++ b/Aspid.MVVM/Packages/tech.aspid.mvvm/Tests/Editor/Converters/Strings/StringFormatConverterTests.cs
@@ -1,0 +1,83 @@
+using NUnit.Framework;
+
+namespace Aspid.MVVM.StarterKit.Tests
+{
+    /// <summary>
+    /// Coverage for <see cref="StringFormatConverter"/> as a full truth table:
+    /// four input values × four format strings × both settings of <c>_formatEmptyValues</c>.
+    /// </summary>
+    /// <remarks>
+    /// Thirty-one of the thirty-two cells are asserted below. The missing one — a <see langword="null"/>
+    /// input with a real format and <c>_formatEmptyValues</c> on — is the behaviour that regressed when
+    /// the converter started inheriting <see cref="GenericToString{TFrom}"/>: the base returns early on
+    /// <see langword="null"/>, so the override never runs. It is asserted separately and stays
+    /// <c>[Ignore]</c>d until that is repaired.
+    /// </remarks>
+    [TestFixture]
+    internal sealed class StringFormatConverterTests
+    {
+        // A null input short-circuits before the format is ever consulted.
+        [TestCase(null, false, null)]
+        [TestCase("", false, null)]
+        [TestCase(" ", false, null)]
+        [TestCase("HP: {0}", false, null)]
+        [TestCase(null, true, null)]
+        [TestCase("", true, null)]
+        [TestCase(" ", true, null)]
+        public void Convert_NullValue_ReturnsNull(string format, bool formatEmptyValues, string expected) =>
+            Assert.AreEqual(expected, new StringFormatConverter(format, formatEmptyValues).Convert(null));
+
+        // A blank format is a no-op regardless of the value or the flag.
+        [TestCase(null, "", false, "")]
+        [TestCase(null, "  ", false, "  ")]
+        [TestCase(null, "abc", false, "abc")]
+        [TestCase(null, "", true, "")]
+        [TestCase(null, "  ", true, "  ")]
+        [TestCase(null, "abc", true, "abc")]
+        [TestCase("", "", false, "")]
+        [TestCase("", "  ", false, "  ")]
+        [TestCase("", "abc", false, "abc")]
+        [TestCase("", "", true, "")]
+        [TestCase("", "  ", true, "  ")]
+        [TestCase("", "abc", true, "abc")]
+        [TestCase(" ", "", false, "")]
+        [TestCase(" ", "  ", false, "  ")]
+        [TestCase(" ", "abc", false, "abc")]
+        [TestCase(" ", "", true, "")]
+        [TestCase(" ", "  ", true, "  ")]
+        [TestCase(" ", "abc", true, "abc")]
+        public void Convert_BlankFormat_ReturnsTheValueUnchanged(
+            string format,
+            string value,
+            bool formatEmptyValues,
+            string expected) =>
+            Assert.AreEqual(expected, new StringFormatConverter(format, formatEmptyValues).Convert(value));
+
+        // A real format applies to non-blank values always, and to blank values only when asked.
+        [TestCase("abc", false, "HP: abc")]
+        [TestCase("abc", true, "HP: abc")]
+        [TestCase("", false, "")]
+        [TestCase("", true, "HP: ")]
+        [TestCase("  ", false, "  ")]
+        [TestCase("  ", true, "HP:   ")]
+        public void Convert_RealFormat_HonoursFormatEmptyValues(
+            string value,
+            bool formatEmptyValues,
+            string expected) =>
+            Assert.AreEqual(expected, new StringFormatConverter("HP: {0}", formatEmptyValues).Convert(value));
+
+        [Test]
+        [Ignore("Fixed in PR 4 — strings. The inherited Convert returns early on null, so the override never runs.")]
+        public void Convert_NullValue_WithFormatEmptyValues_IsStillFormatted() =>
+            Assert.AreEqual("HP: ", new StringFormatConverter("HP: {0}", formatEmptyValues: true).Convert(null));
+
+        [Test]
+        public void DefaultConstructed_IsANoOp() =>
+            Assert.AreEqual("abc", new StringFormatConverter().Convert("abc"));
+
+        [Test]
+        [Ignore("Fixed in PR 4 — strings. An Inspector-authored format must not throw into the dispatch.")]
+        public void Convert_BrokenFormat_FallsBackToTheValueInsteadOfThrowing() =>
+            Assert.AreEqual("abc", new StringFormatConverter("{0}/{1}").Convert("abc"));
+    }
+}

--- a/Aspid.MVVM/Packages/tech.aspid.mvvm/Tests/Editor/Converters/Strings/StringFormatConverterTests.cs.meta
+++ b/Aspid.MVVM/Packages/tech.aspid.mvvm/Tests/Editor/Converters/Strings/StringFormatConverterTests.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 6e16a89ab54eb48b1b7d14d6ce30e26b

--- a/Aspid.MVVM/Packages/tech.aspid.mvvm/Tests/Editor/Converters/Vectors.meta
+++ b/Aspid.MVVM/Packages/tech.aspid.mvvm/Tests/Editor/Converters/Vectors.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 5e0599419be6a4dc5899173d7afd1362
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Aspid.MVVM/Packages/tech.aspid.mvvm/Tests/Editor/Converters/Vectors/Vector3CombineConverterTests.cs
+++ b/Aspid.MVVM/Packages/tech.aspid.mvvm/Tests/Editor/Converters/Vectors/Vector3CombineConverterTests.cs
@@ -1,0 +1,103 @@
+using UnityEngine;
+using NUnit.Framework;
+using Mode = Aspid.MVVM.StarterKit.Vector3CombineConverter.Mode;
+
+namespace Aspid.MVVM.StarterKit.Tests
+{
+    /// <summary>
+    /// Coverage for <see cref="Vector3CombineConverter"/> — all seven <see cref="Mode"/> branches,
+    /// the pre/post converter hooks, and both entry points (<c>Convert(Vector2)</c> and
+    /// <c>Convert(Vector3)</c>).
+    /// </summary>
+    /// <remarks>
+    /// The class is abstract, so the reference vector is supplied here by a stub rather than by a
+    /// scene component. The <c>Convert(Vector2)</c> row pins a known defect: the 2D entry point
+    /// widens its argument before the mode is applied, so the source z is always zero.
+    /// </remarks>
+    [TestFixture]
+    internal sealed class Vector3CombineConverterTests
+    {
+        private static readonly Vector3 From = new(1f, 2f, 3f);
+        private static readonly Vector3 To = new(10f, 20f, 30f);
+
+        [TestCase(Mode.X, 1f, 20f, 30f)]
+        [TestCase(Mode.Y, 10f, 2f, 30f)]
+        [TestCase(Mode.Z, 10f, 20f, 3f)]
+        [TestCase(Mode.XY, 1f, 2f, 30f)]
+        [TestCase(Mode.XZ, 1f, 20f, 3f)]
+        [TestCase(Mode.YZ, 10f, 2f, 3f)]
+        [TestCase(Mode.XYZ, 1f, 2f, 3f)]
+        public void Convert_Vector3_TakesTheNamedAxesFromTheInput(Mode mode, float x, float y, float z) =>
+            Assert.AreEqual(new Vector3(x, y, z), new Stub(To, mode).Convert(From));
+
+        [Test]
+        public void Convert_DefaultConstructed_UsesXyz() =>
+            Assert.AreEqual(From, new Stub(To).Convert(From));
+
+        // Known defect: Convert(Vector2) has no dedicated combine path, so the argument widens to
+        // (x, y, 0) before the mode runs and the source z is lost. Characterisation only — the fix
+        // changes existing scenes and is deliberately out of the Phase 0 batch.
+        [TestCase(Mode.XYZ, 1f, 2f, 0f)]
+        [TestCase(Mode.Z, 10f, 20f, 0f)]
+        [TestCase(Mode.XZ, 1f, 20f, 0f)]
+        [TestCase(Mode.XY, 1f, 2f, 30f)]
+        public void Convert_Vector2_WidensBeforeCombining(Mode mode, float x, float y, float z) =>
+            Assert.AreEqual(new Vector3(x, y, z), new Stub(To, mode).Convert(new Vector2(1f, 2f)));
+
+        [Test]
+        public void Convert_PreConverter_RunsBeforeTheModeSelection() =>
+            Assert.AreEqual(
+                new Vector3(2f, 20f, 30f),
+                new Stub(To, Mode.X, pre: new Offset(1f), post: null).Convert(From));
+
+        [Test]
+        public void Convert_PostConverter_RunsOnTheCombinedResult() =>
+            Assert.AreEqual(
+                new Vector3(2f, 21f, 31f),
+                new Stub(To, Mode.X, pre: null, post: new Offset(1f)).Convert(From));
+
+        [Test]
+        public void Convert_BothHooks_RunInOrder() =>
+            Assert.AreEqual(
+                new Vector3(3f, 21f, 31f),
+                new Stub(To, Mode.X, pre: new Offset(1f), post: new Offset(1f)).Convert(From));
+
+        [Test]
+        [Ignore("Fixed in PR 2 — null-guards. An unassigned Inspector reference must not throw.")]
+        public void Convert_MissingTarget_ReturnsTheInputUnchanged() =>
+            Assert.AreEqual(From, new MissingTargetStub(Mode.XYZ).Convert(From));
+
+        private sealed class Stub : Vector3CombineConverter
+        {
+            private readonly Vector3 _to;
+
+            public Stub(Vector3 to)
+                : base(Mode.XYZ) => _to = to;
+
+            public Stub(Vector3 to, Mode mode)
+                : base(mode) => _to = to;
+
+            public Stub(Vector3 to, Mode mode, IConverterVector3 pre, IConverterVector3 post)
+                : base(mode, pre, post) => _to = to;
+
+            protected override Vector3 VectorTo => _to;
+        }
+
+        private sealed class MissingTargetStub : Vector3CombineConverter
+        {
+            public MissingTargetStub(Mode mode)
+                : base(mode) { }
+
+            protected override Vector3 VectorTo => throw new System.NullReferenceException();
+        }
+
+        private sealed class Offset : IConverterVector3
+        {
+            private readonly float _amount;
+
+            public Offset(float amount) => _amount = amount;
+
+            public Vector3 Convert(Vector3 value) => value + Vector3.one * _amount;
+        }
+    }
+}

--- a/Aspid.MVVM/Packages/tech.aspid.mvvm/Tests/Editor/Converters/Vectors/Vector3CombineConverterTests.cs.meta
+++ b/Aspid.MVVM/Packages/tech.aspid.mvvm/Tests/Editor/Converters/Vectors/Vector3CombineConverterTests.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 77793bef309f24f79bbe81dda14c0979

--- a/Aspid.MVVM/Packages/tech.aspid.mvvm/Tests/Editor/Converters/Vectors/VectorDimensionConverterTests.cs
+++ b/Aspid.MVVM/Packages/tech.aspid.mvvm/Tests/Editor/Converters/Vectors/VectorDimensionConverterTests.cs
@@ -1,0 +1,63 @@
+using UnityEngine;
+using NUnit.Framework;
+using To2 = Aspid.MVVM.StarterKit.Vector3ToVector2Converter.Values;
+using To3 = Aspid.MVVM.StarterKit.Vector2ToVector3Converter.Values;
+
+namespace Aspid.MVVM.StarterKit.Tests
+{
+    /// <summary>
+    /// Coverage for the dimension-changing pair, <see cref="Vector3ToVector2Converter"/> and
+    /// <see cref="Vector2ToVector3Converter"/>.
+    /// </summary>
+    /// <remarks>
+    /// The pair does not round-trip: the 3→2 direction offers all six orderings, the 2→3 direction
+    /// only three. The member names of <see cref="Vector2ToVector3Converter.Values"/> also name the
+    /// <i>destination</i> axes rather than the source components, which is why every mapping is
+    /// spelled out below.
+    /// </remarks>
+    [TestFixture]
+    internal sealed class VectorDimensionConverterTests
+    {
+        [TestCase(To2.XY, 1f, 2f)]
+        [TestCase(To2.XZ, 1f, 3f)]
+        [TestCase(To2.YX, 2f, 1f)]
+        [TestCase(To2.YZ, 2f, 3f)]
+        [TestCase(To2.ZX, 3f, 1f)]
+        [TestCase(To2.ZY, 3f, 2f)]
+        public void Vector3ToVector2_Convert_SelectsComponents(To2 values, float x, float y) =>
+            Assert.AreEqual(
+                new Vector2(x, y),
+                new Vector3ToVector2Converter(values).Convert(new Vector3(1f, 2f, 3f)));
+
+        [Test]
+        public void Vector3ToVector2_DefaultConstructed_TakesXY() =>
+            Assert.AreEqual(
+                new Vector2(1f, 2f),
+                new Vector3ToVector2Converter().Convert(new Vector3(1f, 2f, 3f)));
+
+        // The constant lands in the axis the name omits: XY puts it in z, XZ in y, YZ in x.
+        [TestCase(To3.XY, 1f, 2f, 9f)]
+        [TestCase(To3.XZ, 1f, 9f, 2f)]
+        [TestCase(To3.YZ, 9f, 1f, 2f)]
+        public void Vector2ToVector3_Convert_PlacesTheConstantInTheMissingAxis(
+            To3 values,
+            float x,
+            float y,
+            float z) =>
+            Assert.AreEqual(
+                new Vector3(x, y, z),
+                new Vector2ToVector3Converter(values, thirdValue: 9f).Convert(new Vector2(1f, 2f)));
+
+        [Test]
+        public void Vector2ToVector3_DefaultThirdValue_IsZero() =>
+            Assert.AreEqual(
+                new Vector3(1f, 2f, 0f),
+                new Vector2ToVector3Converter(To3.XY).Convert(new Vector2(1f, 2f)));
+
+        [Test]
+        public void Vector2ToVector3_DefaultConstructed_TakesXY() =>
+            Assert.AreEqual(
+                new Vector3(1f, 2f, 0f),
+                new Vector2ToVector3Converter().Convert(new Vector2(1f, 2f)));
+    }
+}

--- a/Aspid.MVVM/Packages/tech.aspid.mvvm/Tests/Editor/Converters/Vectors/VectorDimensionConverterTests.cs.meta
+++ b/Aspid.MVVM/Packages/tech.aspid.mvvm/Tests/Editor/Converters/Vectors/VectorDimensionConverterTests.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 082a0ac84ffb549cbbcfcbfd5de9dcf2

--- a/Aspid.MVVM/Packages/tech.aspid.mvvm/Tests/Editor/Converters/Vectors/VectorSubstitutionConverterTests.cs
+++ b/Aspid.MVVM/Packages/tech.aspid.mvvm/Tests/Editor/Converters/Vectors/VectorSubstitutionConverterTests.cs
@@ -1,0 +1,69 @@
+using UnityEngine;
+using NUnit.Framework;
+using V2Mode = Aspid.MVVM.StarterKit.Vector2SubstitutionConverter.Mode;
+using V3Mode = Aspid.MVVM.StarterKit.Vector3SubstitutionConverter.Mode;
+
+namespace Aspid.MVVM.StarterKit.Tests
+{
+    /// <summary>
+    /// Exhaustive coverage for <see cref="Vector3SubstitutionConverter"/> (all 27 modes) and
+    /// <see cref="Vector2SubstitutionConverter"/> (all 4) — one row per enum member, so a mis-mapped
+    /// component cannot pass unnoticed.
+    /// </summary>
+    [TestFixture]
+    internal sealed class VectorSubstitutionConverterTests
+    {
+        [TestCase(V3Mode.XYZ, 1f, 2f, 3f)]
+        [TestCase(V3Mode.XZY, 1f, 3f, 2f)]
+        [TestCase(V3Mode.YXZ, 2f, 1f, 3f)]
+        [TestCase(V3Mode.YZX, 2f, 3f, 1f)]
+        [TestCase(V3Mode.ZXY, 3f, 1f, 2f)]
+        [TestCase(V3Mode.ZYX, 3f, 2f, 1f)]
+        [TestCase(V3Mode.XXY, 1f, 1f, 2f)]
+        [TestCase(V3Mode.XYX, 1f, 2f, 1f)]
+        [TestCase(V3Mode.YXX, 2f, 1f, 1f)]
+        [TestCase(V3Mode.XXZ, 1f, 1f, 3f)]
+        [TestCase(V3Mode.XZX, 1f, 3f, 1f)]
+        [TestCase(V3Mode.ZXX, 3f, 1f, 1f)]
+        [TestCase(V3Mode.YYX, 2f, 2f, 1f)]
+        [TestCase(V3Mode.YXY, 2f, 1f, 2f)]
+        [TestCase(V3Mode.XYY, 1f, 2f, 2f)]
+        [TestCase(V3Mode.YYZ, 2f, 2f, 3f)]
+        [TestCase(V3Mode.YZY, 2f, 3f, 2f)]
+        [TestCase(V3Mode.ZYY, 3f, 2f, 2f)]
+        [TestCase(V3Mode.ZZX, 3f, 3f, 1f)]
+        [TestCase(V3Mode.ZXZ, 3f, 1f, 3f)]
+        [TestCase(V3Mode.XZZ, 1f, 3f, 3f)]
+        [TestCase(V3Mode.ZZY, 3f, 3f, 2f)]
+        [TestCase(V3Mode.ZYZ, 3f, 2f, 3f)]
+        [TestCase(V3Mode.YZZ, 2f, 3f, 3f)]
+        [TestCase(V3Mode.XXX, 1f, 1f, 1f)]
+        [TestCase(V3Mode.YYY, 2f, 2f, 2f)]
+        [TestCase(V3Mode.ZZZ, 3f, 3f, 3f)]
+        public void Vector3_Convert_RearrangesComponents(V3Mode mode, float x, float y, float z) =>
+            Assert.AreEqual(
+                new Vector3(x, y, z),
+                new Vector3SubstitutionConverter(mode).Convert(new Vector3(1f, 2f, 3f)));
+
+        [Test]
+        public void Vector3_DefaultConstructed_IsIdentity() =>
+            Assert.AreEqual(
+                new Vector3(1f, 2f, 3f),
+                new Vector3SubstitutionConverter().Convert(new Vector3(1f, 2f, 3f)));
+
+        [TestCase(V2Mode.XY, 1f, 2f)]
+        [TestCase(V2Mode.YX, 2f, 1f)]
+        [TestCase(V2Mode.YY, 2f, 2f)]
+        [TestCase(V2Mode.XX, 1f, 1f)]
+        public void Vector2_Convert_RearrangesComponents(V2Mode mode, float x, float y) =>
+            Assert.AreEqual(
+                new Vector2(x, y),
+                new Vector2SubstitutionConverter(mode).Convert(new Vector2(1f, 2f)));
+
+        [Test]
+        public void Vector2_DefaultConstructed_IsIdentity() =>
+            Assert.AreEqual(
+                new Vector2(1f, 2f),
+                new Vector2SubstitutionConverter().Convert(new Vector2(1f, 2f)));
+    }
+}

--- a/Aspid.MVVM/Packages/tech.aspid.mvvm/Tests/Editor/Converters/Vectors/VectorSubstitutionConverterTests.cs.meta
+++ b/Aspid.MVVM/Packages/tech.aspid.mvvm/Tests/Editor/Converters/Vectors/VectorSubstitutionConverterTests.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: a2ea393a04b7c487687b4d7a32fc7bea


### PR DESCRIPTION
✅ First of a 7-PR stack working through Phase 0 of the converter audit. No production code — it puts a net under the six PRs that follow.

## Summary

- ✅ `Tests/Editor/` with `Aspid.MVVM.StarterKit.Tests.asmdef`, mirroring the FastTools package layout; no `manifest.json` or `package.json` change is needed.
- ✅ **166 characterisation tests** pinning behaviour as it is today, exhaustive where a silent mis-mapping costs most: all 27 `Vector3SubstitutionConverter` modes, all 7 combine modes, six `Comparisons` across four numeric overloads, and the full 4×4×2 truth table of `StringFormatConverter`.
- ⚠️ 10 tests are `[Ignore]`d, each naming the PR that will enable it — the audit's confirmed defects written as the behaviour we want.

## Notes for review

- ⚠️ Some tests lock in behaviour that is wrong (`2_000_000 == 2_000_001` under `Comparisons.Equal`; the source `z` lost in `Convert_Vector2`); both are tracked defects whose fix changes existing scenes, and a comment above each says so.
- 📝 Two undocumented traps are now pinned: the format field is a *composite* format string, so `"F2"` comes back literally, and a `TimeSpan` pattern only works wrapped as `{0:mm\:ss}`.
- ✅ Local run: 166 total, 156 passed, 0 failed, 10 skipped. CI does not run Unity tests today.

<details>
<summary>🇷🇺 Описание на русском</summary>

✅ Первый PR из стека в 7 штук по Фазе 0 аудита конвертеров. Продакшн-кода нет — кладёт сеть под шесть следующих PR.

## Итог

- ✅ `Tests/Editor/` с `Aspid.MVVM.StarterKit.Tests.asmdef` по раскладке пакета FastTools; правки `manifest.json` и `package.json` не нужны.
- ✅ **166 характеризационных тестов** фиксируют поведение как оно есть сейчас, исчерпывающе там, где молчаливая ошибка маппинга стоит дороже всего: все 27 режимов `Vector3SubstitutionConverter`, все 7 режимов combine, шесть `Comparisons` на четырёх числовых перегрузках и полная таблица истинности 4×4×2 для `StringFormatConverter`.
- ⚠️ 10 тестов помечены `[Ignore]`, каждый называет PR, который его включит, — подтверждённые дефекты аудита, записанные как желаемое поведение.

## Заметки для ревью

- ⚠️ Часть тестов фиксирует заведомо неверное поведение (`2_000_000 == 2_000_001` при `Comparisons.Equal`; потеря `z` в `Convert_Vector2`); оба дефекта отслеживаются, их исправление меняет существующие сцены, и над каждым стоит комментарий.
- 📝 Зафиксированы две ловушки, о которых API молчит: поле формата — *composite* format string, поэтому `"F2"` возвращается литералом, а паттерн `TimeSpan` работает только обёрнутым в `{0:mm\:ss}`.
- ✅ Локальный прогон: 166 всего, 156 прошло, 0 упало, 10 пропущено. Unity-тесты в CI сейчас не гоняются.

</details>
