### PR TITLE
fix(starterkit): stop the enum dropdown binder resetting its own selection

### DIFF
--- a/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Unity/Runtime/Binders/Debugs/Log/DebugLogBinder.cs
+++ b/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Unity/Runtime/Binders/Debugs/Log/DebugLogBinder.cs
@@ -29,9 +29,8 @@ namespace Aspid.MVVM.StarterKit
         }
 
         // ReSharper disable once FieldCanBeMadeReadOnly.Local
-        // ReSharper disable once MemberInitializerValueIgnored
         [Tooltip("Converter used to format bound values as log messages. Defaults to ObjectToStringConverter.")]
-        [SerializeReference] private Converter _converter = new ObjectToStringConverter();
+        [SerializeReference] private Converter _converter;
 
         /// <summary>
         /// Initializes a new instance of <see cref="DebugLogBinder"/>.
@@ -39,7 +38,7 @@ namespace Aspid.MVVM.StarterKit
         /// <param name="converter">The converter used to format bound values as log messages. Pass <see langword="null"/> to use <see cref="ObjectToStringConverter"/>.</param>
         public DebugLogBinder(Converter converter = null) : base(BindMode.TwoWay)
         {
-            _converter = converter;
+            _converter = converter ?? new ObjectToStringConverter();
         }
 
         /// <summary>
@@ -50,7 +49,9 @@ namespace Aspid.MVVM.StarterKit
         public void SetValue<T>(T value) =>
             Debug.Log($"SetValue: {GetMessage(value)}");
 
+        // A converter returning null is normal — GenericToString does it for a null input — so it
+        // must not be conflated with having no converter, and the fallback has to survive null too.
         private string GetMessage(object value) =>
-            _converter?.Convert(value) ?? value.ToString();
+            (_converter is not null ? _converter.Convert(value) : value?.ToString()) ?? "null";
     }
 }

--- a/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Unity/Runtime/Binders/Debugs/Log/DebugLogBinder.cs
+++ b/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Unity/Runtime/Binders/Debugs/Log/DebugLogBinder.cs
@@ -49,8 +49,6 @@ namespace Aspid.MVVM.StarterKit
         public void SetValue<T>(T value) =>
             Debug.Log($"SetValue: {GetMessage(value)}");
 
-        // A converter returning null is normal — GenericToString does it for a null input — so it
-        // must not be conflated with having no converter, and the fallback has to survive null too.
         private string GetMessage(object value) =>
             (_converter is not null ? _converter.Convert(value) : value?.ToString()) ?? "null";
     }

--- a/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Unity/Runtime/Binders/Debugs/Log/Mono/DebugLogMonoBinder.cs
+++ b/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Unity/Runtime/Binders/Debugs/Log/Mono/DebugLogMonoBinder.cs
@@ -40,8 +40,6 @@ namespace Aspid.MVVM.StarterKit
         public void SetValue<T>(T value) =>
             Debug.Log($"SetValue: {GetMessage(value)}");
 
-        // A converter returning null is normal — GenericToString does it for a null input — so it
-        // must not be conflated with having no converter, and the fallback has to survive null too.
         private string GetMessage(object value) =>
             (_converter is not null ? _converter.Convert(value) : value?.ToString()) ?? "null";
     }

--- a/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Unity/Runtime/Binders/Debugs/Log/Mono/DebugLogMonoBinder.cs
+++ b/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Unity/Runtime/Binders/Debugs/Log/Mono/DebugLogMonoBinder.cs
@@ -40,7 +40,9 @@ namespace Aspid.MVVM.StarterKit
         public void SetValue<T>(T value) =>
             Debug.Log($"SetValue: {GetMessage(value)}");
 
+        // A converter returning null is normal — GenericToString does it for a null input — so it
+        // must not be conflated with having no converter, and the fallback has to survive null too.
         private string GetMessage(object value) =>
-            _converter?.Convert(value) ?? value.ToString();
+            (_converter is not null ? _converter.Convert(value) : value?.ToString()) ?? "null";
     }
 }

--- a/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Unity/Runtime/Binders/Dropdowns/Options/Mono/DropdownOptionsByEnumMonoBinder.cs
+++ b/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Unity/Runtime/Binders/Dropdowns/Options/Mono/DropdownOptionsByEnumMonoBinder.cs
@@ -2,7 +2,6 @@
 using TMPro;
 using System;
 using UnityEngine;
