### PR TITLE
chore(starterkit): gate PhysicsMaterial on the version that renamed it

### DIFF
--- a/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Unity/Runtime/Binders/Colliders/Colliders/Material/ColliderMaterialBinder.cs
+++ b/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Unity/Runtime/Binders/Colliders/Colliders/Material/ColliderMaterialBinder.cs
@@ -1,7 +1,7 @@
 #nullable enable
 using System;
 using UnityEngine;
-#if UNITY_2023_1_OR_NEWER
+#if UNITY_6000_0_OR_NEWER
 using PhysicsMaterial = UnityEngine.PhysicsMaterial;
 using Converter = Aspid.MVVM.StarterKit.IConverter<UnityEngine.PhysicsMaterial?, UnityEngine.PhysicsMaterial?>;
 #else

--- a/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Unity/Runtime/Binders/Colliders/Colliders/Material/ColliderMaterialSwitcherBinder.cs
+++ b/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Unity/Runtime/Binders/Colliders/Colliders/Material/ColliderMaterialSwitcherBinder.cs
@@ -1,7 +1,7 @@
 #nullable enable
 using System;
 using UnityEngine;
-#if UNITY_2023_1_OR_NEWER
+#if UNITY_6000_0_OR_NEWER
 using PhysicsMaterial = UnityEngine.PhysicsMaterial;
 using Converter = Aspid.MVVM.StarterKit.IConverter<UnityEngine.PhysicsMaterial?, UnityEngine.PhysicsMaterial?>;
 #else

--- a/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Unity/Runtime/Binders/Colliders/Colliders/Material/Mono/ColliderMaterialEnumGroupMonoBinder.cs
+++ b/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Unity/Runtime/Binders/Colliders/Colliders/Material/Mono/ColliderMaterialEnumGroupMonoBinder.cs
@@ -1,5 +1,5 @@
 using UnityEngine;
-#if UNITY_2023_1_OR_NEWER
+#if UNITY_6000_0_OR_NEWER
 using PhysicsMaterial = UnityEngine.PhysicsMaterial;
 using Converter = Aspid.MVVM.StarterKit.IConverter<UnityEngine.PhysicsMaterial, UnityEngine.PhysicsMaterial>;
 #else

--- a/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Unity/Runtime/Binders/Colliders/Colliders/Material/Mono/ColliderMaterialEnumMonoBinder.cs
+++ b/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Unity/Runtime/Binders/Colliders/Colliders/Material/Mono/ColliderMaterialEnumMonoBinder.cs
@@ -1,5 +1,5 @@
 using UnityEngine;
-#if UNITY_2023_1_OR_NEWER
+#if UNITY_6000_0_OR_NEWER
 using PhysicsMaterial = UnityEngine.PhysicsMaterial;
 using Converter = Aspid.MVVM.StarterKit.IConverter<UnityEngine.PhysicsMaterial, UnityEngine.PhysicsMaterial>;
 #else

--- a/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Unity/Runtime/Binders/Colliders/Colliders/Material/Mono/ColliderMaterialMonoBinder.cs
+++ b/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Unity/Runtime/Binders/Colliders/Colliders/Material/Mono/ColliderMaterialMonoBinder.cs
@@ -1,5 +1,5 @@
 using UnityEngine;
-#if UNITY_2023_1_OR_NEWER
+#if UNITY_6000_0_OR_NEWER
 using PhysicsMaterial = UnityEngine.PhysicsMaterial;
 using Converter = Aspid.MVVM.StarterKit.IConverter<UnityEngine.PhysicsMaterial, UnityEngine.PhysicsMaterial>;
 #else

--- a/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Unity/Runtime/Binders/Colliders/Colliders/Material/Mono/ColliderMaterialSwitcherMonoBinder.cs
+++ b/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Unity/Runtime/Binders/Colliders/Colliders/Material/Mono/ColliderMaterialSwitcherMonoBinder.cs
@@ -1,5 +1,5 @@
 using UnityEngine;
-#if UNITY_2023_1_OR_NEWER
+#if UNITY_6000_0_OR_NEWER
 using PhysicsMaterial = UnityEngine.PhysicsMaterial;
 using Converter = Aspid.MVVM.StarterKit.IConverter<UnityEngine.PhysicsMaterial, UnityEngine.PhysicsMaterial>;
 #else

--- a/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Unity/Runtime/Converters/Specific/ConverterSpecificExtensions.cs
+++ b/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Unity/Runtime/Converters/Specific/ConverterSpecificExtensions.cs
@@ -2,7 +2,7 @@
 using System;
 using Aspid.FastTools.Types;
 using UnityEngine;
-#if UNITY_2023_1_OR_NEWER
+#if UNITY_6000_0_OR_NEWER
 using PhysicsMaterial = UnityEngine.PhysicsMaterial;
 #else
 using PhysicsMaterial = UnityEngine.PhysicMaterial;

--- a/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Unity/Runtime/Converters/Specific/IConverterPhysicsMaterial.cs
+++ b/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Unity/Runtime/Converters/Specific/IConverterPhysicsMaterial.cs
@@ -1,5 +1,5 @@
 #nullable enable
-#if UNITY_2023_1_OR_NEWER
+#if UNITY_6000_0_OR_NEWER
 using PhysicsMaterial = UnityEngine.PhysicsMaterial;
 #else
 using PhysicsMaterial = UnityEngine.PhysicMaterial;


### PR DESCRIPTION
🔧 `PhysicMaterial` became `PhysicsMaterial` in Unity 6, not in 2023.1, so `#if UNITY_2023_1_OR_NEWER` named a version two releases too early. Last of the Phase 0 stack; one-line change in eight files.

## Summary

- 🔧 `#if UNITY_2023_1_OR_NEWER` → `#if UNITY_6000_0_OR_NEWER` on the eight `using PhysicsMaterial = …` aliases.

## Notes for review

- 📝 Nothing shipped against a broken configuration — `package.json` declares `"unity": "6000.0"`, so the wrong branch was never selected; it was unreachable for the wrong reason and now is unreachable for the right one.
- ⚠️ The other `UNITY_2023_1_OR_NEWER` gates in these files are untouched: they guard the `[SerializeReference]` open-generic serialization limit, which genuinely is a 2023.1 change.
- ✅ Compiling is the proof: on Unity 6000.4 the `#else` branch references a type that no longer exists, so a wrong define name fails the build rather than passing silently.

<details>
<summary>🇷🇺 Описание на русском</summary>

🔧 `PhysicMaterial` стал `PhysicsMaterial` в Unity 6, а не в 2023.1, поэтому `#if UNITY_2023_1_OR_NEWER` называл версию на два релиза раньше. Последний PR стека Фазы 0; однострочная правка в восьми файлах.

## Итог

- 🔧 `#if UNITY_2023_1_OR_NEWER` → `#if UNITY_6000_0_OR_NEWER` на восьми алиасах `using PhysicsMaterial = …`.

## Заметки для ревью

- 📝 Со сломанной конфигурацией ничего не выпускалось — `package.json` объявляет `"unity": "6000.0"`, так что неверная ветка никогда не выбиралась: она была недостижима по неправильной причине, а теперь недостижима по правильной.
- ⚠️ Остальные гейты `UNITY_2023_1_OR_NEWER` в этих файлах не тронуты: они защищают ограничение сериализации открытых дженериков через `[SerializeReference]`, а это действительно изменение 2023.1.
- ✅ Доказательство — сама компиляция: на Unity 6000.4 ветка `#else` ссылается на тип, которого больше нет, поэтому неверное имя дефайна уронит сборку, а не пройдёт молча.

</details>
