### PR TITLE
fix(starterkit): stop reverse binding re-applying the forward converter

### DIFF
--- a/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Runtime/Binders/TargetProperty/TargetBinder.cs
+++ b/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Runtime/Binders/TargetProperty/TargetBinder.cs
@@ -107,8 +107,7 @@ namespace Aspid.MVVM.StarterKit
     public abstract class TargetBinder<TTarget, TProperty, TConverter> : TargetBinder<TTarget, TProperty>
         where TConverter : IConverter<TProperty?, TProperty?>
     {
-        [Tooltip("Optional converter applied to the value on its way to the target. It also runs in "
-            + "reverse only if it implements ITwoWayConverter.")]
+        [Tooltip("Optional converter applied to the value on its way to the target. It also runs in reverse only if it implements ITwoWayConverter.")]
         [SerializeReference] private TConverter? _converter;
 
         /// <summary>
@@ -146,9 +145,7 @@ namespace Aspid.MVVM.StarterKit
             if (Mode is not (BindMode.OneWayToSource or BindMode.TwoWay)) return;
             if (_converter is null or ITwoWayConverter<TProperty?, TProperty?>) return;
 
-            Debug.LogWarning(
-                $"{GetType().Name} is bound as {Mode} with {_converter.GetType().Name}, which converts "
-                + "one way only. Values sent back to the ViewModel are not converted.");
+            Debug.LogWarning($"{GetType().Name} is bound as {Mode} with {_converter.GetType().Name}, which converts one way only. Values sent back to the ViewModel are not converted.");
         }
     }
 }

--- a/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Runtime/Binders/TargetProperty/TargetBinder.cs
+++ b/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Runtime/Binders/TargetProperty/TargetBinder.cs
@@ -62,34 +62,53 @@ namespace Aspid.MVVM.StarterKit
 
         /// <summary>
         /// Raises <see cref="ValueChanged"/> with <paramref name="value"/>,
-        /// passing it through <see cref="GetConvertedValue"/> first.
+        /// passing it through <see cref="GetConvertedBackValue"/> first.
         /// </summary>
         /// <param name="value">The value to send to the ViewModel.</param>
         protected void RaiseValueChanged(TProperty? value) =>
-            ValueChanged?.Invoke(GetConvertedValue(value));
+            ValueChanged?.Invoke(GetConvertedBackValue(value));
 
         /// <summary>
-        /// Converts <paramref name="value"/> before it is applied to the target property or sent back to the ViewModel.
+        /// Converts <paramref name="value"/> before it is applied to the target property.
         /// Returns <paramref name="value"/> unchanged by default.
         /// </summary>
         /// <param name="value">The value to convert.</param>
         /// <returns>The converted value.</returns>
         protected virtual TProperty? GetConvertedValue(TProperty? value) => value;
+
+        /// <summary>
+        /// Converts <paramref name="value"/> before it is sent back to the ViewModel.
+        /// Returns <paramref name="value"/> unchanged by default.
+        /// </summary>
+        /// <param name="value">The value to convert.</param>
+        /// <returns>The converted value.</returns>
+        /// <remarks>
+        /// Separate from <see cref="GetConvertedValue"/> because the reverse direction is not the
+        /// forward one: applying the forward conversion again compounds it, so a ×100 converter
+        /// turns 0.75 into 7500 on the way back rather than into 0.75.
+        /// </remarks>
+        protected virtual TProperty? GetConvertedBackValue(TProperty? value) => value;
     }
 
     /// <summary>
-    /// Abstract base <see cref="TargetBinder{TTarget,TProperty}"/> that applies an optional <typeparamref name="TConverter"/> to values in both binding directions.
+    /// Abstract base <see cref="TargetBinder{TTarget,TProperty}"/> that applies an optional <typeparamref name="TConverter"/> to the bound value.
     /// Supports <see cref="BindMode.OneWay">OneWay</see> and <see cref="BindMode.OneTime">OneTime</see>: the converter transforms the incoming value before setting it on the target property.
     /// Supports <see cref="BindMode.OneWayToSource">OneWayToSource</see> for reverse binding: when binding is established,
-    /// the current property value is converted and sent back to the ViewModel.
+    /// the current property value is sent back to the ViewModel.
     /// </summary>
