### PR TITLE
fix(starterkit): contain format failures and restore null formatting

### DIFF
--- a/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Runtime/Converters/Strings/GenericToString.cs
+++ b/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Runtime/Converters/Strings/GenericToString.cs
@@ -9,30 +9,21 @@ namespace Aspid.MVVM.StarterKit
     /// </summary>
     /// <typeparam name="TFrom">The type of the value to convert.</typeparam>
     /// <remarks>
-    /// The format is a <b>composite</b> format string, so it needs a placeholder: <c>"{0:F2}"</c>
-    /// formats the value, while <c>"F2"</c> is a literal that comes back unchanged. A format the
-    /// Inspector cannot validate is treated as a configuration mistake, not a failure: the converter
-    /// reports it once and falls back to <see cref="object.ToString"/> rather than throwing into the
-    /// binder that pushed the value.
+    /// The format is a <b>composite</b> format string: <c>"{0:F2}"</c> formats the value, while
+    /// <c>"F2"</c> is a literal. Exceptions from <see cref="Format"/> are routed to
+    /// <see cref="HandleFormatError"/>, which by default logs the error and falls back to
+    /// <see cref="object.ToString"/> instead of throwing into the binder.
     /// </remarks>
     [Serializable]
     public class GenericToString<TFrom> : IConverter<TFrom?, string?>
     {
         [SerializeField] private string? _format;
 
-        [NonSerialized] private bool _loggedFormatFailure;
-
-        /// <summary>
-        /// Initializes a new instance of the <see cref="GenericToString{TFrom}"/> class with no formatting.
-        /// </summary>
         public GenericToString()
         {
             _format = string.Empty;
         }
 
-        /// <summary>
-        /// Initializes a new instance of the <see cref="GenericToString{TFrom}"/> class.
-        /// </summary>
         /// <param name="format">The format string to apply using <see cref="string.Format(string, object)"/>.</param>
         public GenericToString(string format)
         {
@@ -61,11 +52,23 @@ namespace Aspid.MVVM.StarterKit
             {
                 return Format(value);
             }
-            catch (FormatException exception)
+            catch (Exception exception)
             {
-                LogFormatFailure(exception);
-                return value.ToString();
+                return HandleFormatError(value, exception);
             }
+        }
+
+        /// <summary>
+        /// Called when <see cref="Format"/> throws. Override to substitute a different fallback
+        /// value or rethrow when the failure should not be swallowed.
+        /// </summary>
+        /// <param name="value">The non-null value that failed to format.</param>
+        /// <param name="exception">The exception thrown by <see cref="Format"/>.</param>
+        /// <returns>The fallback string, which is <see cref="object.ToString"/> by default.</returns>
+        protected virtual string? HandleFormatError(TFrom value, Exception exception)
+        {
+            Debug.LogError($"{GetType().Name}: format string \"{_format}\" is invalid or threw ({exception.Message}). Falling back to ToString().");
+            return value.ToString();
         }
 
         /// <summary>
@@ -76,15 +79,5 @@ namespace Aspid.MVVM.StarterKit
         /// <returns>The formatted string.</returns>
         protected virtual string Format(TFrom value) =>
             string.Format(_format, value);
-
-        private void LogFormatFailure(FormatException exception)
-        {
-            if (_loggedFormatFailure) return;
-            _loggedFormatFailure = true;
-
-            Debug.LogError(
-                $"{GetType().Name}: format string \"{_format}\" is invalid ({exception.Message}). "
-                + "Falling back to ToString().");
-        }
     }
 }

--- a/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Runtime/Converters/Strings/GenericToString.cs
+++ b/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Runtime/Converters/Strings/GenericToString.cs
@@ -1,6 +1,5 @@
 using System;
 using UnityEngine;
-using System.Diagnostics.CodeAnalysis;
 
 // ReSharper disable once CheckNamespace
 namespace Aspid.MVVM.StarterKit
@@ -9,16 +8,31 @@ namespace Aspid.MVVM.StarterKit
     /// Generic converter that transforms values to strings with optional formatting.
     /// </summary>
     /// <typeparam name="TFrom">The type of the value to convert.</typeparam>