-using System.Collections.Generic;
 #if UNITY_2023_1_OR_NEWER
 using Converter = Aspid.MVVM.StarterKit.IConverter<System.Enum, System.Collections.Generic.IEnumerable<TMPro.TMP_Dropdown.OptionData>>;
 #else
@@ -23,29 +22,48 @@ namespace Aspid.MVVM.StarterKit
         [Tooltip("The converter used to transform the enum value to dropdown option data. When null, the default string representation of each enum value is used.")]
         [SerializeReference] private Converter _converter;
 
+        private Type _populatedType;
+
         /// <summary>
-        /// Clears the current options and repopulates <see cref="TMPro.TMP_Dropdown.options"/> from all values
-        /// of the enum type of <paramref name="value"/>, using the configured converter when assigned,
-        /// or the default string representation of each enum value otherwise.
+        /// Repopulates <see cref="TMPro.TMP_Dropdown.options"/> from all values of the enum type of
+        /// <paramref name="value"/>, using the configured converter when assigned, or the name of each
+        /// enum value otherwise.
         /// </summary>
         /// <param name="value">The bound enum value received from the ViewModel.</param>
+        /// <remarks>
+        /// The option set depends on the enum <i>type</i>, not on the value, so it is rebuilt only when
+        /// the type changes. The rebuild also preserves the current selection: the option list is
+        /// cleared directly rather than through <see cref="TMPro.TMP_Dropdown.ClearOptions"/>, which
+        /// resets the selected index and would clobber a value binder on the same dropdown.
+        /// </remarks>
         public void SetValue(Enum value)
         {
-            CachedComponent.options ??= new List<TMP_Dropdown.OptionData>();
-            CachedComponent.ClearOptions();
+            if (value is null) return;
+
+            var dropdown = CachedComponent;
+            var type = value.GetType();
+
+            if (_populatedType == type && dropdown.options.Count > 0) return;
+            _populatedType = type;
+
+            var selected = dropdown.value;
+            dropdown.options.Clear();
 
             if (_converter is null)
             {
-                var values = Enum.GetValues(value.GetType());
-
-                foreach (var enumObj in values)
-                    CachedComponent.options.Add(new TMP_Dropdown.OptionData(text: enumObj.ToString()));
+                foreach (var name in Enum.GetNames(type))
+                    dropdown.options.Add(new TMP_Dropdown.OptionData(text: name));
             }
             else
             {
                 foreach (var option in _converter.Convert(value))
-                    CachedComponent.options.Add(option);
+                    dropdown.options.Add(option);
             }
+
+            if (dropdown.options.Count > 0)
+                dropdown.SetValueWithoutNotify(Mathf.Clamp(selected, 0, dropdown.options.Count - 1));
+
+            dropdown.RefreshShownValue();
         }
     }
 }

--- a/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Unity/Runtime/Binders/Dropdowns/Options/Mono/DropdownOptionsByEnumMonoBinder.cs
+++ b/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Unity/Runtime/Binders/Dropdowns/Options/Mono/DropdownOptionsByEnumMonoBinder.cs
@@ -31,13 +31,10 @@ namespace Aspid.MVVM.StarterKit
         /// </summary>
         /// <param name="value">The bound enum value received from the ViewModel. Pass <see langword="null"/> to clear all options.</param>
         /// <remarks>
