### PR TITLE
feat(starterkit): give converters a non-generic root interface

### DIFF
--- a/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Runtime/Converters/IConverter.cs
+++ b/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Runtime/Converters/IConverter.cs
@@ -1,8 +1,41 @@
 // ReSharper disable once CheckNamespace
 namespace Aspid.MVVM.StarterKit
 {
-    public interface IConverter<in TFrom, out TTo>
+    /// <summary>
+    /// Marks a type as a converter, whatever it converts between.
+    /// </summary>
+    /// <remarks>
+    /// Deliberately empty. Tooling needs to answer "is this a converter?" for a field type or a
+    /// picker candidate without walking every interface a type implements, and that is all this
+    /// gives. The concrete types stay on <see cref="IConverter{TFrom, TTo}"/>, which is the only
+    /// place a conversion is actually declared — a type may implement it many times over.
+    /// <para>
+    /// It carries no members so that adding it breaks nothing: default interface members are the
+    /// only way an interface can gain members without every implementer changing, and Unity does
+    /// not support them.
+    /// </para>
+    /// </remarks>
+    public interface IConverter { }
+
+    /// <summary>
+    /// Converts a value of type <typeparamref name="TFrom"/> into a value of type <typeparamref name="TTo"/>.
+    /// </summary>
+    /// <typeparam name="TFrom">The type of the value to convert.</typeparam>
+    /// <typeparam name="TTo">The type of the converted value.</typeparam>
+    /// <remarks>
+    /// Conversion is one-directional: there is no reverse operation, and a binder in
+    /// <see cref="BindMode.TwoWay"/> or <see cref="BindMode.OneWayToSource"/> does not get one for
+    /// free. Implementations sit on the hot path of every value push, so
+    /// <see cref="Convert"/> should be pure, allocation-free, and cheap enough to run per frame.
+    /// A type may implement this interface several times to convert between several type pairs.
+    /// </remarks>
+    public interface IConverter<in TFrom, out TTo> : IConverter
     {
+        /// <summary>
+        /// Converts the specified value.
+        /// </summary>
+        /// <param name="value">The value to convert.</param>
+        /// <returns>The converted value.</returns>
         public TTo Convert(TFrom value);
     }
 }

--- a/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Runtime/Converters/IConverter.cs
+++ b/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Runtime/Converters/IConverter.cs
@@ -5,15 +5,9 @@ namespace Aspid.MVVM.StarterKit
     /// Marks a type as a converter, whatever it converts between.
     /// </summary>
     /// <remarks>
-    /// Deliberately empty. Tooling needs to answer "is this a converter?" for a field type or a
-    /// picker candidate without walking every interface a type implements, and that is all this
-    /// gives. The concrete types stay on <see cref="IConverter{TFrom, TTo}"/>, which is the only
-    /// place a conversion is actually declared — a type may implement it many times over.
-    /// <para>
-    /// It carries no members so that adding it breaks nothing: default interface members are the
-    /// only way an interface can gain members without every implementer changing, and Unity does
-    /// not support them.
-    /// </para>
+    /// Deliberately empty, and stays that way: a type may implement
+    /// <see cref="IConverter{TFrom, TTo}"/> many times over, so a member naming the converted types
+    /// here would have to answer for all of them at once.
     /// </remarks>
     public interface IConverter { }
 
@@ -23,11 +17,10 @@ namespace Aspid.MVVM.StarterKit
     /// <typeparam name="TFrom">The type of the value to convert.</typeparam>
     /// <typeparam name="TTo">The type of the converted value.</typeparam>
     /// <remarks>