+    /// <remarks>
+    /// The format is a <b>composite</b> format string, so it needs a placeholder: <c>"{0:F2}"</c>
+    /// formats the value, while <c>"F2"</c> is a literal that comes back unchanged. A format the
+    /// Inspector cannot validate is treated as a configuration mistake, not a failure: the converter
+    /// reports it once and falls back to <see cref="object.ToString"/> rather than throwing into the
+    /// binder that pushed the value.
+    /// </remarks>
     [Serializable]
     public class GenericToString<TFrom> : IConverter<TFrom?, string?>
     {
         [SerializeField] private string? _format;
-        
+
+        [NonSerialized] private bool _loggedFormatFailure;
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="GenericToString{TFrom}"/> class with no formatting.
+        /// </summary>
         public GenericToString()
         {
             _format = string.Empty;
         }
 
+        /// <summary>
+        /// Initializes a new instance of the <see cref="GenericToString{TFrom}"/> class.
+        /// </summary>
         /// <param name="format">The format string to apply using <see cref="string.Format(string, object)"/>.</param>
         public GenericToString(string format)
         {
@@ -26,19 +40,51 @@ namespace Aspid.MVVM.StarterKit
         }
 
         /// <summary>
+        /// Gets the configured composite format string, or <see langword="null"/> when none is set.
+        /// </summary>
+        protected string? FormatString => _format;
+
+        /// <summary>
         /// Converts the specified value to a string using the configured format.
         /// </summary>
         /// <param name="value">The value to convert.</param>
-        /// <returns>The string representation of the value, or <c>null</c> if the value is <c>null</c>.</returns>
-        public string? Convert(TFrom? value)
+        /// <returns>
+        /// The string representation of the value; <see langword="null"/> if the value is
+        /// <see langword="null"/>, and <see cref="object.ToString"/> if the format is blank or invalid.
+        /// </returns>
+        public virtual string? Convert(TFrom? value)
         {
             if (value is null) return null;
             if (string.IsNullOrWhiteSpace(_format)) return value.ToString();
-            
-            return Format(value);
+
+            try
+            {
+                return Format(value);
+            }
+            catch (FormatException exception)
+            {
+                LogFormatFailure(exception);
+                return value.ToString();
+            }
         }
-        
-        protected virtual string Format(TFrom value) => 
+
+        /// <summary>
+        /// Applies the configured format to a non-null value. Called only when the format is not blank;
+        /// override to change how the format is applied.
+        /// </summary>
+        /// <param name="value">The non-null value to format.</param>
+        /// <returns>The formatted string.</returns>
+        protected virtual string Format(TFrom value) =>
             string.Format(_format, value);
+
+        private void LogFormatFailure(FormatException exception)
+        {
+            if (_loggedFormatFailure) return;
+            _loggedFormatFailure = true;
+
+            Debug.LogError(
+                $"{GetType().Name}: format string \"{_format}\" is invalid ({exception.Message}). "
+                + "Falling back to ToString().");
+        }
     }
 }

