### PR TITLE
feat(starterkit): give converters one vocabulary for failing

### DIFF
--- a/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Runtime/Binders/TargetProperty/TargetBoolBinder.cs
+++ b/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Runtime/Binders/TargetProperty/TargetBoolBinder.cs
@@ -29,7 +29,21 @@ namespace Aspid.MVVM.StarterKit
         }
 
         /// <inheritdoc/>
+        /// <remarks>
+        /// When overriding this method, always call <c>base.GetConvertedValue(value)</c> to preserve
+        /// the inversion.
+        /// </remarks>
         protected override bool GetConvertedValue(bool value) =>
-            _isInvert ? !value : value;
+            Invert(base.GetConvertedValue(value));
+
+        /// <inheritdoc/>
+        /// <remarks>
+        /// Inversion is its own inverse, so the reverse direction mirrors the forward one: undo the
+        /// inversion first, then let the base undo whatever it applied.
+        /// </remarks>
+        protected override bool GetConvertedBackValue(bool value) =>
+            base.GetConvertedBackValue(Invert(value));
+
+        private bool Invert(bool value) => _isInvert ? !value : value;
     }
 }

--- a/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Runtime/Converters/ConverterFailureMode.cs
+++ b/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Runtime/Converters/ConverterFailureMode.cs
@@ -5,13 +5,8 @@ namespace Aspid.MVVM.StarterKit
     /// What a converter does with a value it cannot convert.
     /// </summary>
     /// <remarks>
-    /// The shipped converters each answered this differently — one had a throw switch, one logged and
-    /// passed the value through, one returned a default indistinguishable from success — so a
-    /// designer could not predict what a bad value would do. This is the vocabulary they share.
-    /// <para>
     /// This is about the <i>data</i>: a colour string that does not parse, a number outside a range.
     /// A misconfigured converter is a different matter and always reports itself.
-    /// </para>
     /// </remarks>
     public enum ConverterFailureMode
     {

--- a/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Runtime/Converters/ConverterFailureMode.cs
+++ b/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Runtime/Converters/ConverterFailureMode.cs
@@ -1,0 +1,37 @@
+// ReSharper disable once CheckNamespace
+namespace Aspid.MVVM.StarterKit
+{
+    /// <summary>
+    /// What a converter does with a value it cannot convert.
+    /// </summary>
+    /// <remarks>
+    /// The shipped converters each answered this differently — one had a throw switch, one logged and
+    /// passed the value through, one returned a default indistinguishable from success — so a
+    /// designer could not predict what a bad value would do. This is the vocabulary they share.
+    /// <para>
+    /// This is about the <i>data</i>: a colour string that does not parse, a number outside a range.
+    /// A misconfigured converter is a different matter and always reports itself.
+    /// </para>
+    /// </remarks>
+    public enum ConverterFailureMode
+    {
+        /// <summary>
+        /// Return the converter's configured fallback value and report the failure once.
+        /// </summary>
+        ReturnFallback,
+
+        /// <summary>
+        /// Return the incoming value unchanged and report the failure once. Converters whose input
+        /// and output types differ cannot honour this and treat it as
+        /// <see cref="ReturnFallback"/>.
+        /// </summary>
+        ReturnInput,
+
+        /// <summary>
+        /// Throw. Note that a converter runs inside a binder's value push, and dispatch is a bare
+        /// multicast — an exception here stops every binder queued behind this one. Wrap the
+        /// converter in <see cref="SafeConverter{TFrom, TTo}"/> if the throw should stay local.
+        /// </summary>
+        Throw,
+    }
+}

--- a/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Runtime/Converters/ConverterFailureMode.cs.meta
+++ b/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Runtime/Converters/ConverterFailureMode.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: a3b00ccbe462f465e9bc1a3408cfe3e1

--- a/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Unity/Runtime/Binders/Mono/ComponentProperty/ComponentBoolMonoBinder.cs
+++ b/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Unity/Runtime/Binders/Mono/ComponentProperty/ComponentBoolMonoBinder.cs
@@ -14,7 +14,21 @@ namespace Aspid.MVVM.StarterKit
         [SerializeField] private bool _isInvert;
 
         /// <inheritdoc/>
+        /// <remarks>
+        /// When overriding this method, always call <c>base.GetConvertedValue(value)</c> to preserve
+        /// the inversion.
+        /// </remarks>
         protected override bool GetConvertedValue(bool value) =>
-            _isInvert ? !value : value;
+            Invert(base.GetConvertedValue(value));
+
+        /// <inheritdoc/>
+        /// <remarks>
+        /// Inversion is its own inverse, so the reverse direction mirrors the forward one: undo the
+        /// inversion first, then let the base undo whatever it applied.
+        /// </remarks>
+        protected override bool GetConvertedBackValue(bool value) =>
+            base.GetConvertedBackValue(Invert(value));
+
+        private bool Invert(bool value) => _isInvert ? !value : value;
     }
 }