+    /// <remarks>
+    /// The reverse direction only converts when the configured converter implements
+    /// <see cref="ITwoWayConverter{TFrom, TTo}"/>; otherwise the value is sent back unchanged, and a
+    /// binder bound in a reverse mode reports the one-way converter once.
+    /// </remarks>
     /// <typeparam name="TTarget">The type of the target object that exposes the bound property.</typeparam>
     /// <typeparam name="TProperty">The type of the property being bound.</typeparam>
     /// <typeparam name="TConverter">The converter type used to transform the bound value before applying it.</typeparam>
     public abstract class TargetBinder<TTarget, TProperty, TConverter> : TargetBinder<TTarget, TProperty>
         where TConverter : IConverter<TProperty?, TProperty?>
     {
-        [Tooltip("Optional converter applied to the value in both binding directions.")]
+        [Tooltip("Optional converter applied to the value on its way to the target. It also runs in "
+            + "reverse only if it implements ITwoWayConverter.")]
         [SerializeReference] private TConverter? _converter;
 
         /// <summary>
@@ -110,5 +129,26 @@ namespace Aspid.MVVM.StarterKit
         /// <inheritdoc/>
         protected override TProperty? GetConvertedValue(TProperty? value) =>
             _converter is not null ? _converter.Convert(value) : value;
+
+        /// <inheritdoc/>
+        protected override TProperty? GetConvertedBackValue(TProperty? value) =>
+            _converter is ITwoWayConverter<TProperty?, TProperty?> twoWay ? twoWay.ConvertBack(value) : value;
+
+        /// <inheritdoc/>
+        protected override void OnBound()
+        {
+            WarnAboutOneWayConverter();
+            base.OnBound();
+        }
+
+        private void WarnAboutOneWayConverter()
+        {
+            if (Mode is not (BindMode.OneWayToSource or BindMode.TwoWay)) return;
+            if (_converter is null or ITwoWayConverter<TProperty?, TProperty?>) return;
+
+            Debug.LogWarning(
+                $"{GetType().Name} is bound as {Mode} with {_converter.GetType().Name}, which converts "
+                + "one way only. Values sent back to the ViewModel are not converted.");
+        }
     }
 }

--- a/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Runtime/Converters/Composition/PassthroughConverter.cs
+++ b/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Runtime/Converters/Composition/PassthroughConverter.cs
@@ -12,7 +12,7 @@ namespace Aspid.MVVM.StarterKit
     /// deliberate no-op rather than an unfilled slot — and as a neutral element in code.
     /// </remarks>
     [Serializable]
-    public sealed class PassthroughConverter<T> : IConverter<T, T>
+    public sealed class PassthroughConverter<T> : ITwoWayConverter<T, T>
     {
         /// <summary>
         /// Returns the specified value unchanged.
@@ -20,5 +20,12 @@ namespace Aspid.MVVM.StarterKit
         /// <param name="value">The value to pass through.</param>
         /// <returns>The same value.</returns>
         public T Convert(T value) => value;
+
+        /// <summary>
+        /// Returns the specified value unchanged.
+        /// </summary>
+        /// <param name="value">The value to pass through.</param>
+        /// <returns>The same value.</returns>
+        public T ConvertBack(T value) => value;
     }
 }

--- a/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Runtime/Converters/ITwoWayConverter.cs
+++ b/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Runtime/Converters/ITwoWayConverter.cs
@@ -1,0 +1,31 @@
+// ReSharper disable once CheckNamespace
+namespace Aspid.MVVM.StarterKit
+{
+    /// <summary>
+    /// A converter that can also undo itself, for values travelling back to the ViewModel.
+    /// </summary>
+    /// <typeparam name="TFrom">The type held by the ViewModel.</typeparam>
+    /// <typeparam name="TTo">The type held by the View.</typeparam>
+    /// <remarks>
+    /// Most conversions are one-directional and cannot be undone — a number rendered as text, a
+    /// vector reduced to one axis — so this is opt-in. A binder in
+    /// <see cref="BindMode.OneWayToSource"/> or <see cref="BindMode.TwoWay"/> applies
+    /// <see cref="ConvertBack"/> when the configured converter offers it, and sends the value
+    /// unchanged when it does not.
+    /// <para>
+    /// <see cref="ConvertBack"/> is expected to satisfy
+    /// <c>ConvertBack(Convert(x)) == x</c> for every value the binder can carry. A converter that
+    /// cannot promise that should not implement this interface: the alternative is a value that
+    /// silently drifts every time it makes the round trip.
+    /// </para>
+    /// </remarks>
+    public interface ITwoWayConverter<TFrom, TTo> : IConverter<TFrom, TTo>
+    {
+        /// <summary>
+        /// Converts a value coming back from the View.
+        /// </summary>
+        /// <param name="value">The value to convert back.</param>
+        /// <returns>The value as the ViewModel expects it.</returns>
+        public TFrom ConvertBack(TTo value);
+    }
+}

