### PR TITLE
feat(starterkit): let string converters choose their culture

### DIFF
--- a/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Runtime/Converters/Strings/Extensions/ToCultureStringExtensions.cs
+++ b/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Runtime/Converters/Strings/Extensions/ToCultureStringExtensions.cs
@@ -4,16 +4,31 @@ using System.Globalization;
 // ReSharper disable once CheckNamespace
 namespace Aspid.MVVM.StarterKit
 {
+    /// <summary>
+    /// Turns a <see cref="CultureInfoMode"/> into the culture it names, and formats numbers with it.
+    /// </summary>
     public static class ToCultureStringExtensions
     {
+        /// <summary>
+        /// Resolves the culture a <see cref="CultureInfoMode"/> names.
+        /// </summary>
+        /// <param name="mode">The mode to resolve.</param>
+        /// <returns>The named culture, never <see langword="null"/>.</returns>
+        /// <exception cref="ArgumentOutOfRangeException">Thrown when <paramref name="mode"/> is not a declared value.</exception>
+        /// <remarks>
+        /// Both <c>DefaultThread…</c> statics are <see langword="null"/> until an application sets
+        /// them, which is the usual state — those two entries in the Inspector dropdown would
+        /// otherwise do nothing and hand a <see langword="null"/> culture to the caller. They fall
+        /// back to the corresponding current culture instead.
+        /// </remarks>
         public static CultureInfo ToCultureInfo(this CultureInfoMode mode) => mode switch
         {
             CultureInfoMode.CurrentCulture => CultureInfo.CurrentCulture,
             CultureInfoMode.CurrentUICulture => CultureInfo.CurrentUICulture,
             CultureInfoMode.InvariantCulture => CultureInfo.InvariantCulture,
             CultureInfoMode.InstalledUICulture => CultureInfo.InstalledUICulture,
-            CultureInfoMode.DefaultThreadCurrentCulture => CultureInfo.DefaultThreadCurrentCulture,
-            CultureInfoMode.DefaultThreadCurrentUICulture => CultureInfo.DefaultThreadCurrentUICulture,
+            CultureInfoMode.DefaultThreadCurrentCulture => CultureInfo.DefaultThreadCurrentCulture ?? CultureInfo.CurrentCulture,
+            CultureInfoMode.DefaultThreadCurrentUICulture => CultureInfo.DefaultThreadCurrentUICulture ?? CultureInfo.CurrentUICulture,
             _ => throw new ArgumentOutOfRangeException(nameof(mode), mode, null)
         };
 

--- a/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Runtime/Converters/Strings/GenericToString.cs
+++ b/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Runtime/Converters/Strings/GenericToString.cs
@@ -1,5 +1,6 @@
 using System;
 using UnityEngine;
+using System.Globalization;
 
 // ReSharper disable once CheckNamespace
 namespace Aspid.MVVM.StarterKit
@@ -19,6 +20,9 @@ namespace Aspid.MVVM.StarterKit
     {
         [SerializeField] private string? _format;
 
+        [Tooltip("The culture numbers and dates are formatted with. Defaults to the device locale.")]
+        [SerializeField] private CultureInfoMode _culture = CultureInfoMode.CurrentCulture;
+
         public GenericToString()
         {
             _format = string.Empty;
@@ -36,6 +40,11 @@ namespace Aspid.MVVM.StarterKit
         protected string? FormatString => _format;
 
         /// <summary>
+        /// Gets the culture the value is formatted with.
+        /// </summary>
+        protected CultureInfo Culture => _culture.ToCultureInfo();
+
+        /// <summary>
         /// Converts the specified value to a string using the configured format.
         /// </summary>
         /// <param name="value">The value to convert.</param>
@@ -46,7 +55,7 @@ namespace Aspid.MVVM.StarterKit
         public virtual string? Convert(TFrom? value)
         {
             if (value is null) return null;
-            if (string.IsNullOrWhiteSpace(_format)) return value.ToString();
+            if (string.IsNullOrWhiteSpace(_format)) return ToStringValue(value);
 
             try
             {
@@ -78,6 +87,15 @@ namespace Aspid.MVVM.StarterKit
         /// <param name="value">The non-null value to format.</param>
         /// <returns>The formatted string.</returns>
         protected virtual string Format(TFrom value) =>
-            string.Format(_format, value);
+            string.Format(Culture, _format, value);
+
+        // The default is the device locale, which is what ToString() already uses — so the common
+        // path keeps the plain call and takes no boxing for the IFormattable test.
+        private string? ToStringValue(TFrom value) =>
+            _culture is CultureInfoMode.CurrentCulture
+                ? value.ToString()
+                : value is IFormattable formattable
+                    ? formattable.ToString(format: null, Culture)
+                    : value.ToString();
     }
 }

--- a/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Runtime/Converters/Strings/GenericToString.cs
+++ b/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Runtime/Converters/Strings/GenericToString.cs
@@ -91,11 +91,10 @@ namespace Aspid.MVVM.StarterKit
 
         // The default is the device locale, which is what ToString() already uses — so the common
         // path keeps the plain call and takes no boxing for the IFormattable test.
-        private string? ToStringValue(TFrom value) =>
-            _culture is CultureInfoMode.CurrentCulture
-                ? value.ToString()
-                : value is IFormattable formattable
-                    ? formattable.ToString(format: null, Culture)
-                    : value.ToString();
+        private string? ToStringValue(TFrom value) => _culture is CultureInfoMode.CurrentCulture
+            ? value?.ToString()
+            : value is IFormattable formattable
+                ? formattable.ToString(format: null, Culture)
+                : value?.ToString();
     }
 }

--- a/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Unity/Runtime/Converters/Specific/Colors/IConverterColor.cs
+++ b/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Unity/Runtime/Converters/Specific/Colors/IConverterColor.cs
@@ -1,3 +1,4 @@
+#nullable enable
 using UnityEngine;
 
 // ReSharper disable once CheckNamespace

--- a/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Unity/Runtime/Converters/Specific/Colors/IConverterColorBlock.cs
+++ b/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Unity/Runtime/Converters/Specific/Colors/IConverterColorBlock.cs
@@ -1,3 +1,4 @@
+#nullable enable
 using UnityEngine.UI;
 
 // ReSharper disable once CheckNamespace

--- a/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Unity/Runtime/Converters/Specific/IConverterEnumToDropdownOptionData.cs
+++ b/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Unity/Runtime/Converters/Specific/IConverterEnumToDropdownOptionData.cs
@@ -1,3 +1,4 @@
+#nullable enable
 using TMPro;
 using System;
 using System.Collections.Generic;

--- a/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Unity/Runtime/Converters/Specific/IConverterQuaternion.cs
+++ b/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Unity/Runtime/Converters/Specific/IConverterQuaternion.cs
@@ -1,3 +1,4 @@
+#nullable enable
 using UnityEngine;
 
 // ReSharper disable once CheckNamespace

--- a/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Unity/Runtime/Converters/Specific/IConverterRectOffset.cs
+++ b/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Unity/Runtime/Converters/Specific/IConverterRectOffset.cs
@@ -1,3 +1,4 @@
+#nullable enable
 using UnityEngine;
 
 // ReSharper disable once CheckNamespace

--- a/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Unity/Runtime/Converters/Specific/IConverterTexture.cs
+++ b/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Unity/Runtime/Converters/Specific/IConverterTexture.cs
@@ -1,3 +1,4 @@
+#nullable enable
 using UnityEngine;
 
 // ReSharper disable once CheckNamespace

--- a/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Unity/Runtime/Converters/Specific/IConverterTexture2D.cs
+++ b/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Unity/Runtime/Converters/Specific/IConverterTexture2D.cs
@@ -1,3 +1,4 @@
+#nullable enable
 using UnityEngine;
 
 // ReSharper disable once CheckNamespace

--- a/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Unity/Runtime/Converters/Specific/Vectors/IConverterVector2.cs
+++ b/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Unity/Runtime/Converters/Specific/Vectors/IConverterVector2.cs
@@ -1,3 +1,4 @@
+#nullable enable
 using UnityEngine;
 
 // ReSharper disable once CheckNamespace

--- a/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Unity/Runtime/Converters/Specific/Vectors/IConverterVector2ToVector3.cs
+++ b/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Unity/Runtime/Converters/Specific/Vectors/IConverterVector2ToVector3.cs
@@ -1,3 +1,4 @@
+#nullable enable
 using UnityEngine;
 
 // ReSharper disable once CheckNamespace

--- a/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Unity/Runtime/Converters/Specific/Vectors/IConverterVector3.cs
+++ b/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Unity/Runtime/Converters/Specific/Vectors/IConverterVector3.cs
@@ -1,3 +1,4 @@
+#nullable enable
 using UnityEngine;
 
 // ReSharper disable once CheckNamespace

--- a/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Unity/Runtime/Converters/Specific/Vectors/IConverterVector3ToVector2.cs
+++ b/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Unity/Runtime/Converters/Specific/Vectors/IConverterVector3ToVector2.cs
@@ -1,3 +1,4 @@
+#nullable enable
 using UnityEngine;
 
 // ReSharper disable once CheckNamespace

--- a/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Unity/Runtime/Converters/Vectors/BoxColliderCentreCombineConverter.cs
+++ b/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Unity/Runtime/Converters/Vectors/BoxColliderCentreCombineConverter.cs
@@ -1,3 +1,4 @@
+#nullable enable
 using System;
 using UnityEngine;
 

--- a/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Unity/Runtime/Converters/Vectors/BoxColliderSizeCombineConverter.cs
+++ b/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Unity/Runtime/Converters/Vectors/BoxColliderSizeCombineConverter.cs
@@ -1,3 +1,4 @@
+#nullable enable
 using System;
 using UnityEngine;
 

--- a/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Unity/Runtime/Converters/Vectors/CapsuleColliderCentreCombineConverter.cs
+++ b/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Unity/Runtime/Converters/Vectors/CapsuleColliderCentreCombineConverter.cs
@@ -1,3 +1,4 @@
+#nullable enable
 using System;
 using UnityEngine;
 

--- a/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Unity/Runtime/Converters/Vectors/RectTransformAnchoredPositionCombineConverter.cs
+++ b/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Unity/Runtime/Converters/Vectors/RectTransformAnchoredPositionCombineConverter.cs
@@ -1,3 +1,4 @@
+#nullable enable
 using System;
 using UnityEngine;
 

--- a/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Unity/Runtime/Converters/Vectors/SphereColliderCentreCombineConverter.cs
+++ b/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Unity/Runtime/Converters/Vectors/SphereColliderCentreCombineConverter.cs
@@ -1,3 +1,4 @@
+#nullable enable
 using System;
 using UnityEngine;
 

--- a/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Unity/Runtime/Converters/Vectors/TransformEulerAnglesCombineConverter.cs
+++ b/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Unity/Runtime/Converters/Vectors/TransformEulerAnglesCombineConverter.cs
@@ -1,3 +1,4 @@
+#nullable enable
 using System;
 using UnityEngine;
 

--- a/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Unity/Runtime/Converters/Vectors/TransformPositionCombineConverter.cs
+++ b/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Unity/Runtime/Converters/Vectors/TransformPositionCombineConverter.cs
@@ -1,3 +1,4 @@
+#nullable enable
 using System;
 using UnityEngine;
 

--- a/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Unity/Runtime/Converters/Vectors/TransformScaleCombineConverter.cs
+++ b/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Unity/Runtime/Converters/Vectors/TransformScaleCombineConverter.cs
@@ -1,3 +1,4 @@
+#nullable enable
 using System;
 using UnityEngine;
 

--- a/Aspid.MVVM/Packages/tech.aspid.mvvm/Tests/Editor/Converters/Strings/ConverterCultureTests.cs
+++ b/Aspid.MVVM/Packages/tech.aspid.mvvm/Tests/Editor/Converters/Strings/ConverterCultureTests.cs
@@ -1,0 +1,113 @@
+using System;
+using System.Threading;
+using NUnit.Framework;
+using System.Reflection;
+using System.Globalization;
+
+namespace Aspid.MVVM.StarterKit.Tests
+{
+    /// <summary>
+    /// Coverage for the culture a string converter formats with.
+    /// </summary>
+    /// <remarks>
+    /// Every assertion sets the thread culture to German first, because the bug this closes is
+    /// invisible on an English machine: a converter formatted under the device locale with no way to
+    /// override it, so <c>{0:F2}</c> produced <c>3,14</c> on a German device and nothing in the
+    /// Inspector could say otherwise.
+    /// </remarks>
+    [TestFixture]
+    internal sealed class ConverterCultureTests
+    {
+        private CultureInfo _previous;
+
+        [SetUp]
+        public void UseAGermanDevice()
+        {
+            _previous = Thread.CurrentThread.CurrentCulture;
+            Thread.CurrentThread.CurrentCulture = CultureInfo.GetCultureInfo("de-DE");
+        }
+
+        [TearDown]
+        public void RestoreCulture() =>
+            Thread.CurrentThread.CurrentCulture = _previous;
+
+        [Test]
+        public void Format_DefaultsToTheDeviceCulture() =>
+            Assert.AreEqual("3,14", new GenericToString<float>("{0:F2}").Convert(3.14159f));
+
+        [Test]
+        public void Format_HonoursTheConfiguredCulture() =>
+            Assert.AreEqual(
+                "3.14",
+                WithCulture(new GenericToString<float>("{0:F2}"), CultureInfoMode.InvariantCulture).Convert(3.14159f));
+
+        [Test]
+        public void NoFormat_DefaultsToTheDeviceCulture() =>
+            Assert.AreEqual("3,14", new GenericToString<float>().Convert(3.14f));
+
+        [Test]
+        public void NoFormat_HonoursTheConfiguredCulture() =>
+            Assert.AreEqual(
+                "3.14",
+                WithCulture(new GenericToString<float>(), CultureInfoMode.InvariantCulture).Convert(3.14f));
+
+        [Test]
+        public void StringFormatConverter_InheritsTheCultureField() =>
+            Assert.AreEqual(
+                "HP: abc",
+                WithCulture(new StringFormatConverter("HP: {0}"), CultureInfoMode.InvariantCulture).Convert("abc"));
+
+        // Both DefaultThread statics are null until an application sets them, which is the usual
+        // state — two of the six dropdown entries used to resolve to a null culture.
+        [TestCase(CultureInfoMode.DefaultThreadCurrentCulture)]
+        [TestCase(CultureInfoMode.DefaultThreadCurrentUICulture)]
+        public void UnsetDefaultThreadCultures_FallBackInsteadOfReturningNull(CultureInfoMode mode)
+        {
+            var previous = CultureInfo.DefaultThreadCurrentCulture;
+            var previousUi = CultureInfo.DefaultThreadCurrentUICulture;
+
+            try
+            {
+                CultureInfo.DefaultThreadCurrentCulture = null;
+                CultureInfo.DefaultThreadCurrentUICulture = null;
+
+                Assert.IsNotNull(mode.ToCultureInfo());
+            }
+            finally
+            {
+                CultureInfo.DefaultThreadCurrentCulture = previous;
+                CultureInfo.DefaultThreadCurrentUICulture = previousUi;
+            }
+        }
+
+        [TestCase(CultureInfoMode.CurrentCulture)]
+        [TestCase(CultureInfoMode.CurrentUICulture)]
+        [TestCase(CultureInfoMode.InvariantCulture)]
+        [TestCase(CultureInfoMode.InstalledUICulture)]
+        public void EveryDeclaredModeResolves(CultureInfoMode mode) =>
+            Assert.IsNotNull(mode.ToCultureInfo());
+
+        [Test]
+        public void AnUndeclaredModeThrowsWithItsValue() =>
+            Assert.Throws<ArgumentOutOfRangeException>(() => ((CultureInfoMode)99).ToCultureInfo());
+
+        // The culture is Inspector state with no constructor overload, so a test sets it the way the
+        // Inspector does. Walking the base chain covers StringFormatConverter, which inherits it.
+        private static T WithCulture<T>(T converter, CultureInfoMode mode)
+            where T : class
+        {
+            const BindingFlags flags = BindingFlags.Instance | BindingFlags.NonPublic | BindingFlags.DeclaredOnly;
+
+            for (var type = converter.GetType(); type is not null; type = type.BaseType)
+            {
+                var field = type.GetField("_culture", flags);
+                if (field is null) continue;
+
+                field.SetValue(converter, mode);
+                return converter;
+            }
+
+            throw new InvalidOperationException($"{converter.GetType().Name} has no _culture field.");
+        }
+    }
+}

--- a/Aspid.MVVM/Packages/tech.aspid.mvvm/Tests/Editor/Converters/Strings/ConverterCultureTests.cs.meta
+++ b/Aspid.MVVM/Packages/tech.aspid.mvvm/Tests/Editor/Converters/Strings/ConverterCultureTests.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 0c2fd85f79ea14ad294a6b7608846469


### PR DESCRIPTION
✨ Audit items 2.5 and 2.9. `CultureInfoMode` existed and sat on binders, but **no converter read it** — `GenericToString<float>` with `{0:F2}` produced `3,14` on a German device and nothing in the Inspector could say otherwise.

## Summary

- ✨ A culture field on `GenericToString<TFrom>`, inherited by `StringFormatConverter`, `ObjectToStringConverter` and `TimeSpanToStringConverter`.
- 🐛 `ToCultureInfo` no longer returns null: both `DefaultThread…` statics are null until an application sets them, so two of the six dropdown entries resolved to nothing at all.
- 🔧 `#nullable enable` on the 19 Unity-layer converter files that lacked it.

## Notes for review

- ⚡ The no-format path honours the culture but pays nothing by default — the plain `ToString()` call is kept unless a converter is explicitly set to another culture.
- 📝 The tests set the thread culture to German first, because `3.14` and `3,14` only differ where the separator does.
- ⚠️ 2.9 is scoped to the converter files, not the whole assembly: switching on hundreds of binder files at once would bury the real annotations under unrelated warnings.

✅ Local run: 237 total, 235 passed, 0 failed, 2 skipped.

<details>
<summary>🇷🇺 Описание на русском</summary>

✨ Пункты аудита 2.5 и 2.9. `CultureInfoMode` существовал и стоял на биндерах, но **ни один конвертер его не читал** — `GenericToString<float>` с `{0:F2}` давал `3,14` на немецком устройстве, и ничто в инспекторе не могло это изменить.

## Итог

- ✨ Поле культуры на `GenericToString<TFrom>`, наследуется `StringFormatConverter`, `ObjectToStringConverter` и `TimeSpanToStringConverter`.
- 🐛 `ToCultureInfo` больше не возвращает null: оба статика `DefaultThread…` равны null, пока приложение их не задаст, поэтому два из шести пунктов дропдауна не разрешались ни во что.
- 🔧 `#nullable enable` в 19 файлах конвертеров Unity-слоя, где его не было.

## Заметки для ревью

- ⚡ Ветка без формата уважает культуру, но по умолчанию не стоит ничего — обычный вызов `ToString()` сохраняется, пока культуру не задали явно.
- 📝 Тесты сначала ставят немецкую культуру потока, потому что `3.14` и `3,14` отличаются только там, где отличается разделитель.
- ⚠️ 2.9 ограничен файлами конвертеров, а не всей сборкой: включение сразу на сотнях файлов биндеров похоронило бы настоящие аннотации под посторонними предупреждениями.

✅ Локальный прогон: 237 всего, 235 прошло, 0 упало, 2 пропущено.

</details>