--- a/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Unity/Runtime/Converters/Colors/ParseHtmlStringConverter.cs
+++ b/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Unity/Runtime/Converters/Colors/ParseHtmlStringConverter.cs
@@ -8,24 +8,69 @@ namespace Aspid.MVVM.StarterKit
     /// <summary>
     /// Converts HTML color strings (e.g., "#FF0000") to <see cref="Color"/> values.
     /// </summary>
+    /// <remarks>
+    /// The default fallback is fully transparent black, which is also what <c>"#00000000"</c> parses
+    /// to — so a failure and a success were indistinguishable in the scene. A failure is now reported
+    /// once, whichever mode is chosen.
+    /// </remarks>
     [Serializable]
     public sealed class ParseHtmlStringConverter : IConverterStringToColor
     {
-        [SerializeField] private bool _throwException;
+        [Tooltip("What to do with a string that does not parse. ReturnInput is not available here — "
+            + "the input is a string and the output a colour — and behaves as ReturnFallback.")]
+        [SerializeField] private ConverterFailureMode _onFailure = ConverterFailureMode.ReturnFallback;
+
+        [Tooltip("Returned when the string does not parse.")]
         [SerializeField] private Color _defaultColor = new(r: 0, g: 0, b: 0, a: 0);
+
+        [NonSerialized] private bool _loggedFailure;
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="ParseHtmlStringConverter"/> class.
+        /// </summary>
+        public ParseHtmlStringConverter() { }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="ParseHtmlStringConverter"/> class.
+        /// </summary>
+        /// <param name="defaultColor">Returned when the string does not parse.</param>
+        /// <param name="onFailure">What to do with a string that does not parse.</param>
+        public ParseHtmlStringConverter(
+            Color defaultColor,
+            ConverterFailureMode onFailure = ConverterFailureMode.ReturnFallback)
+        {
+            _defaultColor = defaultColor;
+            _onFailure = onFailure;
+        }
 
         /// <summary>
         /// Converts an HTML color string to a <see cref="Color"/>.
         /// </summary>
         /// <param name="value">The HTML color string (e.g., "#FF0000").</param>
-        /// <returns>The parsed color, or the default color if parsing fails, and exceptions are disabled.</returns>
-        /// <exception cref="ArgumentException">Thrown when the color string cannot be parsed and exception throwing is enabled.</exception>
+        /// <returns>The parsed color, or the fallback colour when parsing fails.</returns>
+        /// <exception cref="ArgumentException">
+        /// Thrown when the string cannot be parsed and <c>_onFailure</c> is
+        /// <see cref="ConverterFailureMode.Throw"/>.
+        /// </exception>
         public Color Convert(string? value)
         {
             if (ColorUtility.TryParseHtmlString(value, out var color)) return color;
-            if (!_throwException) return _defaultColor;
 
-            throw new ArgumentException($"Invalid value: {value}");
+            if (_onFailure is ConverterFailureMode.Throw)
+                throw new ArgumentException($"Not an HTML colour: \"{value}\"", nameof(value));
+
+            LogFailure(value);
+            return _defaultColor;
+        }
+
+        private void LogFailure(string? value)
+        {
+            if (_loggedFailure) return;
+            _loggedFailure = true;
+
+            Debug.LogError(
+                $"{nameof(ParseHtmlStringConverter)}: \"{value}\" is not an HTML colour. "
+                + "Using the fallback colour.");
         }
     }
 }