--- a/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Runtime/Converters/ITwoWayConverter.cs
+++ b/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Runtime/Converters/ITwoWayConverter.cs
@@ -7,16 +7,12 @@ namespace Aspid.MVVM.StarterKit
     /// <typeparam name="TFrom">The type held by the ViewModel.</typeparam>
     /// <typeparam name="TTo">The type held by the View.</typeparam>
     /// <remarks>
-    /// Most conversions are one-directional and cannot be undone — a number rendered as text, a
-    /// vector reduced to one axis — so this is opt-in. A binder in
-    /// <see cref="BindMode.OneWayToSource"/> or <see cref="BindMode.TwoWay"/> applies
-    /// <see cref="ConvertBack"/> when the configured converter offers it, and sends the value
-    /// unchanged when it does not.
+    /// Most conversions cannot be undone — a number rendered as text, a vector reduced to one axis —
+    /// so this is opt-in: a binder in <see cref="BindMode.OneWayToSource"/> or
+    /// <see cref="BindMode.TwoWay"/> sends the value unchanged when the converter does not offer it.
     /// <para>
-    /// <see cref="ConvertBack"/> is expected to satisfy
-    /// <c>ConvertBack(Convert(x)) == x</c> for every value the binder can carry. A converter that
-    /// cannot promise that should not implement this interface: the alternative is a value that
-    /// silently drifts every time it makes the round trip.
+    /// <see cref="ConvertBack"/> must satisfy <c>ConvertBack(Convert(x)) == x</c> for every value the
+    /// binder can carry; a converter that cannot promise that makes the value drift each round trip.
     /// </para>
     /// </remarks>
     public interface ITwoWayConverter<TFrom, TTo> : IConverter<TFrom, TTo>

--- a/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Runtime/Converters/ITwoWayConverter.cs.meta
+++ b/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Runtime/Converters/ITwoWayConverter.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: d336c5e415b014814b419101e67af350

--- a/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Runtime/Converters/Numbers/ArithmeticNumberConverter.cs
+++ b/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Runtime/Converters/Numbers/ArithmeticNumberConverter.cs
@@ -19,7 +19,11 @@ namespace Aspid.MVVM.StarterKit
         IConverterDouble, IConverterIntToDouble, IConverterLongToDouble, IConverterFloatToDouble,
         IConverterFloat, IConverterIntToFloat, IConverterLongToFloat, IConverterDoubleToFloat,
         IConverterInt, IConverterLongToInt, IConverterFloatToInt, IConverterDoubleToInt,
