### PR TITLE
fix(starterkit): hide the remaining code-only converters from the picker

### DIFF
--- a/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Runtime/Converters/Specific/Numbers/NumberConverterSpecificExtensions.cs
+++ b/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Runtime/Converters/Specific/Numbers/NumberConverterSpecificExtensions.cs
@@ -237,6 +237,7 @@ namespace Aspid.MVVM.StarterKit
         #endregion
         
         #region Double Classes
+        [TypeSelectorDisplay(Hidden = true)]
         private sealed class ConverterDoubleToInt : GenericFuncConverter<double, int>, IConverterDoubleToInt
         {
             public ConverterDoubleToInt(IConverter<double, int> converter) 
@@ -246,6 +247,7 @@ namespace Aspid.MVVM.StarterKit
                 : base(converter) { }
         }
         
+        [TypeSelectorDisplay(Hidden = true)]
         private sealed class ConverterDoubleToLong : GenericFuncConverter<double, long>, IConverterDoubleToLong
         {
             public ConverterDoubleToLong(IConverter<double, long> converter) 
@@ -255,6 +257,7 @@ namespace Aspid.MVVM.StarterKit
                 : base(converter) { }
         }
         
+        [TypeSelectorDisplay(Hidden = true)]
         private sealed class ConverterDoubleToFloat : GenericFuncConverter<double, float>, IConverterDoubleToFloat
         {
             public ConverterDoubleToFloat(IConverter<double, float> converter) 
@@ -264,6 +267,7 @@ namespace Aspid.MVVM.StarterKit
                 : base(converter) { }
         }
         