--- a/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Unity/Runtime/Converters/Colors/ParseHtmlStringConverter.cs
+++ b/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Unity/Runtime/Converters/Colors/ParseHtmlStringConverter.cs
@@ -11,19 +11,16 @@ namespace Aspid.MVVM.StarterKit
     /// <remarks>
     /// The default fallback is fully transparent black, which is also what <c>"#00000000"</c> parses
     /// to — so a failure and a success were indistinguishable in the scene. A failure is now reported
-    /// once, whichever mode is chosen.
+    /// every time, whichever mode is chosen.
     /// </remarks>
     [Serializable]
     public sealed class ParseHtmlStringConverter : IConverterStringToColor
     {
-        [Tooltip("What to do with a string that does not parse. ReturnInput is not available here — "
-            + "the input is a string and the output a colour — and behaves as ReturnFallback.")]
+        [Tooltip("What to do with a string that does not parse. ReturnInput is not available here — the input is a string and the output a colour — and behaves as ReturnFallback.")]
         [SerializeField] private ConverterFailureMode _onFailure = ConverterFailureMode.ReturnFallback;
 
         [Tooltip("Returned when the string does not parse.")]
         [SerializeField] private Color _defaultColor = new(r: 0, g: 0, b: 0, a: 0);
-
-        [NonSerialized] private bool _loggedFailure;
 
         public ParseHtmlStringConverter() { }
 
@@ -33,8 +30,8 @@ namespace Aspid.MVVM.StarterKit
             Color defaultColor,
             ConverterFailureMode onFailure = ConverterFailureMode.ReturnFallback)
         {
-            _defaultColor = defaultColor;
             _onFailure = onFailure;
+            _defaultColor = defaultColor;
         }
 
         /// <summary>
@@ -53,18 +50,8 @@ namespace Aspid.MVVM.StarterKit
             if (_onFailure is ConverterFailureMode.Throw)
                 throw new ArgumentException($"Not an HTML colour: \"{value}\"", nameof(value));
 
-            LogFailure(value);
+            Debug.LogError($"{nameof(ParseHtmlStringConverter)}: \"{value}\" is not an HTML colour. Using the fallback colour.");
             return _defaultColor;
-        }
-
-        private void LogFailure(string? value)
-        {
-            if (_loggedFailure) return;
-            _loggedFailure = true;
-
-            Debug.LogError(
-                $"{nameof(ParseHtmlStringConverter)}: \"{value}\" is not an HTML colour. "
-                + "Using the fallback colour.");
         }
     }
 }

--- a/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Unity/Runtime/Converters/Colors/ParseHtmlStringConverter.cs
+++ b/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Unity/Runtime/Converters/Colors/ParseHtmlStringConverter.cs
@@ -25,14 +25,8 @@ namespace Aspid.MVVM.StarterKit
 
         [NonSerialized] private bool _loggedFailure;
 
-        /// <summary>
-        /// Initializes a new instance of the <see cref="ParseHtmlStringConverter"/> class.
-        /// </summary>
         public ParseHtmlStringConverter() { }
 