-        IConverterLong, IConverterIntToLong, IConverterFloatToLong, IConverterDoubleToLong
+        IConverterLong, IConverterIntToLong, IConverterFloatToLong, IConverterDoubleToLong,
+        ITwoWayConverter<double, double>,
+        ITwoWayConverter<float, float>,
+        ITwoWayConverter<int, int>,
+        ITwoWayConverter<long, long>
     {
         [SerializeField] private NumberOperation _operation;
         [SerializeField] private double _coefficient;
@@ -109,6 +113,36 @@ namespace Aspid.MVVM.StarterKit
         
         double IConverter<long, double>.Convert(long value) =>
             ((IConverter<double, double>)this).Convert(value);
+        #endregion
+
+        #region Convert back
+        // Only the same-type conversions are reversible: a binder in a reverse mode is constrained to
+        // IConverter<TProperty, TProperty>, and the cross-type overloads narrow, which cannot be undone.
+        double ITwoWayConverter<double, double>.ConvertBack(double value) => Undo(value);
+
+        float ITwoWayConverter<float, float>.ConvertBack(float value) => (float)Undo(value);
+
+        int ITwoWayConverter<int, int>.ConvertBack(int value) => (int)Undo(value);
+
+        long ITwoWayConverter<long, long>.ConvertBack(long value) => (long)Undo(value);
+
+        private double Undo(double value) => _operation switch
+        {
+            NumberOperation.Plus => value - _coefficient,
+            NumberOperation.Minus => value + _coefficient,
+            NumberOperation.Division => value * _coefficient,
+            NumberOperation.Multiply => UndoMultiply(value),
+            _ => throw new ArgumentOutOfRangeException(nameof(_operation), _operation, null)
+        };
+
+        // Mirrors Divide: a zero coefficient makes the forward pass an identity, so undoing it is one too.
+        private double UndoMultiply(double value)
+        {
+            if (_coefficient != 0) return value / _coefficient;
+
+            LogDivideByZero();
+            return value;
+        }
         #endregion
     }
 }

--- a/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Runtime/Converters/Numbers/ArithmeticNumberConverter.cs
+++ b/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Runtime/Converters/Numbers/ArithmeticNumberConverter.cs
@@ -20,22 +20,13 @@ namespace Aspid.MVVM.StarterKit
         IConverterFloat, IConverterIntToFloat, IConverterLongToFloat, IConverterDoubleToFloat,
         IConverterInt, IConverterLongToInt, IConverterFloatToInt, IConverterDoubleToInt,
         IConverterLong, IConverterIntToLong, IConverterFloatToLong, IConverterDoubleToLong,
-        ITwoWayConverter<double, double>,
-        ITwoWayConverter<float, float>,
-        ITwoWayConverter<int, int>,
-        ITwoWayConverter<long, long>
+        ITwoWayConverter<double, double>, ITwoWayConverter<float, float>, ITwoWayConverter<int, int>, ITwoWayConverter<long, long>
     {
-        [SerializeField] private NumberOperation _operation;
         [SerializeField] private double _coefficient;
+        [SerializeField] private NumberOperation _operation;
 
-        /// <summary>
-        /// Initializes a new instance of the <see cref="ArithmeticNumberConverter"/> class with default settings.
-        /// </summary>
         public ArithmeticNumberConverter() { }
 
-        /// <summary>
-        /// Initializes a new instance of the <see cref="ArithmeticNumberConverter"/> class.
-        /// </summary>
         /// <param name="operation">The arithmetic operation to perform.</param>
         /// <param name="coefficient">The coefficient to use in the operation.</param>
         public ArithmeticNumberConverter(NumberOperation operation, double coefficient)
@@ -96,15 +87,6 @@ namespace Aspid.MVVM.StarterKit
             _ => throw new ArgumentOutOfRangeException(nameof(_operation), _operation, null)
         };
 
-        private double Divide(double value)
-        {
-            if (_coefficient != 0)
-                return value / _coefficient;
-
-            Debug.LogError($"{nameof(ArithmeticNumberConverter)}: division by zero coefficient. Returning the input value unchanged.");
-            return value;
-        }
-
         double IConverter<int, double>.Convert(int value) =>
             ((IConverter<double, double>)this).Convert(value);
         
@@ -116,33 +98,38 @@ namespace Aspid.MVVM.StarterKit
         #endregion
 
         #region Convert back
-        // Only the same-type conversions are reversible: a binder in a reverse mode is constrained to
-        // IConverter<TProperty, TProperty>, and the cross-type overloads narrow, which cannot be undone.
-        double ITwoWayConverter<double, double>.ConvertBack(double value) => Undo(value);
+        double ITwoWayConverter<double, double>.ConvertBack(double value) => 
+            Undo(value);
 
-        float ITwoWayConverter<float, float>.ConvertBack(float value) => (float)Undo(value);
+        float ITwoWayConverter<float, float>.ConvertBack(float value) => 
+            (float)Undo(value);
 
-        int ITwoWayConverter<int, int>.ConvertBack(int value) => (int)Undo(value);
+        int ITwoWayConverter<int, int>.ConvertBack(int value) => 
+            (int)Undo(value);
 