-        /// The option set depends on the enum <i>type</i>, not on the value, so it is rebuilt only when
-        /// the type changes. The rebuild also preserves the current selection: the option list is
-        /// cleared directly rather than through <see cref="TMPro.TMP_Dropdown.ClearOptions"/>, which
-        /// resets the selected index and would clobber a value binder on the same dropdown. A
-        /// <see langword="null"/> value carries no enum type to populate from, so it clears the options
-        /// through <see cref="TMPro.TMP_Dropdown.ClearOptions"/> — matching the rest of the options
-        /// binder family, and with no selection left to preserve.
+        /// The option set depends on the enum <i>type</i>, not the value, so it is rebuilt only when the
+        /// type changes. The list is cleared directly rather than through
+        /// <see cref="TMPro.TMP_Dropdown.ClearOptions"/>, which resets the selected index and would clobber
+        /// a value binder on the same dropdown — except for a <see langword="null"/> value, which has none.
         /// </remarks>
         public void SetValue(Enum value)
         {

--- a/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Unity/Runtime/Binders/Dropdowns/Options/Mono/DropdownOptionsByEnumMonoBinder.cs
+++ b/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Unity/Runtime/Binders/Dropdowns/Options/Mono/DropdownOptionsByEnumMonoBinder.cs
@@ -40,8 +40,8 @@ namespace Aspid.MVVM.StarterKit
         {
             if (value is null) return;
 
-            var dropdown = CachedComponent;
             var type = value.GetType();
+            var dropdown = CachedComponent;
 
             if (_populatedType == type && dropdown.options.Count > 0) return;
             _populatedType = type;

--- a/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Unity/Runtime/Binders/Dropdowns/Options/Mono/DropdownOptionsByEnumMonoBinder.cs
+++ b/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Unity/Runtime/Binders/Dropdowns/Options/Mono/DropdownOptionsByEnumMonoBinder.cs
@@ -29,16 +29,24 @@ namespace Aspid.MVVM.StarterKit
         /// <paramref name="value"/>, using the configured converter when assigned, or the name of each
         /// enum value otherwise.
         /// </summary>
-        /// <param name="value">The bound enum value received from the ViewModel.</param>
+        /// <param name="value">The bound enum value received from the ViewModel. Pass <see langword="null"/> to clear all options.</param>
         /// <remarks>
         /// The option set depends on the enum <i>type</i>, not on the value, so it is rebuilt only when
         /// the type changes. The rebuild also preserves the current selection: the option list is
         /// cleared directly rather than through <see cref="TMPro.TMP_Dropdown.ClearOptions"/>, which
-        /// resets the selected index and would clobber a value binder on the same dropdown.
+        /// resets the selected index and would clobber a value binder on the same dropdown. A
+        /// <see langword="null"/> value carries no enum type to populate from, so it clears the options
+        /// through <see cref="TMPro.TMP_Dropdown.ClearOptions"/> — matching the rest of the options
+        /// binder family, and with no selection left to preserve.
         /// </remarks>
         public void SetValue(Enum value)
         {
-            if (value is null) return;
+            if (value is null)
+            {
+                _populatedType = null;
+                CachedComponent.ClearOptions();
+                return;
+            }
 
             var type = value.GetType();
             var dropdown = CachedComponent;

--- a/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Unity/Runtime/Converters/Dropdowns.meta
+++ b/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Unity/Runtime/Converters/Dropdowns.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: ae2a32dcbbec4618bb9cf5479c927359
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Unity/Runtime/Converters/Dropdowns/EnumToDropdownOptionDataConverter.cs
+++ b/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Unity/Runtime/Converters/Dropdowns/EnumToDropdownOptionDataConverter.cs
@@ -21,11 +21,6 @@ namespace Aspid.MVVM.StarterKit
     /// keeps matching the enum member it did before the converter was assigned.
     /// </para>
     /// <para>
-    /// Members missing from the lookup table fall back to its configured default value: an entry without
-    /// a sprite yields an option without an image, and an entry with an empty label yields the name of
-    /// the enum member.
-    /// </para>
-    /// <para>
     /// Sprites are only visible when the dropdown template carries an item image — the built-in TextMeshPro
     /// dropdown prefab does, a hand-built template may not.
     /// </para>

--- a/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Unity/Runtime/Converters/Dropdowns/EnumToDropdownOptionDataConverter.cs
+++ b/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Unity/Runtime/Converters/Dropdowns/EnumToDropdownOptionDataConverter.cs
@@ -1,0 +1,87 @@
+#if UNITY_2023_1_OR_NEWER || ASPID_MVVM_TEXT_MESH_PRO_INTEGRATION
+#nullable enable
+using TMPro;
+using System;
+using UnityEngine;
+using Aspid.FastTools.Enums;
+using System.Collections.Generic;
+
+// ReSharper disable once CheckNamespace
+namespace Aspid.MVVM.StarterKit
+{
+    /// <summary>
+    /// <see cref="IConverterEnumToDropdownOptionData"/> that builds one
+    /// <see cref="TMP_Dropdown.OptionData"/> per member of the bound enum type, resolving the label and
+    /// the sprite of each option through a configurable <see cref="EnumValues{TValue}"/> lookup table.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// Options are emitted in declaration order of the enum type, which is the same order
+    /// <see cref="DropdownOptionsByEnumMonoBinder"/> uses without a converter — so the selected index
+    /// keeps matching the enum member it did before the converter was assigned.
+    /// </para>
+    /// <para>
+    /// Members missing from the lookup table fall back to its configured default value: an entry without
+    /// a sprite yields an option without an image, and an entry with an empty label yields the name of
+    /// the enum member.
+    /// </para>
+    /// <para>
+    /// Sprites are only visible when the dropdown template carries an item image — the built-in TextMeshPro
+    /// dropdown prefab does, a hand-built template may not.
+    /// </para>
+    /// </remarks>
+    [Serializable]
+    public sealed class EnumToDropdownOptionDataConverter : IConverterEnumToDropdownOptionData
+    {
+        [Tooltip("Lookup table mapping each enum value to the label and the sprite of its dropdown option.")]
+        [SerializeField] private EnumValues<DropdownOption>? _options;
+
+        /// <summary>
+        /// Builds the option data for every member of the enum type of <paramref name="value"/>.
+        /// </summary>
+        /// <param name="value">The bound enum value received from the ViewModel; only its type is used.</param>
+        /// <returns>
+        /// One <see cref="TMP_Dropdown.OptionData"/> per enum member in declaration order,
+        /// or an empty sequence when <paramref name="value"/> is <see langword="null"/>.
+        /// </returns>
+        public IEnumerable<TMP_Dropdown.OptionData> Convert(Enum? value)
+        {
+            if (value is null) yield break;
+
+            foreach (Enum member in Enum.GetValues(value.GetType()))
+            {
+                var option = _options?.GetValue(member) ?? default;
+                var text = string.IsNullOrWhiteSpace(option.Text)
+                    ? member.ToString() 
+                    : option.Text;
+
+                yield return new TMP_Dropdown.OptionData(text) { image = option.Sprite };
+            }
+        }
+
+        /// <summary>
+        /// Serializable pair of a label and an optional sprite describing a single dropdown option.
+        /// </summary>
+        [Serializable]
+        private struct DropdownOption
+        {
+            [Tooltip("The label shown for the option. When empty, the name of the enum value is used.")]
+            [SerializeField] private string? _text;
+
+            [Tooltip("The sprite shown next to the label. When empty, the option is shown without an image.")]
+            [SerializeField] private Sprite? _sprite;
+
+            /// <summary>
+            /// Gets the label shown for the option.
+            /// Empty when the name of the enum value should be used instead.
+            /// </summary>
+            public string? Text => _text;
+
+            /// <summary>
+            /// Gets the sprite shown next to the label, or <see langword="null"/> when the option has no image.
+            /// </summary>
+            public Sprite? Sprite => _sprite;
+        }
+    }
+}
+#endif

--- a/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Unity/Runtime/Converters/Dropdowns/EnumToDropdownOptionDataConverter.cs.meta
+++ b/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Unity/Runtime/Converters/Dropdowns/EnumToDropdownOptionDataConverter.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 2dc924233fde4e3e8458c45956e31f42
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {fileID: 2800000, guid: 0d0d85abe18854107bff963db8208bbc, type: 3}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Aspid.MVVM/Packages/tech.aspid.mvvm/Tests/Editor/Aspid.MVVM.StarterKit.Tests.asmdef
+++ b/Aspid.MVVM/Packages/tech.aspid.mvvm/Tests/Editor/Aspid.MVVM.StarterKit.Tests.asmdef
@@ -5,9 +5,11 @@
         "UnityEngine.TestRunner",
         "UnityEditor.TestRunner",
         "Aspid.MVVM",
+        "Aspid.MVVM.Unity",
         "Aspid.MVVM.StarterKit",
         "Aspid.MVVM.StarterKit.Unity",
-        "Aspid.FastTools.Unity"
+        "Aspid.FastTools.Unity",
+        "Unity.TextMeshPro"
     ],
     "includePlatforms": [
         "Editor"

--- a/Aspid.MVVM/Packages/tech.aspid.mvvm/Tests/Editor/Binders.meta
+++ b/Aspid.MVVM/Packages/tech.aspid.mvvm/Tests/Editor/Binders.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: e719619e09c074ac6b79bee84309fb0e
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Aspid.MVVM/Packages/tech.aspid.mvvm/Tests/Editor/Binders/DebugLogBinderTests.cs
+++ b/Aspid.MVVM/Packages/tech.aspid.mvvm/Tests/Editor/Binders/DebugLogBinderTests.cs
@@ -1,0 +1,54 @@
+using UnityEngine;
+using NUnit.Framework;
+using UnityEngine.TestTools;
+
+namespace Aspid.MVVM.StarterKit.Tests
+{
+    /// <summary>
+    /// Coverage for <see cref="DebugLogBinder"/>'s message building — the one place where a
+    /// converter returning <see langword="null"/> and having no converter at all had to stop being
+    /// the same thing.
+    /// </summary>
+    [TestFixture]
+    internal sealed class DebugLogBinderTests
+    {
+        [Test]
+        public void SetValue_NullValue_LogsInsteadOfThrowing()
+        {
+            LogAssert.Expect(LogType.Log, "SetValue: null");
+
+            new DebugLogBinder().SetValue<string>(null);
+        }
+
+        [Test]
+        public void SetValue_NullValue_WithoutConverter_LogsInsteadOfThrowing()
+        {
+            LogAssert.Expect(LogType.Log, "SetValue: null");
+
+            new DebugLogBinder(new NullConverter()).SetValue("ignored");
+        }
+
+        [Test]
+        public void SetValue_UsesTheConfiguredConverter()
+        {
+            LogAssert.Expect(LogType.Log, "SetValue: HP: 42");
+
+            new DebugLogBinder(new ObjectToStringConverter("HP: {0}")).SetValue(42);
+        }
+
+        // The parameter is documented as "pass null to use ObjectToStringConverter", which the
+        // constructor used to contradict by overwriting the field initialiser with null.
+        [Test]
+        public void DefaultConstructed_FallsBackToObjectToStringConverter()
+        {
+            LogAssert.Expect(LogType.Log, "SetValue: 42");
+
+            new DebugLogBinder().SetValue(42);
+        }
+
+        private sealed class NullConverter : IConverterObjectToString
+        {
+            public string Convert(object value) => null;
+        }
+    }
+}

--- a/Aspid.MVVM/Packages/tech.aspid.mvvm/Tests/Editor/Binders/DebugLogBinderTests.cs.meta
+++ b/Aspid.MVVM/Packages/tech.aspid.mvvm/Tests/Editor/Binders/DebugLogBinderTests.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 532f0f2fd02384a3ca97b6754584d944

--- a/Aspid.MVVM/Packages/tech.aspid.mvvm/Tests/Editor/Binders/DropdownOptionsByEnumMonoBinderTests.cs
+++ b/Aspid.MVVM/Packages/tech.aspid.mvvm/Tests/Editor/Binders/DropdownOptionsByEnumMonoBinderTests.cs
@@ -1,0 +1,97 @@
+using TMPro;
+using UnityEngine;
+using NUnit.Framework;
+
+namespace Aspid.MVVM.StarterKit.Tests
+{
+    internal enum Difficulty
+    {
+        Easy,
+        Normal,
+        Hard,
+    }
+
+    internal enum Season
+    {
+        Winter,
+        Spring,
+    }
+
+    /// <summary>
+    /// Coverage for <see cref="DropdownOptionsByEnumMonoBinder"/>: the option set depends on the enum
+    /// type, so pushing the same type again must not rebuild the list — and rebuilding must not throw
+    /// the current selection away.
+    /// </summary>
+    [TestFixture]
+    internal sealed class DropdownOptionsByEnumMonoBinderTests
+    {
+        private GameObject _gameObject;
+        private TMP_Dropdown _dropdown;
+        private DropdownOptionsByEnumMonoBinder _binder;
+
+        [SetUp]
+        public void CreateDropdown()
+        {
+            _gameObject = new GameObject(nameof(DropdownOptionsByEnumMonoBinderTests));
+            _dropdown = _gameObject.AddComponent<TMP_Dropdown>();
+            _binder = _gameObject.AddComponent<DropdownOptionsByEnumMonoBinder>();
+        }
+
+        [TearDown]
+        public void DestroyDropdown() =>
+            Object.DestroyImmediate(_gameObject);
+
+        [Test]
+        public void SetValue_PopulatesOneOptionPerEnumMember()
+        {
+            _binder.SetValue(Difficulty.Easy);
+
+            Assert.AreEqual(3, _dropdown.options.Count);
+            Assert.AreEqual("Easy", _dropdown.options[0].text);
+            Assert.AreEqual("Normal", _dropdown.options[1].text);
+            Assert.AreEqual("Hard", _dropdown.options[2].text);
+        }
+
+        // The selection lives on the same dropdown and is usually driven by a second binder, so a
+        // push that changes nothing must not reset it.
+        [Test]
+        public void SetValue_SameEnumType_KeepsTheSelection()
+        {
+            _binder.SetValue(Difficulty.Easy);
+            _dropdown.SetValueWithoutNotify(2);
+
+            _binder.SetValue(Difficulty.Hard);
+
+            Assert.AreEqual(2, _dropdown.value);
+        }
+
+        [Test]
+        public void SetValue_DifferentEnumType_RebuildsTheOptions()
+        {
+            _binder.SetValue(Difficulty.Easy);
+            _binder.SetValue(Season.Winter);
+
+            Assert.AreEqual(2, _dropdown.options.Count);
+            Assert.AreEqual("Winter", _dropdown.options[0].text);
+        }
+
+        [Test]
+        public void SetValue_RebuildClampsASelectionThatNoLongerExists()
+        {
+            _binder.SetValue(Difficulty.Easy);
+            _dropdown.SetValueWithoutNotify(2);
+
+            _binder.SetValue(Season.Winter);
+
+            Assert.AreEqual(1, _dropdown.value);
+        }
+
+        [Test]
+        public void SetValue_Null_IsIgnored()
+        {
+            _binder.SetValue(null);
+
+            Assert.AreEqual(0, _dropdown.options.Count);
+        }
+    }
+}

--- a/Aspid.MVVM/Packages/tech.aspid.mvvm/Tests/Editor/Binders/DropdownOptionsByEnumMonoBinderTests.cs.meta
+++ b/Aspid.MVVM/Packages/tech.aspid.mvvm/Tests/Editor/Binders/DropdownOptionsByEnumMonoBinderTests.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: afdcaf937eb2042bc8837c60ed4fe052


### PR DESCRIPTION
🐛 Sixth of the Phase 0 stack, and the last one with production changes.

## Summary

- 🐛 **`DropdownOptionsByEnumMonoBinder` stops resetting its own selection**: it rebuilt the option list on every push through `TMP_Dropdown.ClearOptions()`, which also resets the selected index — so on a dropdown carrying both an options binder and a value binder, every push wiped what the other binder had just set.
- ⚡ The option set depends on the enum *type*, so it is rebuilt only when the type changes, and `Enum.GetNames` replaces `Enum.GetValues` + `ToString()` — same text, no boxing per member.
- 🐛 `DebugLogBinder` / `DebugLogMonoBinder` stop conflating "the converter returned null" with "there is no converter", so a null value no longer throws from the fallback.
- 🐛 `DebugLogBinder`'s constructor honours its own `<param>` doc instead of overwriting the field initialiser with null.

## Notes for review

- 📝 This does not make the binder reflection-free — `Enum.GetNames` is reflection; what changed is that it runs once per enum type instead of once per push.
- ⚠️ Restore uses `SetValueWithoutNotify`, not `value`, so restoring the index cannot push a phantom edit back into the ViewModel.
- ✅ `SetValue_SameEnumType_KeepsTheSelection` had teeth from the start: under the old code `ClearOptions()` reset `m_Value` to 0 and it fails.

✅ Local run: 181 total, 179 passed, 0 failed, 2 skipped.

<details>
<summary>🇷🇺 Описание на русском</summary>

🐛 Шестой PR стека Фазы 0 и последний с продакшн-изменениями.

## Итог

- 🐛 **`DropdownOptionsByEnumMonoBinder` перестаёт сбрасывать собственный выбор**: он пересобирал список опций на каждый push через `TMP_Dropdown.ClearOptions()`, который заодно сбрасывает выбранный индекс, — поэтому на дропдауне с options- и value-биндером каждый push стирал то, что только что установил второй.
- ⚡ Набор опций зависит от *типа* enum, поэтому пересобирается только при смене типа, а `Enum.GetNames` заменяет `Enum.GetValues` + `ToString()` — тот же текст, без бокса на каждый член.
- 🐛 `DebugLogBinder` / `DebugLogMonoBinder` перестают путать «конвертер вернул null» с «конвертера нет», поэтому null-значение больше не бросает из отката.
- 🐛 Конструктор `DebugLogBinder` соблюдает собственный `<param>`-док вместо затирания инициализатора значением null.

## Заметки для ревью

- 📝 Это не делает биндер свободным от рефлексии — `Enum.GetNames` и есть рефлексия; изменилось то, что она выполняется раз на тип, а не на каждый push.
- ⚠️ При восстановлении используется `SetValueWithoutNotify`, а не `value`, чтобы восстановление индекса не толкнуло фантомную правку во ViewModel.
- ✅ `SetValue_SameEnumType_KeepsTheSelection` имел зубы с самого начала: на старом коде `ClearOptions()` сбрасывал `m_Value` в 0, и он падает.

✅ Локальный прогон: 181 всего, 179 прошло, 0 упало, 2 пропущено.

</details>