-        /// <summary>
-        /// Initializes a new instance of the <see cref="ParseHtmlStringConverter"/> class.
-        /// </summary>
         /// <param name="defaultColor">Returned when the string does not parse.</param>
         /// <param name="onFailure">What to do with a string that does not parse.</param>
         public ParseHtmlStringConverter(

--- a/Aspid.MVVM/Packages/tech.aspid.mvvm/Tests/Editor/Converters/ParseHtmlStringConverterTests.cs
+++ b/Aspid.MVVM/Packages/tech.aspid.mvvm/Tests/Editor/Converters/ParseHtmlStringConverterTests.cs
@@ -20,9 +20,10 @@ namespace Aspid.MVVM.StarterKit.Tests
             Assert.AreEqual(new Color(r, g, b), new ParseHtmlStringConverter().Convert(html));
 
         [Test]
-        public void Convert_UnparseableString_ReturnsTheFallbackAndReportsOnce()
+        public void Convert_UnparseableString_ReturnsTheFallbackAndReportsEveryTime()
         {
-            LogAssert.Expect(LogType.Error, new Regex("is not an HTML colour"));
+            for (var i = 0; i < 3; i++)
+                LogAssert.Expect(LogType.Error, new Regex("is not an HTML colour"));
 
             var converter = new ParseHtmlStringConverter(Color.magenta);
 

--- a/Aspid.MVVM/Packages/tech.aspid.mvvm/Tests/Editor/Converters/ParseHtmlStringConverterTests.cs
+++ b/Aspid.MVVM/Packages/tech.aspid.mvvm/Tests/Editor/Converters/ParseHtmlStringConverterTests.cs
@@ -1,0 +1,72 @@
+using System;
+using UnityEngine;
+using NUnit.Framework;
+using UnityEngine.TestTools;
+using System.Text.RegularExpressions;
+
+namespace Aspid.MVVM.StarterKit.Tests
+{
+    /// <summary>
+    /// Coverage for <see cref="ParseHtmlStringConverter"/> and, through it, the shared
+    /// <see cref="ConverterFailureMode"/> vocabulary.
+    /// </summary>
+    [TestFixture]
+    internal sealed class ParseHtmlStringConverterTests
+    {
+        [TestCase("#FF0000", 1f, 0f, 0f)]
+        [TestCase("#00FF00", 0f, 1f, 0f)]
+        [TestCase("red", 1f, 0f, 0f)]
+        public void Convert_ParsesAnHtmlColour(string html, float r, float g, float b) =>
+            Assert.AreEqual(new Color(r, g, b), new ParseHtmlStringConverter().Convert(html));
+
+        [Test]
+        public void Convert_UnparseableString_ReturnsTheFallbackAndReportsOnce()
+        {
+            LogAssert.Expect(LogType.Error, new Regex("is not an HTML colour"));
+
+            var converter = new ParseHtmlStringConverter(Color.magenta);
+
+            Assert.AreEqual(Color.magenta, converter.Convert("not a colour"));
+            converter.Convert("still not");
+            converter.Convert("nor this");
+        }
+
+        [Test]
+        public void Convert_Null_ReturnsTheFallback()
+        {
+            LogAssert.Expect(LogType.Error, new Regex("is not an HTML colour"));
+
+            Assert.AreEqual(Color.magenta, new ParseHtmlStringConverter(Color.magenta).Convert(null));
+        }
+
+        [Test]
+        public void Convert_ThrowMode_Throws() =>
+            Assert.Throws<ArgumentException>(
+                () => new ParseHtmlStringConverter(Color.magenta, ConverterFailureMode.Throw).Convert("nope"));
+
+        // The default fallback is transparent black, which "#00000000" also parses to — so before the
+        // failure was reported these two cases were indistinguishable in the scene.
+        [Test]
+        public void Convert_FailureAndTransparentBlack_AreNowDistinguishable()
+        {
+            var converter = new ParseHtmlStringConverter();
+
+            Assert.AreEqual(new Color(0, 0, 0, 0), converter.Convert("#00000000"));
+            LogAssert.NoUnexpectedReceived();
+
+            LogAssert.Expect(LogType.Error, new Regex("is not an HTML colour"));
+            Assert.AreEqual(new Color(0, 0, 0, 0), converter.Convert("nope"));
+        }
+
+        // The input is a string and the output a colour, so there is no input to return.
+        [Test]
+        public void Convert_ReturnInputMode_BehavesAsReturnFallback()
+        {
+            LogAssert.Expect(LogType.Error, new Regex("is not an HTML colour"));
+
+            var converter = new ParseHtmlStringConverter(Color.magenta, ConverterFailureMode.ReturnInput);
+
+            Assert.AreEqual(Color.magenta, converter.Convert("nope"));
+        }
+    }
+}

--- a/Aspid.MVVM/Packages/tech.aspid.mvvm/Tests/Editor/Converters/ParseHtmlStringConverterTests.cs.meta
+++ b/Aspid.MVVM/Packages/tech.aspid.mvvm/Tests/Editor/Converters/ParseHtmlStringConverterTests.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: f2945e6c2d5784809959238772803e7f


### PR DESCRIPTION
✨ Audit items 2.3 and 2.4 — four converters answered "what happens to a value I cannot convert?" four different ways, so a designer could not predict what a bad value would do. Completes Phase 2.

## Summary

- ✨ **`ConverterFailureMode`** — the shared vocabulary: `ReturnFallback`, `ReturnInput`, `Throw`.
- ♻️ `ParseHtmlStringConverter` speaks it; its `_throwException` bool becomes the three-way choice.
- 🐛 A failed parse now reports itself — the default fallback is transparent black, which `"#00000000"` also parses to, so failure and success were indistinguishable in the scene.
- 🐛 **Repairs a regression #159 would have shipped**: inversion is its own inverse, so the old double-forward pass was accidentally right for `TargetBoolBinder` and `ComponentBoolMonoBinder`, and splitting the hook left them reporting the opposite of the truth in `OneWayToSource`.
- ♻️ Both bool binders chain through `base`, as their clamping siblings already do.

## Notes for review

- ⚠️ `ReturnInput` cannot apply where input and output types differ; `ParseHtmlStringConverter` documents the coercion to `ReturnFallback` and a test pins it.
- ⚠️ `Throw` carries a warning in its own summary: dispatch is a bare multicast, so a throw stops every binder queued behind it — the summary points at `SafeConverter`.
- 📝 Audit item 2.4 turned out smaller than expected: both bool binders derive from the two-argument base, which has no converter, so there was nothing to lose — the real defect in that row was the reverse direction above.

✅ Local run: 245 total, 243 passed, 0 failed, 2 skipped.

<details>
<summary>🇷🇺 Описание на русском</summary>

✨ Пункты аудита 2.3 и 2.4 — четыре конвертера отвечали на вопрос «что делать со значением, которое я не могу преобразовать?» четырьмя способами, поэтому дизайнер не мог предсказать поведение на плохом значении. Закрывает Фазу 2.

## Итог

- ✨ **`ConverterFailureMode`** — общий словарь: `ReturnFallback`, `ReturnInput`, `Throw`.
- ♻️ `ParseHtmlStringConverter` на нём; его bool `_throwException` становится выбором из трёх.
- 🐛 Провал разбора теперь сообщается — откат по умолчанию прозрачный чёрный, в который разбирается и `"#00000000"`, поэтому провал и успех были в сцене неразличимы.
- 🐛 **Чинит регрессию, которую отгрузил бы #159**: инверсия сама себе обратна, поэтому старый двойной прямой проход был случайно верен для `TargetBoolBinder` и `ComponentBoolMonoBinder`, а разделение хука оставило их сообщающими противоположное истине в `OneWayToSource`.
- ♻️ Оба bool-биндера вызывают `base`, как уже делают их «клампящие» соседи.

## Заметки для ревью

- ⚠️ `ReturnInput` неприменим там, где типы входа и выхода различаются; `ParseHtmlStringConverter` документирует приведение к `ReturnFallback`, и тест это фиксирует.
- ⚠️ У `Throw` предупреждение в собственном summary: рассылка — голый multicast, поэтому бросок останавливает все биндеры позади; summary указывает на `SafeConverter`.
- 📝 Пункт 2.4 оказался меньше ожидаемого: оба bool-биндера наследуют двухаргументную базу без конвертера, так что терять было нечего — настоящий дефект той строки в обратном направлении выше.

✅ Локальный прогон: 245 всего, 243 прошло, 0 упало, 2 пропущено.

</details>