-        long ITwoWayConverter<long, long>.ConvertBack(long value) => (long)Undo(value);
+        long ITwoWayConverter<long, long>.ConvertBack(long value) => 
+            (long)Undo(value);
 
         private double Undo(double value) => _operation switch
         {
             NumberOperation.Plus => value - _coefficient,
             NumberOperation.Minus => value + _coefficient,
             NumberOperation.Division => value * _coefficient,
-            NumberOperation.Multiply => UndoMultiply(value),
+            NumberOperation.Multiply => Divide(value),
             _ => throw new ArgumentOutOfRangeException(nameof(_operation), _operation, null)
         };
-
-        // Mirrors Divide: a zero coefficient makes the forward pass an identity, so undoing it is one too.
-        private double UndoMultiply(double value)
+        #endregion
+        
+        private double Divide(double value)
         {
-            if (_coefficient != 0) return value / _coefficient;
+            if (_coefficient != 0)
+                return value / _coefficient;
 
             LogDivideByZero();
             return value;
         }
-        #endregion
+
+        private static void LogDivideByZero() =>
+            Debug.LogError($"{nameof(ArithmeticNumberConverter)}: division by zero coefficient. Returning the input value unchanged.");
     }
 }

--- a/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Runtime/Converters/SequenceConverters.cs
+++ b/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Runtime/Converters/SequenceConverters.cs
@@ -14,7 +14,7 @@ namespace Aspid.MVVM.StarterKit
     /// skipped rather than treated as an error.
     /// </remarks>
     [Serializable]
-    public class SequenceConverters<T> : IConverter<T, T>
+    public class SequenceConverters<T> : ITwoWayConverter<T, T>
     {
         // ReSharper disable once FieldCanBeMadeReadOnly.Local
         [SerializeReference] private IConverter<T, T>?[] _converters;
@@ -42,6 +42,31 @@ namespace Aspid.MVVM.StarterKit
                 if (converter is not null)
                     value = converter.Convert(value);
             }
+
+            return value;
+        }
+
+        /// <summary>
+        /// Converts the specified value by undoing each converter in reverse order.
+        /// </summary>
+        /// <param name="value">The value to convert back.</param>
+        /// <returns>
+        /// The result after every link has been undone, or the value unchanged if any link converts
+        /// one way only — undoing part of a chain would leave the value in neither space.
+        /// </returns>
+        public T ConvertBack(T value)
+        {
+            if (_converters is null) return value;
+
+            for (var i = _converters.Length - 1; i >= 0; i--)
+            {
+                if (_converters[i] is null) continue;
+                if (_converters[i] is not ITwoWayConverter<T, T>) return value;
+            }
+
+            for (var i = _converters.Length - 1; i >= 0; i--)
+                if (_converters[i] is ITwoWayConverter<T, T> twoWay)
+                    value = twoWay.ConvertBack(value);
 
             return value;
         }

--- a/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Unity/Runtime/Binders/Mono/ComponentProperty/ComponentMonoBinder.cs
+++ b/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Unity/Runtime/Binders/Mono/ComponentProperty/ComponentMonoBinder.cs
@@ -94,8 +94,7 @@ namespace Aspid.MVVM.StarterKit
         where TComponent : Component
         where TConverter : IConverter<TProperty, TProperty>
     {
-        [Tooltip("Optional converter applied to the value on its way to the component. It also runs in "
-            + "reverse only if it implements ITwoWayConverter.")]
+        [Tooltip("Optional converter applied to the value on its way to the component. It also runs in reverse only if it implements ITwoWayConverter.")]
         [SerializeReference] private TConverter _converter;
 
         /// <inheritdoc/>
@@ -119,8 +118,7 @@ namespace Aspid.MVVM.StarterKit
             if (_converter is null or ITwoWayConverter<TProperty, TProperty>) return;
 
             Debug.LogWarning(
-                $"{GetType().Name} is bound as {Mode} with {_converter.GetType().Name}, which converts "
-                + "one way only. Values sent back to the ViewModel are not converted.",
+                $"{GetType().Name} is bound as {Mode} with {_converter.GetType().Name}, which converts one way only. Values sent back to the ViewModel are not converted.",
                 context: this);
         }
     }