-    /// Conversion is one-directional: there is no reverse operation, and a binder in
-    /// <see cref="BindMode.TwoWay"/> or <see cref="BindMode.OneWayToSource"/> does not get one for
-    /// free. Implementations sit on the hot path of every value push, so
-    /// <see cref="Convert"/> should be pure, allocation-free, and cheap enough to run per frame.
-    /// A type may implement this interface several times to convert between several type pairs.
+    /// Conversion is one-directional: a binder in <see cref="BindMode.TwoWay"/> or
+    /// <see cref="BindMode.OneWayToSource"/> does not get the reverse for free. Implementations sit on
+    /// the hot path of every value push, so <see cref="Convert"/> should be pure, allocation-free and
+    /// cheap enough to run per frame. A type may implement this interface for several type pairs.
     /// </remarks>
     public interface IConverter<in TFrom, out TTo> : IConverter
     {

--- a/Aspid.MVVM/Packages/tech.aspid.mvvm/Tests/Editor/Converters/ConverterPickerContractTests.cs
+++ b/Aspid.MVVM/Packages/tech.aspid.mvvm/Tests/Editor/Converters/ConverterPickerContractTests.cs
@@ -68,17 +68,13 @@ namespace Aspid.MVVM.StarterKit.Tests
         private static IEnumerable<Type> ConverterTypes() => Assemblies()
             .SelectMany(assembly => assembly.GetTypes())
             .Where(type => !type.IsInterface && !type.IsAbstract)
-            .Where(ImplementsConverter);
+            .Where(type => typeof(IConverter).IsAssignableFrom(type));
 
         private static IEnumerable<Assembly> Assemblies() => new[]
         {
-            typeof(IConverter<,>).Assembly,
+            typeof(IConverter).Assembly,
             typeof(IConverterVector3).Assembly,
         }.Distinct();
-
-        private static bool ImplementsConverter(Type type) => type
-            .GetInterfaces()
-            .Any(i => i.IsGenericType && i.GetGenericTypeDefinition() == typeof(IConverter<,>));
 
         // The picker calls Activator.CreateInstance(type, nonPublic: true), so a private or
         // protected parameterless constructor is enough to make a type constructible.


### PR DESCRIPTION
✨ First of Phase 2. Tooling has no way to ask "is this a converter?" — which is why there are 51 `[SerializeReference]` converter points and no validation behind any of them.

## Summary

- ✨ `IConverter` — an empty marker that `IConverter<TFrom, TTo>` extends.
- 📝 Full documentation on both, closing the audit's "the central abstraction has zero `///` lines".
- ♻️ `ConverterPickerContractTests` scans through the marker instead of matching generic definitions.

## Notes for review

- ⚠️ **The marker is empty against the audit's recommendation**: a type implements `IConverter<TFrom, TTo>` as many times as it has pairs, so a single `FromType` / `ToType` would have to answer for all of them at once, and `ConvertObject` boxes on the hot path of every value push.
- 📝 Only `ConvertObject` is genuinely lost, and it can return later as an opt-in `IObjectConverter` at nobody's cost.
- ✅ Zero breaking change: no implementer, serialized data or picker behaviour changes, and the contract test on the marker still finds all 36+ converters including private nested adapters.

✅ Local run: 181 total, 179 passed, 0 failed, 2 skipped.

<details>
<summary>🇷🇺 Описание на русском</summary>

✨ Первый PR Фазы 2. У тулинга нет способа спросить «это конвертер?» — поэтому в пакете 51 точка `[SerializeReference]` с конвертерами и ни одной валидации за ними.

## Итог

- ✨ `IConverter` — пустой маркер, который расширяет `IConverter<TFrom, TTo>`.
- 📝 Полная документация на обоих, закрывает пункт аудита «у центральной абстракции ноль строк `///`».
- ♻️ `ConverterPickerContractTests` сканирует через маркер вместо сопоставления generic-определений.

## Заметки для ревью

- ⚠️ **Маркер пуст вопреки рекомендации аудита**: тип реализует `IConverter<TFrom, TTo>` столько раз, сколько у него пар, поэтому один `FromType` / `ToType` отвечал бы сразу за все, а `ConvertObject` боксит на горячем пути каждой отправки значения.
- 📝 Реально теряется только `ConvertObject`, и он может приехать позже как opt-in `IObjectConverter`, никому ничего не стоя.
- ✅ Ломающих изменений ноль: не меняются ни реализации, ни сериализованные данные, ни поведение пикера, а контракт-тест на маркере по-прежнему находит все 36+ конвертеров, включая приватные вложенные адаптеры.

✅ Локальный прогон: 181 всего, 179 прошло, 0 упало, 2 пропущено.

</details>