+        [TypeSelectorDisplay(Hidden = true)]
         private sealed class ConverterDouble : GenericFuncConverter<double, double>, IConverterDouble
         {
             public ConverterDouble(IConverter<double, double> converter) 

--- a/Aspid.MVVM/Packages/tech.aspid.mvvm/Tests/Editor/Aspid.MVVM.StarterKit.Tests.asmdef
+++ b/Aspid.MVVM/Packages/tech.aspid.mvvm/Tests/Editor/Aspid.MVVM.StarterKit.Tests.asmdef
@@ -6,7 +6,8 @@
         "UnityEditor.TestRunner",
         "Aspid.MVVM",
         "Aspid.MVVM.StarterKit",
-        "Aspid.MVVM.StarterKit.Unity"
+        "Aspid.MVVM.StarterKit.Unity",
+        "Aspid.FastTools.Unity"
     ],
     "includePlatforms": [
         "Editor"

--- a/Aspid.MVVM/Packages/tech.aspid.mvvm/Tests/Editor/Converters/ConverterPickerContractTests.cs
+++ b/Aspid.MVVM/Packages/tech.aspid.mvvm/Tests/Editor/Converters/ConverterPickerContractTests.cs
@@ -1,0 +1,112 @@
+using System;
+using System.Linq;
+using System.Text;
+using System.Reflection;
+using NUnit.Framework;
+using Aspid.FastTools.Types;
+using System.Collections.Generic;
+
+namespace Aspid.MVVM.StarterKit.Tests
+{
+    /// <summary>
+    /// Contract between the shipped converters and the <c>[SerializeReference]</c> type picker:
+    /// a type the picker cannot construct must not be offered.
+    /// </summary>
+    /// <remarks>
+    /// The picker instantiates a chosen type through <see cref="Activator"/> and, when that fails,
+    /// through <c>FormatterServices.GetUninitializedObject</c> — which skips field initialisers and
+    /// leaves a delegate-backed adapter with a null delegate. Nothing in the picker filters by
+    /// accessibility or by constructor availability, so the guard has to live on the type itself as
+    /// <c>[TypeSelectorDisplay(Hidden = true)]</c>. Enumerating the assemblies here catches the next
+    /// adapter somebody adds without it.
+    /// </remarks>
+    [TestFixture]
+    internal sealed class ConverterPickerContractTests
+    {
+        [Test]
+        public void EveryConverterWithoutAParameterlessConstructor_IsHiddenFromThePicker()
+        {
+            var offenders = ConverterTypes()
+                .Where(type => !HasParameterlessConstructor(type))
+                .Where(type => !IsHidden(type))
+                .ToArray();
+
+            Assert.IsEmpty(offenders, Explain(offenders));
+        }
+
+        [Test]
+        public void EveryConverterTheInspectorCanAuthor_IsVisibleInThePicker()
+        {
+            var hidden = ConverterTypes()
+                .Where(HasParameterlessConstructor)
+                .Where(IsHidden)
+                .ToArray();
+
+            Assert.IsEmpty(
+                hidden,
+                "These converters can be constructed by the picker but are hidden from it. "
+                + "If that is intentional the exclusion belongs in this test:"
+                + Environment.NewLine
+                + string.Join(Environment.NewLine, hidden.Select(t => "  - " + t.FullName)));
+        }
+
+        // Guards against the two tests above passing vacuously: both are "no offenders" assertions,
+        // so if the scan ever stopped seeing the private adapters — a changed namespace, an assembly
+        // rename, an attribute the compiler stopped emitting — they would go green while the picker
+        // filled back up with types it cannot construct.
+        [Test]
+        public void TheScanSeesBothPopulationsItGuards()
+        {
+            var types = ConverterTypes().ToArray();
+
+            Assert.That(types.Length, Is.GreaterThan(30), "converter types found");
+            Assert.That(
+                types.Count(t => !HasParameterlessConstructor(t)),
+                Is.GreaterThan(20),
+                "converters the picker cannot construct — the population the hidden-check guards");
+            Assert.That(types.Count(IsHidden), Is.GreaterThan(20), "converters carrying the attribute");
+        }
+
+        private static IEnumerable<Type> ConverterTypes() => Assemblies()
+            .SelectMany(assembly => assembly.GetTypes())
+            .Where(type => !type.IsInterface && !type.IsAbstract)
+            .Where(ImplementsConverter);
+
+        private static IEnumerable<Assembly> Assemblies() => new[]
+        {
+            typeof(IConverter<,>).Assembly,
+            typeof(IConverterVector3).Assembly,
+        }.Distinct();
+
+        private static bool ImplementsConverter(Type type) => type
+            .GetInterfaces()
+            .Any(i => i.IsGenericType && i.GetGenericTypeDefinition() == typeof(IConverter<,>));
+
+        // The picker calls Activator.CreateInstance(type, nonPublic: true), so a private or
+        // protected parameterless constructor is enough to make a type constructible.
+        private static bool HasParameterlessConstructor(Type type) => type.GetConstructor(
+            BindingFlags.Instance | BindingFlags.Public | BindingFlags.NonPublic,
+            binder: null,
+            Type.EmptyTypes,
+            modifiers: null) is not null;
+
+        private static bool IsHidden(Type type) =>
+            type.GetCustomAttribute<TypeSelectorDisplayAttribute>(inherit: false)?.Hidden is true;
+
+        private static string Explain(IReadOnlyCollection<Type> offenders)
+        {
+            if (offenders.Count == 0) return string.Empty;
+
+            var message = new StringBuilder()
+                .AppendLine("These converters have no parameterless constructor, so picking one from the")
+                .AppendLine("Inspector yields an instance with null fields and throws on the first push.")
+                .AppendLine("Mark each with [TypeSelectorDisplay(Hidden = true)]:")
+                .AppendLine();
+
+            foreach (var type in offenders)
+                message.Append("  - ").AppendLine(type.FullName);
+
+            return message.ToString();
+        }
+    }
+}

--- a/Aspid.MVVM/Packages/tech.aspid.mvvm/Tests/Editor/Converters/ConverterPickerContractTests.cs
+++ b/Aspid.MVVM/Packages/tech.aspid.mvvm/Tests/Editor/Converters/ConverterPickerContractTests.cs
@@ -13,12 +13,10 @@ namespace Aspid.MVVM.StarterKit.Tests
     /// a type the picker cannot construct must not be offered.
     /// </summary>
     /// <remarks>
-    /// The picker instantiates a chosen type through <see cref="Activator"/> and, when that fails,
-    /// through <c>FormatterServices.GetUninitializedObject</c> — which skips field initialisers and
-    /// leaves a delegate-backed adapter with a null delegate. Nothing in the picker filters by
-    /// accessibility or by constructor availability, so the guard has to live on the type itself as
-    /// <c>[TypeSelectorDisplay(Hidden = true)]</c>. Enumerating the assemblies here catches the next
-    /// adapter somebody adds without it.
+    /// The picker falls back to <c>FormatterServices.GetUninitializedObject</c> when
+    /// <see cref="Activator"/> fails, which skips field initialisers and leaves a delegate-backed
+    /// adapter with a null delegate. It filters by neither accessibility nor constructor, so the
+    /// guard has to live on the type as <c>[TypeSelectorDisplay(Hidden = true)]</c>.
     /// </remarks>
     [TestFixture]
     internal sealed class ConverterPickerContractTests

--- a/Aspid.MVVM/Packages/tech.aspid.mvvm/Tests/Editor/Converters/ConverterPickerContractTests.cs.meta
+++ b/Aspid.MVVM/Packages/tech.aspid.mvvm/Tests/Editor/Converters/ConverterPickerContractTests.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 20776468795af496da2439faf0f73713


### PR DESCRIPTION
🐛 Third of the Phase 0 stack. #133 hid the `Int`/`Long`/`Float` adapter regions from the type picker but missed `Double`, and `[TypeSelectorDisplay]` declares `Inherited = false` — so picking one of the four stragglers still produced an instance with a null delegate.

## Summary

- 🐛 `[TypeSelectorDisplay(Hidden = true)]` on `ConverterDoubleToInt`, `ConverterDoubleToLong`, `ConverterDoubleToFloat` and `ConverterDouble`.
- ✅ `ConverterPickerContractTests` — a reflection contract over both StarterKit assemblies: what the picker cannot construct must not be offered, what it can must stay visible.
- 🔧 The test asmdef gains a reference to `Aspid.FastTools.Unity` to read the attribute.

## Notes for review

- ✅ The contract pins the scanned population sizes, so neither "no offenders" assertion can pass vacuously after a rename or assembly split.
- 📝 Constructibility matches the picker exactly — `Activator.CreateInstance(type, nonPublic: true)`, so private parameterless constructors count.
- ✅ Local run: 170 total, 164 passed, 0 failed, 6 skipped.

<details>
<summary>🇷🇺 Описание на русском</summary>

🐛 Третий PR стека Фазы 0. #133 скрыл из пикера регионы адаптеров `Int`/`Long`/`Float`, но пропустил `Double`, а `[TypeSelectorDisplay]` объявлен с `Inherited = false` — поэтому выбор одного из четырёх оставшихся по-прежнему давал экземпляр с null-делегатом.

## Итог

- 🐛 `[TypeSelectorDisplay(Hidden = true)]` на `ConverterDoubleToInt`, `ConverterDoubleToLong`, `ConverterDoubleToFloat` и `ConverterDouble`.
- ✅ `ConverterPickerContractTests` — рефлексивный контракт по обеим сборкам StarterKit: что пикер не может сконструировать — не должно предлагаться, что может — должно остаться видимым.
- 🔧 asmdef тестов получает ссылку на `Aspid.FastTools.Unity`, чтобы читать атрибут.

## Заметки для ревью

- ✅ Контракт фиксирует размеры сканируемых популяций, поэтому проверки «нарушителей нет» не пройдут вхолостую после переименования или разделения сборки.
- 📝 Конструируемость совпадает с пикером точь-в-точь — `Activator.CreateInstance(type, nonPublic: true)`, то есть приватные конструкторы без параметров считаются.
- ✅ Локальный прогон: 170 всего, 164 прошло, 0 упало, 6 пропущено.

</details>