--- a/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Unity/Runtime/Binders/Mono/ComponentProperty/ComponentMonoBinder.cs
+++ b/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Unity/Runtime/Binders/Mono/ComponentProperty/ComponentMonoBinder.cs
@@ -55,18 +55,30 @@ namespace Aspid.MVVM.StarterKit
 
         /// <summary>
         /// Raises <see cref="ValueChanged"/> with <paramref name="value"/>,
-        /// passing it through <see cref="GetConvertedValue"/> first.
+        /// passing it through <see cref="GetConvertedBackValue"/> first.
         /// </summary>
         /// <param name="value">The value to send to the ViewModel.</param>
         protected void RaiseValueChanged(TProperty value) =>
-            ValueChanged?.Invoke(GetConvertedValue(value));
+            ValueChanged?.Invoke(GetConvertedBackValue(value));
 
         /// <summary>
-        /// Converts <paramref name="value"/> before it is applied to the component or sent back to the ViewModel. Returns the value unchanged by default.
+        /// Converts <paramref name="value"/> before it is applied to the component. Returns the value unchanged by default.
         /// </summary>
         /// <param name="value">The value to convert.</param>
         /// <returns>The converted value.</returns>
         protected virtual TProperty GetConvertedValue(TProperty value) => value;
+
+        /// <summary>
+        /// Converts <paramref name="value"/> before it is sent back to the ViewModel. Returns the value unchanged by default.
+        /// </summary>
+        /// <param name="value">The value to convert.</param>
+        /// <returns>The converted value.</returns>
+        /// <remarks>
+        /// Separate from <see cref="GetConvertedValue"/> because the reverse direction is not the
+        /// forward one: applying the forward conversion again compounds it, so a ×100 converter
+        /// turns 0.75 into 7500 on the way back rather than into 0.75.
+        /// </remarks>
+        protected virtual TProperty GetConvertedBackValue(TProperty value) => value;
     }
     
     /// <summary>
@@ -82,10 +94,34 @@ namespace Aspid.MVVM.StarterKit
         where TComponent : Component
         where TConverter : IConverter<TProperty, TProperty>
     {
+        [Tooltip("Optional converter applied to the value on its way to the component. It also runs in "
+            + "reverse only if it implements ITwoWayConverter.")]
         [SerializeReference] private TConverter _converter;
 
         /// <inheritdoc/>
         protected override TProperty GetConvertedValue(TProperty value) =>
             _converter is not null ? _converter.Convert(value) : value;
+
+        /// <inheritdoc/>
+        protected override TProperty GetConvertedBackValue(TProperty value) =>
+            _converter is ITwoWayConverter<TProperty, TProperty> twoWay ? twoWay.ConvertBack(value) : value;
+
+        /// <inheritdoc/>
+        protected override void OnBound()
+        {
+            WarnAboutOneWayConverter();
+            base.OnBound();
+        }
+
+        private void WarnAboutOneWayConverter()
+        {
+            if (Mode is not (BindMode.OneWayToSource or BindMode.TwoWay)) return;
+            if (_converter is null or ITwoWayConverter<TProperty, TProperty>) return;
+
+            Debug.LogWarning(
+                $"{GetType().Name} is bound as {Mode} with {_converter.GetType().Name}, which converts "
+                + "one way only. Values sent back to the ViewModel are not converted.",
+                context: this);
+        }
     }
 }