--- a/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Runtime/Converters/Strings/ObjectToStringConverter.cs
+++ b/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Runtime/Converters/Strings/ObjectToStringConverter.cs
@@ -4,13 +4,19 @@ using System;
 namespace Aspid.MVVM.StarterKit
 {
     /// <summary>
-    /// Converts any object to its string representation with optional formatting.
+    /// <see cref="GenericToString{TFrom}"/> for any object, with optional formatting.
     /// </summary>
     [Serializable]
     public sealed class ObjectToStringConverter : GenericToString<object?>, IConverterObjectToString
     {
+        /// <summary>
+        /// Initializes a new instance of the <see cref="ObjectToStringConverter"/> class with no formatting.
+        /// </summary>
         public ObjectToStringConverter() { }
-        
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="ObjectToStringConverter"/> class.
+        /// </summary>
         /// <param name="format">The format string to apply using <see cref="string.Format(string, object)"/>.</param>
         public ObjectToStringConverter(string format)
             : base(format) { }

--- a/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Runtime/Converters/Strings/ObjectToStringConverter.cs
+++ b/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Runtime/Converters/Strings/ObjectToStringConverter.cs
@@ -9,14 +9,8 @@ namespace Aspid.MVVM.StarterKit
     [Serializable]
     public sealed class ObjectToStringConverter : GenericToString<object?>, IConverterObjectToString
     {
-        /// <summary>
-        /// Initializes a new instance of the <see cref="ObjectToStringConverter"/> class with no formatting.
-        /// </summary>
         public ObjectToStringConverter() { }
 
-        /// <summary>
-        /// Initializes a new instance of the <see cref="ObjectToStringConverter"/> class.
-        /// </summary>
         /// <param name="format">The format string to apply using <see cref="string.Format(string, object)"/>.</param>
         public ObjectToStringConverter(string format)
             : base(format) { }

--- a/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Runtime/Converters/Strings/StringFormatConverter.cs
+++ b/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Runtime/Converters/Strings/StringFormatConverter.cs
@@ -37,8 +37,7 @@ namespace Aspid.MVVM.StarterKit
         /// The base class short-circuits on <see langword="null"/> before <see cref="Format"/> is
         /// reached, so covering null takes substituting an empty string ahead of it.
         /// </remarks>
-        public override string? Convert(string? value) =>
-            value is null && _formatEmptyValues && !string.IsNullOrWhiteSpace(FormatString)
+        public override string? Convert(string? value) => value is null && _formatEmptyValues && !string.IsNullOrWhiteSpace(FormatString)
                 ? base.Convert(string.Empty)
                 : base.Convert(value);
 

--- a/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Runtime/Converters/Strings/StringFormatConverter.cs
+++ b/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Runtime/Converters/Strings/StringFormatConverter.cs
@@ -5,25 +5,57 @@ using UnityEngine;
 namespace Aspid.MVVM.StarterKit
 {
     /// <summary>
-    /// Converts string values by applying a format string with optional handling of empty values.
+    /// <see cref="GenericToString{TFrom}"/> for strings, with optional handling of empty values.
     /// </summary>
+    /// <remarks>
+    /// By default a blank input passes through unformatted, so a label bound to an empty field stays
+    /// empty rather than showing the surrounding text with a hole in it. Set
+    /// <c>_formatEmptyValues</c> to format blank and <see langword="null"/> input as well.
+    /// </remarks>
     [Serializable]
     public class StringFormatConverter : GenericToString<string>, IConverterString
     {
         [SerializeField] private bool _formatEmptyValues;
 
+        /// <summary>
+        /// Initializes a new instance of the <see cref="StringFormatConverter"/> class with no formatting.
+        /// </summary>
         public StringFormatConverter() { }
 
+        /// <summary>
+        /// Initializes a new instance of the <see cref="StringFormatConverter"/> class.
+        /// </summary>
         /// <param name="format">The format string to apply using <see cref="string.Format(string, object)"/>.</param>
-        /// <param name="formatEmptyValues">If <c>true</c>, applies the format even when the input value is empty or whitespace-only. Default is <c>false</c>.</param>
+        /// <param name="formatEmptyValues">If <see langword="true"/>, applies the format even when the input value is null, empty or whitespace-only. Default is <see langword="false"/>.</param>
         public StringFormatConverter(string format, bool formatEmptyValues = false)
             : base(format)
         {
             _formatEmptyValues = formatEmptyValues;
         }
 
-        protected override string Format(string value) => _formatEmptyValues || !string.IsNullOrWhiteSpace(value) 
-            ? base.Format(value)
-            : value;
+        /// <summary>
+        /// Converts the specified string, formatting <see langword="null"/> as empty when
+        /// <c>_formatEmptyValues</c> is set.
+        /// </summary>
+        /// <param name="value">The value to convert.</param>
+        /// <returns>The formatted string, or the value unchanged when the format does not apply.</returns>
+        /// <remarks>
+        /// The base class short-circuits on <see langword="null"/> before <see cref="Format"/> is
+        /// reached, so covering null takes substituting an empty string ahead of it.
+        /// </remarks>
+        public override string? Convert(string? value) =>
+            value is null && _formatEmptyValues && !string.IsNullOrWhiteSpace(FormatString)
+                ? base.Convert(string.Empty)
+                : base.Convert(value);
+
+        /// <summary>
+        /// Applies the format unless the value is blank and blank values are not being formatted.
+        /// </summary>
+        /// <param name="value">The non-null value to format.</param>
+        /// <returns>The formatted string, or the value unchanged.</returns>
+        protected override string Format(string value) =>
+            _formatEmptyValues || !string.IsNullOrWhiteSpace(value)
+                ? base.Format(value)
+                : value;
     }
 }

--- a/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Runtime/Converters/Strings/StringFormatConverter.cs
+++ b/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Runtime/Converters/Strings/StringFormatConverter.cs
@@ -38,8 +38,8 @@ namespace Aspid.MVVM.StarterKit
         /// reached, so covering null takes substituting an empty string ahead of it.
         /// </remarks>
         public override string? Convert(string? value) => value is null && _formatEmptyValues && !string.IsNullOrWhiteSpace(FormatString)
-                ? base.Convert(string.Empty)
-                : base.Convert(value);
+            ? base.Convert(string.Empty)
+            : base.Convert(value);
 
         /// <summary>
         /// Applies the format unless the value is blank and blank values are not being formatted.

--- a/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Runtime/Converters/Strings/StringFormatConverter.cs
+++ b/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Runtime/Converters/Strings/StringFormatConverter.cs
@@ -17,14 +17,8 @@ namespace Aspid.MVVM.StarterKit
     {
         [SerializeField] private bool _formatEmptyValues;
 
-        /// <summary>
-        /// Initializes a new instance of the <see cref="StringFormatConverter"/> class with no formatting.
-        /// </summary>
         public StringFormatConverter() { }
 
-        /// <summary>
-        /// Initializes a new instance of the <see cref="StringFormatConverter"/> class.
-        /// </summary>
         /// <param name="format">The format string to apply using <see cref="string.Format(string, object)"/>.</param>
         /// <param name="formatEmptyValues">If <see langword="true"/>, applies the format even when the input value is null, empty or whitespace-only. Default is <see langword="false"/>.</param>
         public StringFormatConverter(string format, bool formatEmptyValues = false)
@@ -53,9 +47,8 @@ namespace Aspid.MVVM.StarterKit
         /// </summary>
         /// <param name="value">The non-null value to format.</param>
         /// <returns>The formatted string, or the value unchanged.</returns>
-        protected override string Format(string value) =>
-            _formatEmptyValues || !string.IsNullOrWhiteSpace(value)
-                ? base.Format(value)
-                : value;
+        protected override string Format(string value) => _formatEmptyValues || !string.IsNullOrWhiteSpace(value)
+            ? base.Format(value)
+            : value;
     }
 }

--- a/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Runtime/Converters/Strings/TimeSpanToStringConverter.cs
+++ b/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Runtime/Converters/Strings/TimeSpanToStringConverter.cs
@@ -4,13 +4,24 @@ using System;
 namespace Aspid.MVVM.StarterKit
 {
     /// <summary>
-    /// Converts <see cref="TimeSpan"/> values to their string representation with optional formatting.
+    /// <see cref="GenericToString{TFrom}"/> for <see cref="TimeSpan"/> values, with optional formatting.
     /// </summary>
+    /// <remarks>
+    /// The format is a <b>composite</b> format string, so a <see cref="TimeSpan"/> pattern has to be
+    /// wrapped in a placeholder: <c>"{0:mm\\:ss}"</c> yields <c>05:05</c>, while the bare
+    /// <c>"mm\\:ss"</c> that <see cref="TimeSpan.ToString(string)"/> would take comes back as itself.
+    /// </remarks>
     [Serializable]
     public sealed class TimeSpanToStringConverter : GenericToString<TimeSpan>, IConverterTimeSpanToString
     {
+        /// <summary>
+        /// Initializes a new instance of the <see cref="TimeSpanToStringConverter"/> class with no formatting.
+        /// </summary>
         public TimeSpanToStringConverter() { }
 
+        /// <summary>
+        /// Initializes a new instance of the <see cref="TimeSpanToStringConverter"/> class.
+        /// </summary>
         /// <param name="format">The format string to apply using <see cref="string.Format(string, object)"/>.</param>
         public TimeSpanToStringConverter(string format)
             : base(format) { }

--- a/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Runtime/Converters/Strings/TimeSpanToStringConverter.cs
+++ b/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Runtime/Converters/Strings/TimeSpanToStringConverter.cs
@@ -14,14 +14,8 @@ namespace Aspid.MVVM.StarterKit
     [Serializable]
     public sealed class TimeSpanToStringConverter : GenericToString<TimeSpan>, IConverterTimeSpanToString
     {
-        /// <summary>
-        /// Initializes a new instance of the <see cref="TimeSpanToStringConverter"/> class with no formatting.
-        /// </summary>
         public TimeSpanToStringConverter() { }
 
-        /// <summary>
-        /// Initializes a new instance of the <see cref="TimeSpanToStringConverter"/> class.
-        /// </summary>
         /// <param name="format">The format string to apply using <see cref="string.Format(string, object)"/>.</param>
         public TimeSpanToStringConverter(string format)
             : base(format) { }

--- a/Aspid.MVVM/Packages/tech.aspid.mvvm/Tests/Editor/Converters/Strings/GenericToStringTests.cs
+++ b/Aspid.MVVM/Packages/tech.aspid.mvvm/Tests/Editor/Converters/Strings/GenericToStringTests.cs
@@ -65,14 +65,47 @@ namespace Aspid.MVVM.StarterKit.Tests
         }
 
         [Test]
-        public void Convert_BrokenFormat_LogsOncePerInstance()
+        public void Convert_BrokenFormat_LogsEveryFailure()
         {
+            LogAssert.Expect(LogType.Error, new Regex("is invalid"));
+            LogAssert.Expect(LogType.Error, new Regex("is invalid"));
             LogAssert.Expect(LogType.Error, new Regex("is invalid"));
 
             var converter = new GenericToString<int>("{0}/{1}");
             converter.Convert(1);
             converter.Convert(2);
             converter.Convert(3);
+        }
+
+        // Converters feed UI, so any exception out of Format — not just FormatException — must
+        // degrade instead of tearing the binder dispatch.
+        [Test]
+        public void Convert_ThrowingFormatOverride_FallsBackToToString()
+        {
+            LogAssert.Expect(LogType.Error, new Regex("is invalid or threw"));
+
+            Assert.AreEqual("42", new ThrowingFormat().Convert(42));
+        }
+
+        [Test]
+        public void Convert_ErrorHookOverride_SuppliesTheFallback() =>
+            Assert.AreEqual("n/a", new CustomErrorFallback().Convert(42));
+
+        private sealed class ThrowingFormat : GenericToString<int>
+        {
+            public ThrowingFormat()
+                : base("{0}") { }
+
+            protected override string Format(int value) =>
+                throw new InvalidOperationException("boom");
+        }
+
+        private sealed class CustomErrorFallback : GenericToString<int>
+        {
+            public CustomErrorFallback()
+                : base("{0}/{1}") { }
+
+            protected override string HandleFormatError(int value, Exception exception) => "n/a";
         }
 
         [Test]

--- a/Aspid.MVVM/Packages/tech.aspid.mvvm/Tests/Editor/Converters/Strings/GenericToStringTests.cs
+++ b/Aspid.MVVM/Packages/tech.aspid.mvvm/Tests/Editor/Converters/Strings/GenericToStringTests.cs
@@ -1,5 +1,8 @@
 using System;
+using UnityEngine;
 using NUnit.Framework;
+using UnityEngine.TestTools;
+using System.Text.RegularExpressions;
 
 namespace Aspid.MVVM.StarterKit.Tests
 {
@@ -43,15 +46,34 @@ namespace Aspid.MVVM.StarterKit.Tests
         public void Convert_FormatWithoutPlaceholder_ReturnsTheFormatVerbatim() =>
             Assert.AreEqual("F2", new GenericToString<float>("F2").Convert(3.5f));
 
+        // An Inspector-authored format is unvalidated input; throwing from here would tear the
+        // multicast dispatch and take unrelated binders on the same object down with it.
         [Test]
-        [Ignore("Fixed in PR 4 — strings. An Inspector-authored format must not throw into the dispatch.")]
-        public void Convert_BrokenFormat_FallsBackToToStringInsteadOfThrowing() =>
+        public void Convert_BrokenFormat_FallsBackToToStringInsteadOfThrowing()
+        {
+            LogAssert.Expect(LogType.Error, new Regex("is invalid"));
+
             Assert.AreEqual("42", new GenericToString<int>("{0}/{1}").Convert(42));
+        }
 
         [Test]
-        [Ignore("Fixed in PR 4 — strings.")]
-        public void Convert_UnbalancedBrace_FallsBackToToStringInsteadOfThrowing() =>
+        public void Convert_UnbalancedBrace_FallsBackToToStringInsteadOfThrowing()
+        {
+            LogAssert.Expect(LogType.Error, new Regex("is invalid"));
+
             Assert.AreEqual("42", new GenericToString<int>("HP: {0} {").Convert(42));
+        }
+
+        [Test]
+        public void Convert_BrokenFormat_LogsOncePerInstance()
+        {
+            LogAssert.Expect(LogType.Error, new Regex("is invalid"));
+
+            var converter = new GenericToString<int>("{0}/{1}");
+            converter.Convert(1);
+            converter.Convert(2);
+            converter.Convert(3);
+        }
 
         [Test]
         public void ObjectToStringConverter_NoFormat_FallsBackToToString() =>

--- a/Aspid.MVVM/Packages/tech.aspid.mvvm/Tests/Editor/Converters/Strings/StringFormatConverterTests.cs
+++ b/Aspid.MVVM/Packages/tech.aspid.mvvm/Tests/Editor/Converters/Strings/StringFormatConverterTests.cs
@@ -1,4 +1,7 @@
+using UnityEngine;
 using NUnit.Framework;
+using UnityEngine.TestTools;
+using System.Text.RegularExpressions;
 
 namespace Aspid.MVVM.StarterKit.Tests
 {
@@ -7,11 +10,10 @@ namespace Aspid.MVVM.StarterKit.Tests
     /// four input values × four format strings × both settings of <c>_formatEmptyValues</c>.
     /// </summary>
     /// <remarks>
-    /// Thirty-one of the thirty-two cells are asserted below. The missing one — a <see langword="null"/>
-    /// input with a real format and <c>_formatEmptyValues</c> on — is the behaviour that regressed when
-    /// the converter started inheriting <see cref="GenericToString{TFrom}"/>: the base returns early on
-    /// <see langword="null"/>, so the override never runs. It is asserted separately and stays
-    /// <c>[Ignore]</c>d until that is repaired.
+    /// All thirty-two cells are asserted. The interesting one is a <see langword="null"/> input with a
+    /// real format and <c>_formatEmptyValues</c> on: the base class short-circuits on
+    /// <see langword="null"/> before <c>Format</c> is reached, so covering it takes an explicit
+    /// <c>Convert</c> override and it gets a test of its own.
     /// </remarks>
     [TestFixture]
     internal sealed class StringFormatConverterTests
@@ -67,7 +69,6 @@ namespace Aspid.MVVM.StarterKit.Tests
             Assert.AreEqual(expected, new StringFormatConverter("HP: {0}", formatEmptyValues).Convert(value));
 
         [Test]
-        [Ignore("Fixed in PR 4 — strings. The inherited Convert returns early on null, so the override never runs.")]
         public void Convert_NullValue_WithFormatEmptyValues_IsStillFormatted() =>
             Assert.AreEqual("HP: ", new StringFormatConverter("HP: {0}", formatEmptyValues: true).Convert(null));
 
@@ -76,8 +77,11 @@ namespace Aspid.MVVM.StarterKit.Tests
             Assert.AreEqual("abc", new StringFormatConverter().Convert("abc"));
 
         [Test]
-        [Ignore("Fixed in PR 4 — strings. An Inspector-authored format must not throw into the dispatch.")]
-        public void Convert_BrokenFormat_FallsBackToTheValueInsteadOfThrowing() =>
+        public void Convert_BrokenFormat_FallsBackToTheValueInsteadOfThrowing()
+        {
+            LogAssert.Expect(LogType.Error, new Regex("is invalid"));
+
             Assert.AreEqual("abc", new StringFormatConverter("{0}/{1}").Convert("abc"));
+        }
     }
 }


### PR DESCRIPTION
🐛 Fourth of the Phase 0 stack. A format string typed into the Inspector is unvalidated input, and `string.Format` threw straight into the binder that pushed the value — dispatch is a bare multicast, so one bad format cut the subscriber list and silently stopped *unrelated, correctly configured* binders on the same object.

## Summary

- 🐛 `GenericToString` treats an unusable format as a configuration mistake: report once per instance, fall back to `ToString()`, leave the dispatch intact.
- 🐛 Restores a behaviour lost in #133 — `_formatEmptyValues` stopped covering null input once `StringFormatConverter` began inheriting `Convert`, because the base short-circuits on null before the override is reached.
- ✨ `GenericToString` exposes `FormatString` to subclasses, the read access `ObjectToStringConverter` and friends never had.
- 📝 Restores the `<summary>` blocks #133 dropped and states in both string converters that the format is *composite*.

## Notes for review

- ⚠️ The catch is narrow — `FormatException` only, which is what a malformed composite string throws; `Format` stays virtual, so an override throwing anything else still propagates.
- 📝 Reading the configured format is what makes the null fix exact: the obvious one-line override would return `""` with a blank format where both current and pre-#133 code return `null`, and the tests assert all thirty-two cells of that truth table.
- ⚠️ The TimeSpan trap is documented, not fixed: `"{0:mm\:ss}"` works and the bare pattern comes back as itself, since changing that means changing what the format field means — a Phase 2 decision.

✅ Local run: 171 total, 169 passed, 0 failed, 2 skipped (platform-dependent narrowing, Phase 2).

<details>
<summary>🇷🇺 Описание на русском</summary>

🐛 Четвёртый PR стека Фазы 0. Строка формата из инспектора — невалидированный ввод, а `string.Format` бросал прямо в биндер, который толкнул значение: рассылка — голый multicast, поэтому один битый формат обрывал список подписчиков и молча останавливал *посторонние, корректно настроенные* биндеры на том же объекте.

## Итог

- 🐛 `GenericToString` считает непригодный формат ошибкой конфигурации: сообщить один раз на экземпляр, откатиться на `ToString()`, оставить рассылку целой.
- 🐛 Возвращает поведение, потерянное в #133: `_formatEmptyValues` перестал покрывать null, когда `StringFormatConverter` начал наследовать `Convert`, — база выходит на null раньше, чем доходит до override.
- ✨ `GenericToString` открывает подклассам `FormatString` — доступ на чтение, которого у `ObjectToStringConverter` и соседей никогда не было.
- 📝 Возвращает `<summary>`-блоки, удалённые в #133, и фиксирует в обоих строковых конвертерах, что формат — *composite*.

## Заметки для ревью

- ⚠️ Catch узкий — только `FormatException`, который бросает некорректная composite-строка; `Format` остаётся виртуальным, поэтому override с другим исключением по-прежнему пробрасывается.
- 📝 Чтение настроенного формата делает правку null точной: очевидный однострочный override при пустом формате вернул бы `""` там, где и текущий код, и код до #133 возвращают `null`, — тесты проверяют все тридцать две ячейки этой таблицы.
- ⚠️ Ловушка с TimeSpan задокументирована, а не исправлена: `"{0:mm\:ss}"` работает, голый паттерн возвращается сам собой, потому что изменить это значит изменить смысл поля формата — решение Фазы 2.

✅ Локальный прогон: 171 всего, 169 прошло, 0 упало, 2 пропущено (платформозависимое сужение, Фаза 2).

</details>