--- a/Aspid.MVVM/Packages/tech.aspid.mvvm/Tests/Editor/Converters/TwoWayConverterTests.cs
+++ b/Aspid.MVVM/Packages/tech.aspid.mvvm/Tests/Editor/Converters/TwoWayConverterTests.cs
@@ -1,0 +1,123 @@
+using NUnit.Framework;
+
+namespace Aspid.MVVM.StarterKit.Tests
+{
+    /// <summary>
+    /// Coverage for <see cref="ITwoWayConverter{TFrom, TTo}"/> and the converters that implement it.
+    /// </summary>
+    /// <remarks>
+    /// The contract each implementation signs is <c>ConvertBack(Convert(x)) == x</c>, so most of what
+    /// follows is a round trip rather than a hand-computed expected value.
+    /// </remarks>
+    [TestFixture]
+    internal sealed class TwoWayConverterTests
+    {
+        [TestCase(NumberOperation.Plus)]
+        [TestCase(NumberOperation.Minus)]
+        [TestCase(NumberOperation.Multiply)]
+        [TestCase(NumberOperation.Division)]
+        public void Arithmetic_RoundTripsDouble(NumberOperation operation)
+        {
+            var converter = TwoWay<double>(operation, coefficient: 4);
+
+            Assert.AreEqual(0.75d, converter.ConvertBack(converter.Convert(0.75d)), delta: 1e-12);
+        }
+
+        // The audit's example: a x100 converter used to send 0.75 back as 7500, because the reverse
+        // path applied the forward conversion a second time.
+        [Test]
+        public void Arithmetic_MultiplyUndoesRatherThanCompounds()
+        {
+            var converter = TwoWay<double>(NumberOperation.Multiply, coefficient: 100);
+
+            Assert.AreEqual(75d, converter.Convert(0.75d), delta: 1e-12);
+            Assert.AreEqual(0.75d, converter.ConvertBack(75d), delta: 1e-12);
+        }
+
+        [Test]
+        public void Arithmetic_PlusUndoes() =>
+            Assert.AreEqual(3d, TwoWay<double>(NumberOperation.Plus, 2).ConvertBack(5d), delta: 1e-12);
+
+        [Test]
+        public void Arithmetic_MinusUndoes() =>
+            Assert.AreEqual(3d, TwoWay<double>(NumberOperation.Minus, 2).ConvertBack(1d), delta: 1e-12);
+
+        [Test]
+        public void Arithmetic_DivisionUndoes() =>
+            Assert.AreEqual(6d, TwoWay<double>(NumberOperation.Division, 2).ConvertBack(3d), delta: 1e-12);
+
+        [Test]
+        public void Arithmetic_RoundTripsFloat()
+        {
+            var converter = TwoWay<float>(NumberOperation.Multiply, coefficient: 4);
+
+            Assert.AreEqual(0.75f, converter.ConvertBack(converter.Convert(0.75f)), delta: 1e-6f);
+        }
+
+        [Test]
+        public void Arithmetic_RoundTripsInt()
+        {
+            var converter = TwoWay<int>(NumberOperation.Plus, coefficient: 7);
+
+            Assert.AreEqual(5, converter.ConvertBack(converter.Convert(5)));
+        }
+
+        [Test]
+        public void Arithmetic_RoundTripsLong()
+        {
+            var converter = TwoWay<long>(NumberOperation.Minus, coefficient: 7);
+
+            Assert.AreEqual(5L, converter.ConvertBack(converter.Convert(5L)));
+        }
+
+        [Test]
+        public void Passthrough_RoundTrips() =>
+            Assert.AreEqual(7, new PassthroughConverter<int>().ConvertBack(7));
+
+        [Test]
+        public void Sequence_UndoesEveryLinkInReverseOrder()
+        {
+            var sequence = new SequenceConverters<double>(
+                new ArithmeticNumberConverter(NumberOperation.Plus, 3),
+                new ArithmeticNumberConverter(NumberOperation.Multiply, 2));
+
+            Assert.AreEqual(16d, sequence.Convert(5d), delta: 1e-12);
+            Assert.AreEqual(5d, sequence.ConvertBack(16d), delta: 1e-12);
+        }
+
+        [Test]
+        public void Sequence_EmptyChain_RoundTrips() =>
+            Assert.AreEqual(5d, new SequenceConverters<double>().ConvertBack(5d), delta: 1e-12);
+
+        // Undoing part of a chain would leave the value in neither space, so a single one-way link
+        // makes the whole sequence one-way.
+        [Test]
+        public void Sequence_WithAOneWayLink_ReturnsTheValueUnchanged()
+        {
+            var sequence = new SequenceConverters<double>(
+                new ArithmeticNumberConverter(NumberOperation.Plus, 3),
+                new OneWayDouble());
+
+            Assert.AreEqual(16d, sequence.ConvertBack(16d), delta: 1e-12);
+        }
+
+        [Test]
+        public void Sequence_NullLinksAreSkippedInBothDirections()
+        {
+            var sequence = new SequenceConverters<double>(
+                new ArithmeticNumberConverter(NumberOperation.Plus, 3),
+                null);
+
+            Assert.AreEqual(8d, sequence.Convert(5d), delta: 1e-12);
+            Assert.AreEqual(5d, sequence.ConvertBack(8d), delta: 1e-12);
+        }
+
+        private static ITwoWayConverter<T, T> TwoWay<T>(NumberOperation operation, double coefficient) =>
+            (ITwoWayConverter<T, T>)(object)new ArithmeticNumberConverter(operation, coefficient);
+
+        private sealed class OneWayDouble : IConverter<double, double>
+        {
+            public double Convert(double value) => value;
+        }
+    }
+}

--- a/Aspid.MVVM/Packages/tech.aspid.mvvm/Tests/Editor/Converters/TwoWayConverterTests.cs.meta
+++ b/Aspid.MVVM/Packages/tech.aspid.mvvm/Tests/Editor/Converters/TwoWayConverterTests.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 3983b9b49fd624705a0cb0283a242938


### PR DESCRIPTION
🐛 Audit item 2.2. `RaiseValueChanged` passed the outgoing value through `GetConvertedValue` — the **forward** conversion — so a binder with `ArithmeticNumberConverter` set to ×100 in `OneWayToSource` reported **0.75 as 7500**. The type system cannot catch it: `IConverter<TProperty, TProperty>` type-checks in both directions.

## Summary

- 🐛 The reverse path gets its own hook — `GetConvertedValue` splits into forward and `GetConvertedBackValue` on both affected bases.
- ✨ `ITwoWayConverter<TFrom, TTo>`, opt-in, because most conversions genuinely cannot be undone.
- ⚠️ A binder bound in a reverse mode with a one-way converter warns once, so the silent case becomes visible.
- ✅ Implemented for `ArithmeticNumberConverter` (its four same-type overloads), `PassthroughConverter` and `SequenceConverters`.

## Notes for review

- 📝 The ~100 existing `GetConvertedValue` overrides keep working untouched — they are all forward-only, and nothing had to be renamed at the call sites.
- ⚠️ This changes behaviour on purpose: the old double-forward pass produced a wrong number in every case where the converter was not an involution, so there is nothing to preserve.
- 📝 `SequenceConverters` refuses to partly undo — if any link is one-way it returns the value unchanged, since a partly undone chain leaves the value in neither space.

✅ Local run: 225 total, 223 passed, 0 failed, 2 skipped.

<details>
<summary>🇷🇺 Описание на русском</summary>

🐛 Пункт аудита 2.2. `RaiseValueChanged` прогонял исходящее значение через `GetConvertedValue` — **прямое** преобразование, — поэтому биндер с `ArithmeticNumberConverter` на ×100 в `OneWayToSource` сообщал **0.75 как 7500**. Типы это не ловят: `IConverter<TProperty, TProperty>` проходит проверку в обе стороны.

## Итог

- 🐛 У обратного пути свой хук — `GetConvertedValue` разделён на прямой и `GetConvertedBackValue` в обеих затронутых базах.
- ✨ `ITwoWayConverter<TFrom, TTo>`, opt-in, потому что большинство преобразований действительно необратимы.
- ⚠️ Биндер в обратном режиме с односторонним конвертером предупреждает один раз — молчаливый случай становится видимым.
- ✅ Реализовано для `ArithmeticNumberConverter` (четыре однотипные перегрузки), `PassthroughConverter` и `SequenceConverters`.

## Заметки для ревью

- 📝 ~100 существующих override `GetConvertedValue` работают без правок — все они прямые, и переименовывать вызовы не пришлось.
- ⚠️ Поведение меняется намеренно: старый двойной прямой проход давал неверное число в каждом случае, где конвертер не был инволюцией, — сохранять нечего.
- 📝 `SequenceConverters` отказывается отменять частично — если хоть одно звено одностороннее, значение возвращается без изменений, потому что частично отменённая цепочка оставляет его ни в одном из пространств.

✅ Локальный прогон: 225 всего, 223 прошло, 0 упало, 2 пропущено.

</details>
