### PR TITLE
feat(starterkit): add string manipulation and rich-text converters

### DIFF
--- a/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Runtime/Converters/Strings/ConcatStringConverter.cs
+++ b/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Runtime/Converters/Strings/ConcatStringConverter.cs
@@ -1,0 +1,55 @@
+using System;
+using UnityEngine;
+
+// ReSharper disable once CheckNamespace
+namespace Aspid.MVVM.StarterKit
+{
+    /// <summary>
+    /// Wraps a string in authored text.
+    /// </summary>
+    /// <remarks>
+    /// Friendlier than remembering where <c>{0}</c> goes, and it can leave a blank value alone rather
+    /// than decorating nothing.
+    /// </remarks>
+    [Serializable]
+    public sealed class ConcatStringConverter : IConverterString
+    {
+        [Tooltip("Placed before the value.")]
+        [SerializeField] private string _prefix = string.Empty;
+
+        [Tooltip("Placed after the value.")]
+        [SerializeField] private string _suffix = string.Empty;
+
+        [Tooltip("Leave a blank value undecorated.")]
+        [SerializeField] private bool _skipWhenEmpty = true;
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="ConcatStringConverter"/> class that adds nothing.
+        /// </summary>
+        public ConcatStringConverter() { }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="ConcatStringConverter"/> class.
+        /// </summary>
+        /// <param name="prefix">Placed before the value.</param>
+        /// <param name="suffix">Placed after the value.</param>
+        /// <param name="skipWhenEmpty">If <see langword="true"/>, leaves a blank value undecorated.</param>
+        public ConcatStringConverter(string prefix, string suffix, bool skipWhenEmpty = true)
+        {
+            _prefix = prefix;
+            _suffix = suffix;
+            _skipWhenEmpty = skipWhenEmpty;
+        }
+
+        /// <summary>
+        /// Wraps the specified string.
+        /// </summary>
+        /// <param name="value">The string to wrap.</param>
+        /// <returns>The wrapped string, or the value unchanged when it is blank and that is configured.</returns>
+        public string? Convert(string? value)
+        {
+            if (_skipWhenEmpty && string.IsNullOrWhiteSpace(value)) return value;
+            return _prefix + value + _suffix;
+        }
+    }
+}

--- a/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Runtime/Converters/Strings/ConcatStringConverter.cs
+++ b/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Runtime/Converters/Strings/ConcatStringConverter.cs
@@ -23,14 +23,8 @@ namespace Aspid.MVVM.StarterKit
         [Tooltip("Leave a blank value undecorated.")]
         [SerializeField] private bool _skipWhenEmpty = true;
 
-        /// <summary>
-        /// Initializes a new instance of the <see cref="ConcatStringConverter"/> class that adds nothing.
-        /// </summary>
         public ConcatStringConverter() { }
 
-        /// <summary>
-        /// Initializes a new instance of the <see cref="ConcatStringConverter"/> class.
-        /// </summary>
         /// <param name="prefix">Placed before the value.</param>
         /// <param name="suffix">Placed after the value.</param>
         /// <param name="skipWhenEmpty">If <see langword="true"/>, leaves a blank value undecorated.</param>

--- a/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Runtime/Converters/Strings/ConcatStringConverter.cs.meta
+++ b/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Runtime/Converters/Strings/ConcatStringConverter.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: f40f968243e35eceed76b1a1733c1b36

--- a/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Runtime/Converters/Strings/DefaultStringConverter.cs
+++ b/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Runtime/Converters/Strings/DefaultStringConverter.cs
@@ -1,0 +1,50 @@
+using System;
+using UnityEngine;
+
+// ReSharper disable once CheckNamespace
+namespace Aspid.MVVM.StarterKit
+{
+    /// <summary>
+    /// Substitutes a placeholder for a blank string.
+    /// </summary>
+    /// <remarks>
+    /// A label bound to an unset name should read "—", not nothing. Without this the ViewModel has to
+    /// know what the empty state looks like.
+    /// </remarks>
+    [Serializable]
+    public sealed class DefaultStringConverter : IConverterString
+    {
+        [Tooltip("Shown when the bound string is blank.")]
+        [SerializeField] private string _fallback = "—";
+
+        [Tooltip("Count a string of spaces as blank.")]
+        [SerializeField] private bool _treatWhiteSpaceAsEmpty = true;
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="DefaultStringConverter"/> class with an em dash.
+        /// </summary>
+        public DefaultStringConverter() { }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="DefaultStringConverter"/> class.
+        /// </summary>
+        /// <param name="fallback">Shown when the bound string is blank.</param>
+        /// <param name="treatWhiteSpaceAsEmpty">If <see langword="true"/>, counts a string of spaces as blank.</param>
+        public DefaultStringConverter(string fallback, bool treatWhiteSpaceAsEmpty = true)
+        {
+            _fallback = fallback;
+            _treatWhiteSpaceAsEmpty = treatWhiteSpaceAsEmpty;
+        }
+
+        /// <summary>
+        /// Returns the specified string, or the placeholder when it is blank.
+        /// </summary>
+        /// <param name="value">The string to check.</param>
+        /// <returns>The string, or the placeholder.</returns>
+        public string? Convert(string? value)
+        {
+            var blank = _treatWhiteSpaceAsEmpty ? string.IsNullOrWhiteSpace(value) : string.IsNullOrEmpty(value);
+            return blank ? _fallback : value;
+        }
+    }
+}

--- a/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Runtime/Converters/Strings/DefaultStringConverter.cs
+++ b/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Runtime/Converters/Strings/DefaultStringConverter.cs
@@ -20,14 +20,9 @@ namespace Aspid.MVVM.StarterKit
         [Tooltip("Count a string of spaces as blank.")]
         [SerializeField] private bool _treatWhiteSpaceAsEmpty = true;
 
-        /// <summary>
-        /// Initializes a new instance of the <see cref="DefaultStringConverter"/> class with an em dash.
-        /// </summary>
+        /// <remarks>Default: with an em dash.</remarks>
         public DefaultStringConverter() { }
 
-        /// <summary>
-        /// Initializes a new instance of the <see cref="DefaultStringConverter"/> class.
-        /// </summary>
         /// <param name="fallback">Shown when the bound string is blank.</param>
         /// <param name="treatWhiteSpaceAsEmpty">If <see langword="true"/>, counts a string of spaces as blank.</param>
         public DefaultStringConverter(string fallback, bool treatWhiteSpaceAsEmpty = true)

--- a/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Runtime/Converters/Strings/DefaultStringConverter.cs.meta
+++ b/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Runtime/Converters/Strings/DefaultStringConverter.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 76ddef99a1386d7f12c5338cdceb5370

--- a/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Runtime/Converters/Strings/MaskStringConverter.cs
+++ b/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Runtime/Converters/Strings/MaskStringConverter.cs
@@ -1,0 +1,61 @@
+using System;
+using UnityEngine;
+
+// ReSharper disable once CheckNamespace
+namespace Aspid.MVVM.StarterKit
+{
+    /// <summary>
+    /// Hides the middle of a string, keeping a few characters at each end.
+    /// </summary>
+    /// <remarks>Account identifiers, e-mail addresses and promo codes shown in a settings screen.</remarks>
+    [Serializable]
+    public sealed class MaskStringConverter : IConverterString
+    {
+        [Tooltip("How many characters to leave visible at the start.")]
+        [SerializeField] private int _visibleHead = 2;
+
+        [Tooltip("How many characters to leave visible at the end.")]
+        [SerializeField] private int _visibleTail = 2;
+
+        [Tooltip("The character the hidden part is written with.")]
+        [SerializeField] private char _maskChar = '•';
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="MaskStringConverter"/> class showing two characters at each end.
+        /// </summary>
+        public MaskStringConverter() { }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="MaskStringConverter"/> class.
+        /// </summary>
+        /// <param name="visibleHead">How many characters to leave visible at the start.</param>
+        /// <param name="visibleTail">How many characters to leave visible at the end.</param>
+        /// <param name="maskChar">The character the hidden part is written with.</param>
+        public MaskStringConverter(int visibleHead, int visibleTail, char maskChar = '•')
+        {
+            _visibleHead = visibleHead;
+            _visibleTail = visibleTail;
+            _maskChar = maskChar;
+        }
+
+        /// <summary>
+        /// Masks the middle of the specified string.
+        /// </summary>
+        /// <param name="value">The string to mask.</param>
+        /// <returns>
+        /// The masked string. A string too short to keep both ends is masked completely, so a short
+        /// value never leaks by being left alone.
+        /// </returns>
+        public string? Convert(string? value)
+        {
+            if (string.IsNullOrEmpty(value)) return value;
+
+            var head = Math.Max(0, _visibleHead);
+            var tail = Math.Max(0, _visibleTail);
+
+            if (head + tail >= value!.Length) return new string(_maskChar, value.Length);
+
+            return value[..head] + new string(_maskChar, value.Length - head - tail) + value[^tail..];
+        }
+    }
+}

--- a/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Runtime/Converters/Strings/MaskStringConverter.cs
+++ b/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Runtime/Converters/Strings/MaskStringConverter.cs
@@ -20,14 +20,9 @@ namespace Aspid.MVVM.StarterKit
         [Tooltip("The character the hidden part is written with.")]
         [SerializeField] private char _maskChar = '•';
 
-        /// <summary>
-        /// Initializes a new instance of the <see cref="MaskStringConverter"/> class showing two characters at each end.
-        /// </summary>
+        /// <remarks>Default: showing two characters at each end.</remarks>
         public MaskStringConverter() { }
 
-        /// <summary>
-        /// Initializes a new instance of the <see cref="MaskStringConverter"/> class.
-        /// </summary>
         /// <param name="visibleHead">How many characters to leave visible at the start.</param>
         /// <param name="visibleTail">How many characters to leave visible at the end.</param>
         /// <param name="maskChar">The character the hidden part is written with.</param>

--- a/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Runtime/Converters/Strings/MaskStringConverter.cs.meta
+++ b/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Runtime/Converters/Strings/MaskStringConverter.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: f5eef6b74117673f3d38531ad9a7d9ce

--- a/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Runtime/Converters/Strings/PadStringConverter.cs
+++ b/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Runtime/Converters/Strings/PadStringConverter.cs
@@ -19,14 +19,9 @@ namespace Aspid.MVVM.StarterKit
         [Tooltip("Pad on the left rather than the right.")]
         [SerializeField] private bool _padLeft = true;
 
-        /// <summary>
-        /// Initializes a new instance of the <see cref="PadStringConverter"/> class padding to eight characters.
-        /// </summary>
+        /// <remarks>Default: padding to eight characters.</remarks>
         public PadStringConverter() { }
 
-        /// <summary>
-        /// Initializes a new instance of the <see cref="PadStringConverter"/> class.
-        /// </summary>
         /// <param name="totalWidth">The width to pad to.</param>
         /// <param name="padChar">The character used for padding.</param>
         /// <param name="padLeft">If <see langword="true"/>, pads on the left.</param>

--- a/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Runtime/Converters/Strings/PadStringConverter.cs
+++ b/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Runtime/Converters/Strings/PadStringConverter.cs
@@ -1,0 +1,51 @@
+using System;
+using UnityEngine;
+
+// ReSharper disable once CheckNamespace
+namespace Aspid.MVVM.StarterKit
+{
+    /// <summary>
+    /// Pads a string to a fixed width.
+    /// </summary>
+    [Serializable]
+    public sealed class PadStringConverter : IConverterString
+    {
+        [Tooltip("The width to pad to.")]
+        [SerializeField] private int _totalWidth = 8;
+
+        [Tooltip("The character used for padding.")]
+        [SerializeField] private char _padChar = ' ';
+
+        [Tooltip("Pad on the left rather than the right.")]
+        [SerializeField] private bool _padLeft = true;
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="PadStringConverter"/> class padding to eight characters.
+        /// </summary>
+        public PadStringConverter() { }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="PadStringConverter"/> class.
+        /// </summary>
+        /// <param name="totalWidth">The width to pad to.</param>
+        /// <param name="padChar">The character used for padding.</param>
+        /// <param name="padLeft">If <see langword="true"/>, pads on the left.</param>
+        public PadStringConverter(int totalWidth, char padChar = ' ', bool padLeft = true)
+        {
+            _totalWidth = totalWidth;
+            _padChar = padChar;
+            _padLeft = padLeft;
+        }
+
+        /// <summary>
+        /// Pads the specified string.
+        /// </summary>
+        /// <param name="value">The string to pad.</param>
+        /// <returns>The padded string.</returns>
+        public string? Convert(string? value)
+        {
+            if (value is null) return null;
+            return _padLeft ? value.PadLeft(_totalWidth, _padChar) : value.PadRight(_totalWidth, _padChar);
+        }
+    }
+}

--- a/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Runtime/Converters/Strings/PadStringConverter.cs.meta
+++ b/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Runtime/Converters/Strings/PadStringConverter.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: b649344f9081c842cfcc4b98d95ae047

--- a/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Runtime/Converters/Strings/RepeatStringConverter.cs
+++ b/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Runtime/Converters/Strings/RepeatStringConverter.cs
@@ -1,0 +1,60 @@
+using System;
+using UnityEngine;
+
+// ReSharper disable once CheckNamespace
+namespace Aspid.MVVM.StarterKit
+{
+    /// <summary>
+    /// Repeats a piece of text once per count.
+    /// </summary>
+    /// <remarks>Star ratings and pip counters without an array of sprites.</remarks>
+    [Serializable]
+    public sealed class RepeatStringConverter : IConverter<int, string>
+    {
+        [Tooltip("The text repeated once per count.")]
+        [SerializeField] private string _unit = "★";
+
+        [Tooltip("The text used for the remainder up to the maximum. When empty, nothing is added.")]
+        [SerializeField] private string _emptyUnit = "☆";
+
+        [Tooltip("The total number of units. Zero means no maximum.")]
+        [SerializeField] private int _max = 5;
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="RepeatStringConverter"/> class with five stars.
+        /// </summary>
+        public RepeatStringConverter() { }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="RepeatStringConverter"/> class.
+        /// </summary>
+        /// <param name="unit">The text repeated once per count.</param>
+        /// <param name="max">The total number of units. Zero means no maximum.</param>
+        /// <param name="emptyUnit">The text used for the remainder up to the maximum.</param>
+        public RepeatStringConverter(string unit, int max = 0, string emptyUnit = "")
+        {
+            _unit = unit;
+            _max = max;
+            _emptyUnit = emptyUnit;
+        }
+
+        /// <summary>
+        /// Repeats the unit the specified number of times.
+        /// </summary>
+        /// <param name="value">How many units to write.</param>
+        /// <returns>The repeated text.</returns>
+        public string Convert(int value)
+        {
+            var filled = Math.Max(0, _max > 0 ? Math.Min(value, _max) : value);
+            var builder = new System.Text.StringBuilder();
+
+            for (var i = 0; i < filled; i++) builder.Append(_unit);
+
+            if (_max > 0 && !string.IsNullOrEmpty(_emptyUnit))
+                for (var i = filled; i < _max; i++)
+                    builder.Append(_emptyUnit);
+
+            return builder.ToString();
+        }
+    }
+}

--- a/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Runtime/Converters/Strings/RepeatStringConverter.cs
+++ b/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Runtime/Converters/Strings/RepeatStringConverter.cs
@@ -20,14 +20,9 @@ namespace Aspid.MVVM.StarterKit
         [Tooltip("The total number of units. Zero means no maximum.")]
         [SerializeField] private int _max = 5;
 
-        /// <summary>
-        /// Initializes a new instance of the <see cref="RepeatStringConverter"/> class with five stars.
-        /// </summary>
+        /// <remarks>Default: with five stars.</remarks>
         public RepeatStringConverter() { }
 
-        /// <summary>
-        /// Initializes a new instance of the <see cref="RepeatStringConverter"/> class.
-        /// </summary>
         /// <param name="unit">The text repeated once per count.</param>
         /// <param name="max">The total number of units. Zero means no maximum.</param>
         /// <param name="emptyUnit">The text used for the remainder up to the maximum.</param>

--- a/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Runtime/Converters/Strings/RepeatStringConverter.cs.meta
+++ b/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Runtime/Converters/Strings/RepeatStringConverter.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 114ea61024e42a78bcc499f5ed440fcf

--- a/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Runtime/Converters/Strings/ReplaceStringConverter.cs
+++ b/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Runtime/Converters/Strings/ReplaceStringConverter.cs
@@ -1,0 +1,53 @@
+using System;
+using UnityEngine;
+
+// ReSharper disable once CheckNamespace
+namespace Aspid.MVVM.StarterKit
+{
+    /// <summary>
+    /// Replaces occurrences of one piece of text with another.
+    /// </summary>
+    [Serializable]
+    public sealed class ReplaceStringConverter : IConverterString
+    {
+        [Tooltip("The text to look for. When empty, the string passes through.")]
+        [SerializeField] private string _search = string.Empty;
+
+        [Tooltip("The text put in its place.")]
+        [SerializeField] private string _replacement = string.Empty;
+
+        [Tooltip("Match without regard to case.")]
+        [SerializeField] private bool _ignoreCase;
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="ReplaceStringConverter"/> class that replaces nothing.
+        /// </summary>
+        public ReplaceStringConverter() { }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="ReplaceStringConverter"/> class.
+        /// </summary>
+        /// <param name="search">The text to look for.</param>
+        /// <param name="replacement">The text put in its place.</param>
+        /// <param name="ignoreCase">If <see langword="true"/>, matches without regard to case.</param>
+        public ReplaceStringConverter(string search, string replacement, bool ignoreCase = false)
+        {
+            _search = search;
+            _replacement = replacement;
+            _ignoreCase = ignoreCase;
+        }
+
+        /// <summary>
+        /// Replaces every occurrence in the specified string.
+        /// </summary>
+        /// <param name="value">The string to search.</param>
+        /// <returns>The string with replacements made.</returns>
+        public string? Convert(string? value)
+        {
+            if (value is null || string.IsNullOrEmpty(_search)) return value;
+
+            var comparison = _ignoreCase ? StringComparison.OrdinalIgnoreCase : StringComparison.Ordinal;
+            return value.Replace(_search, _replacement ?? string.Empty, comparison);
+        }
+    }
+}

--- a/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Runtime/Converters/Strings/ReplaceStringConverter.cs
+++ b/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Runtime/Converters/Strings/ReplaceStringConverter.cs
@@ -19,14 +19,8 @@ namespace Aspid.MVVM.StarterKit
         [Tooltip("Match without regard to case.")]
         [SerializeField] private bool _ignoreCase;
 
-        /// <summary>
-        /// Initializes a new instance of the <see cref="ReplaceStringConverter"/> class that replaces nothing.
-        /// </summary>
         public ReplaceStringConverter() { }
 
-        /// <summary>
-        /// Initializes a new instance of the <see cref="ReplaceStringConverter"/> class.
-        /// </summary>
         /// <param name="search">The text to look for.</param>
         /// <param name="replacement">The text put in its place.</param>
         /// <param name="ignoreCase">If <see langword="true"/>, matches without regard to case.</param>

--- a/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Runtime/Converters/Strings/ReplaceStringConverter.cs.meta
+++ b/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Runtime/Converters/Strings/ReplaceStringConverter.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: c53492e762b182209f93435bbf69f6f4

--- a/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Runtime/Converters/Strings/SubstringConverter.cs
+++ b/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Runtime/Converters/Strings/SubstringConverter.cs
@@ -17,14 +17,9 @@ namespace Aspid.MVVM.StarterKit
         [Tooltip("How many characters to take. Zero or less takes everything from the start.")]
         [SerializeField] private int _length = 1;
 
-        /// <summary>
-        /// Initializes a new instance of the <see cref="SubstringConverter"/> class taking the first character.
-        /// </summary>
+        /// <remarks>Default: taking the first character.</remarks>
         public SubstringConverter() { }
 
-        /// <summary>
-        /// Initializes a new instance of the <see cref="SubstringConverter"/> class.
-        /// </summary>
         /// <param name="start">Where the slice starts.</param>
         /// <param name="length">How many characters to take.</param>
         public SubstringConverter(int start, int length)

--- a/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Runtime/Converters/Strings/SubstringConverter.cs
+++ b/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Runtime/Converters/Strings/SubstringConverter.cs
@@ -1,0 +1,52 @@
+using System;
+using UnityEngine;
+
+// ReSharper disable once CheckNamespace
+namespace Aspid.MVVM.StarterKit
+{
+    /// <summary>
+    /// Takes a slice out of a string.
+    /// </summary>
+    /// <remarks>An avatar initial, a prefix, a fixed-position field of a code.</remarks>
+    [Serializable]
+    public sealed class SubstringConverter : IConverterString
+    {
+        [Tooltip("Where the slice starts.")]
+        [SerializeField] private int _start;
+
+        [Tooltip("How many characters to take. Zero or less takes everything from the start.")]
+        [SerializeField] private int _length = 1;
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="SubstringConverter"/> class taking the first character.
+        /// </summary>
+        public SubstringConverter() { }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="SubstringConverter"/> class.
+        /// </summary>
+        /// <param name="start">Where the slice starts.</param>
+        /// <param name="length">How many characters to take.</param>
+        public SubstringConverter(int start, int length)
+        {
+            _start = start;
+            _length = length;
+        }
+
+        /// <summary>
+        /// Takes the configured slice.
+        /// </summary>
+        /// <param name="value">The string to slice.</param>
+        /// <returns>The slice, clamped to what the string actually holds.</returns>
+        public string? Convert(string? value)
+        {
+            if (string.IsNullOrEmpty(value)) return value;
+
+            var start = Math.Clamp(_start, 0, value!.Length);
+            var available = value.Length - start;
+            var length = _length <= 0 ? available : Math.Min(_length, available);
+
+            return value.Substring(start, length);
+        }
+    }
+}

--- a/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Runtime/Converters/Strings/SubstringConverter.cs.meta
+++ b/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Runtime/Converters/Strings/SubstringConverter.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 618681781b4eac0806d3cc02d9854e4c

--- a/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Runtime/Converters/Strings/TextCase.cs
+++ b/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Runtime/Converters/Strings/TextCase.cs
@@ -1,0 +1,29 @@
+// ReSharper disable once CheckNamespace
+namespace Aspid.MVVM.StarterKit
+{
+    /// <summary>
+    /// The casing <see cref="TextCaseConverter"/> applies.
+    /// </summary>
+    public enum TextCase
+    {
+        /// <summary>
+        /// Every letter upper case.
+        /// </summary>
+        Upper,
+
+        /// <summary>
+        /// Every letter lower case.
+        /// </summary>
+        Lower,
+
+        /// <summary>
+        /// The first letter of the string upper case, the rest untouched.
+        /// </summary>
+        FirstUpper,
+
+        /// <summary>
+        /// The first letter of every word upper case, the rest lower.
+        /// </summary>
+        Title,
+    }
+}

--- a/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Runtime/Converters/Strings/TextCase.cs.meta
+++ b/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Runtime/Converters/Strings/TextCase.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 812af3554855e9903d0112fc43b6fb16

--- a/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Runtime/Converters/Strings/TextCaseConverter.cs
+++ b/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Runtime/Converters/Strings/TextCaseConverter.cs
@@ -22,14 +22,9 @@ namespace Aspid.MVVM.StarterKit
         [Tooltip("The culture whose casing rules apply. Turkish and Azeri differ from the rest.")]
         [SerializeField] private CultureInfoMode _culture = CultureInfoMode.CurrentCulture;
 
-        /// <summary>
-        /// Initializes a new instance of the <see cref="TextCaseConverter"/> class upper-casing.
-        /// </summary>
+        /// <remarks>Default: upper-casing.</remarks>
         public TextCaseConverter() { }
 
-        /// <summary>
-        /// Initializes a new instance of the <see cref="TextCaseConverter"/> class.
-        /// </summary>
         /// <param name="textCase">Which casing to apply.</param>
         /// <param name="culture">The culture whose casing rules apply.</param>
         public TextCaseConverter(TextCase textCase, CultureInfoMode culture = CultureInfoMode.CurrentCulture)

--- a/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Runtime/Converters/Strings/TextCaseConverter.cs
+++ b/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Runtime/Converters/Strings/TextCaseConverter.cs
@@ -1,0 +1,63 @@
+using System;
+using UnityEngine;
+using System.Globalization;
+
+// ReSharper disable once CheckNamespace
+namespace Aspid.MVVM.StarterKit
+{
+    /// <summary>
+    /// Changes the casing of a string.
+    /// </summary>
+    /// <remarks>
+    /// Casing is presentation, so it belongs on this side of the binding. It is also culture-bound —
+    /// Turkish has a dotless lower-case I, so a naive upper-casing of "i" produces the wrong letter
+    /// there — which is why the culture is a setting rather than an assumption.
+    /// </remarks>
+    [Serializable]
+    public sealed class TextCaseConverter : IConverterString
+    {
+        [Tooltip("Which casing to apply.")]
+        [SerializeField] private TextCase _case;
+
+        [Tooltip("The culture whose casing rules apply. Turkish and Azeri differ from the rest.")]
+        [SerializeField] private CultureInfoMode _culture = CultureInfoMode.CurrentCulture;
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="TextCaseConverter"/> class upper-casing.
+        /// </summary>
+        public TextCaseConverter() { }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="TextCaseConverter"/> class.
+        /// </summary>
+        /// <param name="textCase">Which casing to apply.</param>
+        /// <param name="culture">The culture whose casing rules apply.</param>
+        public TextCaseConverter(TextCase textCase, CultureInfoMode culture = CultureInfoMode.CurrentCulture)
+        {
+            _case = textCase;
+            _culture = culture;
+        }
+
+        /// <summary>
+        /// Applies the configured casing.
+        /// </summary>
+        /// <param name="value">The string to recase.</param>
+        /// <returns>The recased string.</returns>
+        /// <exception cref="ArgumentOutOfRangeException">Thrown when the casing is not a declared value.</exception>
+        public string? Convert(string? value)
+        {
+            if (string.IsNullOrEmpty(value)) return value;
+
+            var culture = _culture.ToCultureInfo();
+
+            return _case switch
+            {
+                TextCase.Upper => value!.ToUpper(culture),
+                TextCase.Lower => value!.ToLower(culture),
+                TextCase.FirstUpper => char.ToUpper(value![0], culture) + value[1..],
+                TextCase.Title => culture.TextInfo.ToTitleCase(value!.ToLower(culture)),
+                _ => throw new ArgumentOutOfRangeException(nameof(_case), _case, null)
+            };
+        }
+    }
+}

--- a/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Runtime/Converters/Strings/TextCaseConverter.cs.meta
+++ b/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Runtime/Converters/Strings/TextCaseConverter.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 9cdcebb9b5e00232473a312f5d34af7e

--- a/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Runtime/Converters/Strings/TrimSide.cs
+++ b/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Runtime/Converters/Strings/TrimSide.cs
@@ -1,0 +1,24 @@
+// ReSharper disable once CheckNamespace
+namespace Aspid.MVVM.StarterKit
+{
+    /// <summary>
+    /// Which ends <see cref="TrimStringConverter"/> trims.
+    /// </summary>
+    public enum TrimSide
+    {
+        /// <summary>
+        /// Both ends.
+        /// </summary>
+        Both,
+
+        /// <summary>
+        /// The start only.
+        /// </summary>
+        Start,
+
+        /// <summary>
+        /// The end only.
+        /// </summary>
+        End,
+    }
+}

--- a/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Runtime/Converters/Strings/TrimSide.cs.meta
+++ b/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Runtime/Converters/Strings/TrimSide.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 406443c5aaed7d563a21a6b5b5440c5c

--- a/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Runtime/Converters/Strings/TrimStringConverter.cs
+++ b/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Runtime/Converters/Strings/TrimStringConverter.cs
@@ -1,0 +1,57 @@
+using System;
+using UnityEngine;
+
+// ReSharper disable once CheckNamespace
+namespace Aspid.MVVM.StarterKit
+{
+    /// <summary>
+    /// Removes surrounding characters from a string.
+    /// </summary>
+    /// <remarks>Sanitising what came back from an input field before it is shown again.</remarks>
+    [Serializable]
+    public sealed class TrimStringConverter : IConverterString
+    {
+        [Tooltip("Which ends to trim.")]
+        [SerializeField] private TrimSide _side = TrimSide.Both;
+
+        [Tooltip("The characters to remove. When empty, whitespace is removed.")]
+        [SerializeField] private string _trimChars = string.Empty;
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="TrimStringConverter"/> class trimming whitespace from both ends.
+        /// </summary>
+        public TrimStringConverter() { }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="TrimStringConverter"/> class.
+        /// </summary>
+        /// <param name="side">Which ends to trim.</param>
+        /// <param name="trimChars">The characters to remove. When empty, whitespace is removed.</param>
+        public TrimStringConverter(TrimSide side, string trimChars = "")
+        {
+            _side = side;
+            _trimChars = trimChars;
+        }
+
+        /// <summary>
+        /// Trims the specified string.
+        /// </summary>
+        /// <param name="value">The string to trim.</param>
+        /// <returns>The trimmed string.</returns>
+        /// <exception cref="ArgumentOutOfRangeException">Thrown when the side is not a declared value.</exception>
+        public string? Convert(string? value)
+        {
+            if (value is null) return null;
+
+            var chars = string.IsNullOrEmpty(_trimChars) ? null : _trimChars.ToCharArray();
+
+            return _side switch
+            {
+                TrimSide.Both => chars is null ? value.Trim() : value.Trim(chars),
+                TrimSide.Start => chars is null ? value.TrimStart() : value.TrimStart(chars),
+                TrimSide.End => chars is null ? value.TrimEnd() : value.TrimEnd(chars),
+                _ => throw new ArgumentOutOfRangeException(nameof(_side), _side, null)
+            };
+        }
+    }
+}

--- a/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Runtime/Converters/Strings/TrimStringConverter.cs
+++ b/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Runtime/Converters/Strings/TrimStringConverter.cs
@@ -17,14 +17,9 @@ namespace Aspid.MVVM.StarterKit
         [Tooltip("The characters to remove. When empty, whitespace is removed.")]
         [SerializeField] private string _trimChars = string.Empty;
 
-        /// <summary>
-        /// Initializes a new instance of the <see cref="TrimStringConverter"/> class trimming whitespace from both ends.
-        /// </summary>
+        /// <remarks>Default: trimming whitespace from both ends.</remarks>
         public TrimStringConverter() { }
 
-        /// <summary>
-        /// Initializes a new instance of the <see cref="TrimStringConverter"/> class.
-        /// </summary>
         /// <param name="side">Which ends to trim.</param>
         /// <param name="trimChars">The characters to remove. When empty, whitespace is removed.</param>
         public TrimStringConverter(TrimSide side, string trimChars = "")

--- a/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Runtime/Converters/Strings/TrimStringConverter.cs.meta
+++ b/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Runtime/Converters/Strings/TrimStringConverter.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 016083644456673eaac6aa3cfa0f9355

--- a/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Runtime/Converters/Strings/TruncateSide.cs
+++ b/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Runtime/Converters/Strings/TruncateSide.cs
@@ -1,0 +1,24 @@
+// ReSharper disable once CheckNamespace
+namespace Aspid.MVVM.StarterKit
+{
+    /// <summary>
+    /// Which end <see cref="TruncateStringConverter"/> cuts from.
+    /// </summary>
+    public enum TruncateSide
+    {
+        /// <summary>
+        /// Keep the start, cut the end.
+        /// </summary>
+        End,
+
+        /// <summary>
+        /// Keep the end, cut the start.
+        /// </summary>
+        Start,
+
+        /// <summary>
+        /// Keep both ends, cut the middle.
+        /// </summary>
+        Middle,
+    }
+}

--- a/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Runtime/Converters/Strings/TruncateSide.cs.meta
+++ b/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Runtime/Converters/Strings/TruncateSide.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 5257305500f73a729365f8647f2ff10a

--- a/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Runtime/Converters/Strings/TruncateStringConverter.cs
+++ b/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Runtime/Converters/Strings/TruncateStringConverter.cs
@@ -27,14 +27,9 @@ namespace Aspid.MVVM.StarterKit
         [Tooltip("Cut at a space rather than mid-word.")]
         [SerializeField] private bool _atWordBoundary;
 
-        /// <summary>
-        /// Initializes a new instance of the <see cref="TruncateStringConverter"/> class cutting at twenty characters.
-        /// </summary>
+        /// <remarks>Default: cutting at twenty characters.</remarks>
         public TruncateStringConverter() { }
 
-        /// <summary>
-        /// Initializes a new instance of the <see cref="TruncateStringConverter"/> class.
-        /// </summary>
         /// <param name="maxLength">The longest string allowed through, ellipsis included.</param>
         /// <param name="side">Which end to cut from.</param>
         /// <param name="atWordBoundary">If <see langword="true"/>, cuts at a space rather than mid-word.</param>

--- a/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Runtime/Converters/Strings/TruncateStringConverter.cs
+++ b/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Runtime/Converters/Strings/TruncateStringConverter.cs
@@ -1,0 +1,83 @@
+using System;
+using UnityEngine;
+
+// ReSharper disable once CheckNamespace
+namespace Aspid.MVVM.StarterKit
+{
+    /// <summary>
+    /// Shortens a string that is too long to fit.
+    /// </summary>
+    /// <remarks>
+    /// Player names, chat lines and item descriptions arrive at whatever length their author chose,
+    /// and a fixed-width control will either clip them without warning or push its neighbours out of
+    /// place.
+    /// </remarks>
+    [Serializable]
+    public sealed class TruncateStringConverter : IConverterString
+    {
+        [Tooltip("The longest string allowed through, ellipsis included.")]
+        [SerializeField] private int _maxLength = 20;
+
+        [Tooltip("Appended where the string was cut.")]
+        [SerializeField] private string _ellipsis = "…";
+
+        [Tooltip("Which end to cut from.")]
+        [SerializeField] private TruncateSide _side = TruncateSide.End;
+
+        [Tooltip("Cut at a space rather than mid-word.")]
+        [SerializeField] private bool _atWordBoundary;
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="TruncateStringConverter"/> class cutting at twenty characters.
+        /// </summary>
+        public TruncateStringConverter() { }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="TruncateStringConverter"/> class.
+        /// </summary>
+        /// <param name="maxLength">The longest string allowed through, ellipsis included.</param>
+        /// <param name="side">Which end to cut from.</param>
+        /// <param name="atWordBoundary">If <see langword="true"/>, cuts at a space rather than mid-word.</param>
+        public TruncateStringConverter(int maxLength, TruncateSide side = TruncateSide.End, bool atWordBoundary = false)
+        {
+            _maxLength = maxLength;
+            _side = side;
+            _atWordBoundary = atWordBoundary;
+        }
+
+        /// <summary>
+        /// Shortens the specified string if it exceeds the limit.
+        /// </summary>
+        /// <param name="value">The string to shorten.</param>
+        /// <returns>The string, no longer than the limit.</returns>
+        /// <exception cref="ArgumentOutOfRangeException">Thrown when the side is not a declared value.</exception>
+        public string? Convert(string? value)
+        {
+            if (value is null || _maxLength <= 0 || value.Length <= _maxLength) return value;
+
+            var ellipsis = _ellipsis ?? string.Empty;
+
+            // Nothing sensible to keep once the marker fills the budget.
+            if (ellipsis.Length >= _maxLength) return ellipsis[.._maxLength];
+
+            var keep = _maxLength - ellipsis.Length;
+
+            return _side switch
+            {
+                TruncateSide.End => Cut(value, keep) + ellipsis,
+                TruncateSide.Start => ellipsis + value[^keep..],
+                TruncateSide.Middle => value[..((keep + 1) / 2)] + ellipsis + value[^(keep / 2)..],
+                _ => throw new ArgumentOutOfRangeException(nameof(_side), _side, null)
+            };
+        }
+
+        private string Cut(string value, int keep)
+        {
+            var head = value[..keep];
+            if (!_atWordBoundary) return head;
+
+            var space = head.LastIndexOf(' ');
+            return space > 0 ? head[..space] : head;
+        }
+    }
+}

--- a/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Runtime/Converters/Strings/TruncateStringConverter.cs.meta
+++ b/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Runtime/Converters/Strings/TruncateStringConverter.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 749d5f25683f8400a9972046c9afd46f

--- a/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Unity/Runtime/Converters/Strings.meta
+++ b/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Unity/Runtime/Converters/Strings.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: b9e5044ae86cb45c585c26f90d22194c
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Unity/Runtime/Converters/Strings/ColorStop.cs
+++ b/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Unity/Runtime/Converters/Strings/ColorStop.cs
@@ -1,0 +1,26 @@
+#nullable enable
+using System;
+using UnityEngine;
+
+// ReSharper disable once CheckNamespace
+namespace Aspid.MVVM.StarterKit
+{
+    /// <summary>
+    /// One colour of a <see cref="ThresholdRichTextColorConverter"/> scale.
+    /// </summary>
+    [Serializable]
+    public struct ColorStop
+    {
+        /// <summary>
+        /// The value at or above which this colour applies.
+        /// </summary>
+        [Tooltip("The value at or above which this colour applies.")]
+        public float Threshold;
+
+        /// <summary>
+        /// The colour used from this threshold up.
+        /// </summary>
+        [Tooltip("The colour used from this threshold up.")]
+        public Color Color;
+    }
+}

--- a/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Unity/Runtime/Converters/Strings/ColorStop.cs.meta
+++ b/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Unity/Runtime/Converters/Strings/ColorStop.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 5f23b704c199c39340e80b447e5a8e49

--- a/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Unity/Runtime/Converters/Strings/RichTextColorConverter.cs
+++ b/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Unity/Runtime/Converters/Strings/RichTextColorConverter.cs
@@ -1,0 +1,52 @@
+#nullable enable
+using System;
+using UnityEngine;
+
+// ReSharper disable once CheckNamespace
+namespace Aspid.MVVM.StarterKit
+{
+    /// <summary>
+    /// Wraps a string in a rich-text colour tag.
+    /// </summary>
+    /// <remarks>
+    /// The Greeter sample writes this by hand as an example of a custom converter; shipping it means
+    /// nobody has to.
+    /// </remarks>
+    [Serializable]
+    public sealed class RichTextColorConverter : IConverterString
+    {
+        [Tooltip("The colour the text is tagged with.")]
+        [SerializeField] private Color _color = Color.white;
+
+        [Tooltip("Include the alpha channel in the tag.")]
+        [SerializeField] private bool _includeAlpha;
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="RichTextColorConverter"/> class colouring white.
+        /// </summary>
+        public RichTextColorConverter() { }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="RichTextColorConverter"/> class.
+        /// </summary>
+        /// <param name="color">The colour the text is tagged with.</param>
+        /// <param name="includeAlpha">If <see langword="true"/>, includes the alpha channel.</param>
+        public RichTextColorConverter(Color color, bool includeAlpha = false)
+        {
+            _color = color;
+            _includeAlpha = includeAlpha;
+        }
+
+        /// <summary>
+        /// Wraps the specified string in a colour tag.
+        /// </summary>
+        /// <param name="value">The string to colour.</param>
+        /// <returns>The tagged string.</returns>
+        public string? Convert(string? value) =>
+            string.IsNullOrEmpty(value) ? value : Wrap(value!, _color, _includeAlpha);
+
+        internal static string Wrap(string value, Color color, bool includeAlpha) =>
+            "<color=#" + (includeAlpha ? ColorUtility.ToHtmlStringRGBA(color) : ColorUtility.ToHtmlStringRGB(color))
+            + ">" + value + "</color>";
+    }
+}

--- a/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Unity/Runtime/Converters/Strings/RichTextColorConverter.cs
+++ b/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Unity/Runtime/Converters/Strings/RichTextColorConverter.cs
@@ -21,14 +21,9 @@ namespace Aspid.MVVM.StarterKit
         [Tooltip("Include the alpha channel in the tag.")]
         [SerializeField] private bool _includeAlpha;
 
-        /// <summary>
-        /// Initializes a new instance of the <see cref="RichTextColorConverter"/> class colouring white.
-        /// </summary>
+        /// <remarks>Default: colouring white.</remarks>
         public RichTextColorConverter() { }
 
-        /// <summary>
-        /// Initializes a new instance of the <see cref="RichTextColorConverter"/> class.
-        /// </summary>
         /// <param name="color">The colour the text is tagged with.</param>
         /// <param name="includeAlpha">If <see langword="true"/>, includes the alpha channel.</param>
         public RichTextColorConverter(Color color, bool includeAlpha = false)

--- a/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Unity/Runtime/Converters/Strings/RichTextColorConverter.cs.meta
+++ b/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Unity/Runtime/Converters/Strings/RichTextColorConverter.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 2a1e012075ebbf2a8139d57e82e6fc21

--- a/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Unity/Runtime/Converters/Strings/RichTextNoParseConverter.cs
+++ b/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Unity/Runtime/Converters/Strings/RichTextNoParseConverter.cs
@@ -1,0 +1,31 @@
+#nullable enable
+using System;
+
+// ReSharper disable once CheckNamespace
+namespace Aspid.MVVM.StarterKit
+{
+    /// <summary>
+    /// Stops rich-text markup in a string from being interpreted.
+    /// </summary>
+    /// <remarks>
+    /// TextMeshPro reads markup out of any text it is given, including text a player typed. A name
+    /// like <c>&lt;size=400%&gt;</c> resizes the label it lands in — and it lands in every label that
+    /// shows that player, on every other player's screen. This is the cheapest correct answer:
+    /// <c>&lt;noparse&gt;</c> tells TMP to render the characters rather than obey them.
+    /// <para>
+    /// Reach for this on anything a player can type. The rest of the converters here add markup and
+    /// are for text the game itself authors.
+    /// </para>
+    /// </remarks>
+    [Serializable]
+    public sealed class RichTextNoParseConverter : IConverterString
+    {
+        /// <summary>
+        /// Wraps the specified string so its markup is shown rather than obeyed.
+        /// </summary>
+        /// <param name="value">The untrusted string.</param>
+        /// <returns>The wrapped string.</returns>
+        public string? Convert(string? value) =>
+            string.IsNullOrEmpty(value) ? value : "<noparse>" + value + "</noparse>";
+    }
+}

--- a/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Unity/Runtime/Converters/Strings/RichTextNoParseConverter.cs
+++ b/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Unity/Runtime/Converters/Strings/RichTextNoParseConverter.cs
@@ -8,14 +8,10 @@ namespace Aspid.MVVM.StarterKit
     /// Stops rich-text markup in a string from being interpreted.
     /// </summary>
     /// <remarks>
-    /// TextMeshPro reads markup out of any text it is given, including text a player typed. A name
-    /// like <c>&lt;size=400%&gt;</c> resizes the label it lands in — and it lands in every label that
-    /// shows that player, on every other player's screen. This is the cheapest correct answer:
-    /// <c>&lt;noparse&gt;</c> tells TMP to render the characters rather than obey them.
-    /// <para>
-    /// Reach for this on anything a player can type. The rest of the converters here add markup and
-    /// are for text the game itself authors.
-    /// </para>
+    /// TextMeshPro reads markup out of any text it is given, including text a player typed: a name like
+    /// <c>&lt;size=400%&gt;</c> resizes every label that shows that player, on every screen.
+    /// <c>&lt;noparse&gt;</c> renders the characters instead. Reach for this on anything a player can
+    /// type — the rest of the converters here add markup and are for text the game itself authors.
     /// </remarks>
     [Serializable]
     public sealed class RichTextNoParseConverter : IConverterString

--- a/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Unity/Runtime/Converters/Strings/RichTextNoParseConverter.cs.meta
+++ b/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Unity/Runtime/Converters/Strings/RichTextNoParseConverter.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 794deffbfe45cad033d362b9d6b094f4

--- a/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Unity/Runtime/Converters/Strings/RichTextSizeConverter.cs
+++ b/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Unity/Runtime/Converters/Strings/RichTextSizeConverter.cs
@@ -1,0 +1,49 @@
+#nullable enable
+using System;
+using UnityEngine;
+
+// ReSharper disable once CheckNamespace
+namespace Aspid.MVVM.StarterKit
+{
+    /// <summary>
+    /// Wraps a string in a rich-text size tag.
+    /// </summary>
+    [Serializable]
+    public sealed class RichTextSizeConverter : IConverterString
+    {
+        [Tooltip("The size applied to the text.")]
+        [SerializeField] private float _size = 100f;
+
+        [Tooltip("Treat the size as a percentage of the label's own size rather than as points.")]
+        [SerializeField] private bool _isPercent = true;
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="RichTextSizeConverter"/> class at full size.
+        /// </summary>
+        public RichTextSizeConverter() { }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="RichTextSizeConverter"/> class.
+        /// </summary>
+        /// <param name="size">The size applied to the text.</param>
+        /// <param name="isPercent">If <see langword="true"/>, treats the size as a percentage.</param>
+        public RichTextSizeConverter(float size, bool isPercent = true)
+        {
+            _size = size;
+            _isPercent = isPercent;
+        }
+
+        /// <summary>
+        /// Wraps the specified string in a size tag.
+        /// </summary>
+        /// <param name="value">The string to resize.</param>
+        /// <returns>The tagged string.</returns>
+        public string? Convert(string? value)
+        {
+            if (string.IsNullOrEmpty(value)) return value;
+
+            var size = _size.ToString(System.Globalization.CultureInfo.InvariantCulture);
+            return "<size=" + size + (_isPercent ? "%>" : ">") + value + "</size>";
+        }
+    }
+}

--- a/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Unity/Runtime/Converters/Strings/RichTextSizeConverter.cs
+++ b/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Unity/Runtime/Converters/Strings/RichTextSizeConverter.cs
@@ -17,14 +17,9 @@ namespace Aspid.MVVM.StarterKit
         [Tooltip("Treat the size as a percentage of the label's own size rather than as points.")]
         [SerializeField] private bool _isPercent = true;
 
-        /// <summary>
-        /// Initializes a new instance of the <see cref="RichTextSizeConverter"/> class at full size.
-        /// </summary>
+        /// <remarks>Default: at full size.</remarks>
         public RichTextSizeConverter() { }
 
-        /// <summary>
-        /// Initializes a new instance of the <see cref="RichTextSizeConverter"/> class.
-        /// </summary>
         /// <param name="size">The size applied to the text.</param>
         /// <param name="isPercent">If <see langword="true"/>, treats the size as a percentage.</param>
         public RichTextSizeConverter(float size, bool isPercent = true)

--- a/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Unity/Runtime/Converters/Strings/RichTextSizeConverter.cs.meta
+++ b/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Unity/Runtime/Converters/Strings/RichTextSizeConverter.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: a5b4abc012ca0b2bfab2e3a4d8293e78

--- a/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Unity/Runtime/Converters/Strings/RichTextStyleConverter.cs
+++ b/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Unity/Runtime/Converters/Strings/RichTextStyleConverter.cs
@@ -23,14 +23,8 @@ namespace Aspid.MVVM.StarterKit
         [Tooltip("Wrap in <s>.")]
         [SerializeField] private bool _strikethrough;
 
-        /// <summary>
-        /// Initializes a new instance of the <see cref="RichTextStyleConverter"/> class with no styling.
-        /// </summary>
         public RichTextStyleConverter() { }
 
-        /// <summary>
-        /// Initializes a new instance of the <see cref="RichTextStyleConverter"/> class.
-        /// </summary>
         /// <param name="bold">Whether to wrap in <c>&lt;b&gt;</c>.</param>
         /// <param name="italic">Whether to wrap in <c>&lt;i&gt;</c>.</param>
         /// <param name="underline">Whether to wrap in <c>&lt;u&gt;</c>.</param>

--- a/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Unity/Runtime/Converters/Strings/RichTextStyleConverter.cs
+++ b/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Unity/Runtime/Converters/Strings/RichTextStyleConverter.cs
@@ -1,0 +1,68 @@
+#nullable enable
+using System;
+using UnityEngine;
+
+// ReSharper disable once CheckNamespace
+namespace Aspid.MVVM.StarterKit
+{
+    /// <summary>
+    /// Wraps a string in rich-text style tags.
+    /// </summary>
+    [Serializable]
+    public sealed class RichTextStyleConverter : IConverterString
+    {
+        [Tooltip("Wrap in <b>.")]
+        [SerializeField] private bool _bold;
+
+        [Tooltip("Wrap in <i>.")]
+        [SerializeField] private bool _italic;
+
+        [Tooltip("Wrap in <u>.")]
+        [SerializeField] private bool _underline;
+
+        [Tooltip("Wrap in <s>.")]
+        [SerializeField] private bool _strikethrough;
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="RichTextStyleConverter"/> class with no styling.
+        /// </summary>
+        public RichTextStyleConverter() { }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="RichTextStyleConverter"/> class.
+        /// </summary>
+        /// <param name="bold">Whether to wrap in <c>&lt;b&gt;</c>.</param>
+        /// <param name="italic">Whether to wrap in <c>&lt;i&gt;</c>.</param>
+        /// <param name="underline">Whether to wrap in <c>&lt;u&gt;</c>.</param>
+        /// <param name="strikethrough">Whether to wrap in <c>&lt;s&gt;</c>.</param>
+        public RichTextStyleConverter(
+            bool bold = false,
+            bool italic = false,
+            bool underline = false,
+            bool strikethrough = false)
+        {
+            _bold = bold;
+            _italic = italic;
+            _underline = underline;
+            _strikethrough = strikethrough;
+        }
+
+        /// <summary>
+        /// Wraps the specified string in the configured tags.
+        /// </summary>
+        /// <param name="value">The string to style.</param>
+        /// <returns>The tagged string.</returns>
+        public string? Convert(string? value)
+        {
+            if (string.IsNullOrEmpty(value)) return value;
+
+            var text = value!;
+            if (_bold) text = "<b>" + text + "</b>";
+            if (_italic) text = "<i>" + text + "</i>";
+            if (_underline) text = "<u>" + text + "</u>";
+            if (_strikethrough) text = "<s>" + text + "</s>";
+
+            return text;
+        }
+    }
+}

--- a/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Unity/Runtime/Converters/Strings/RichTextStyleConverter.cs.meta
+++ b/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Unity/Runtime/Converters/Strings/RichTextStyleConverter.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: d962afa3db121983aef15f030f5b4368

--- a/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Unity/Runtime/Converters/Strings/ThresholdRichTextColorConverter.cs
+++ b/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Unity/Runtime/Converters/Strings/ThresholdRichTextColorConverter.cs
@@ -28,14 +28,8 @@ namespace Aspid.MVVM.StarterKit
         [Tooltip("The culture the number is formatted with.")]
         [SerializeField] private CultureInfoMode _culture = CultureInfoMode.CurrentCulture;
 
-        /// <summary>
-        /// Initializes a new instance of the <see cref="ThresholdRichTextColorConverter"/> class with no stops.
-        /// </summary>
         public ThresholdRichTextColorConverter() { }
 
-        /// <summary>
-        /// Initializes a new instance of the <see cref="ThresholdRichTextColorConverter"/> class.
-        /// </summary>
         /// <param name="stops">Colours by threshold.</param>
         /// <param name="fallback">Used when the value is below every threshold.</param>
         public ThresholdRichTextColorConverter(ColorStop[]? stops, Color fallback)

--- a/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Unity/Runtime/Converters/Strings/ThresholdRichTextColorConverter.cs
+++ b/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Unity/Runtime/Converters/Strings/ThresholdRichTextColorConverter.cs
@@ -1,0 +1,77 @@
+#nullable enable
+using System;
+using UnityEngine;
+
+// ReSharper disable once CheckNamespace
+namespace Aspid.MVVM.StarterKit
+{
+    /// <summary>
+    /// Writes a number as coloured text, the colour chosen by how large it is.
+    /// </summary>
+    /// <remarks>
+    /// Health below a quarter in red, above three quarters in green, and the number itself in the
+    /// same label — one converter instead of a number binder plus a colour binder that have to be
+    /// kept in step.
+    /// </remarks>
+    [Serializable]
+    public sealed class ThresholdRichTextColorConverter : IConverter<float, string>
+    {
+        [Tooltip("Colours by threshold. The highest threshold at or below the value wins.")]
+        [SerializeField] private ColorStop[] _stops = Array.Empty<ColorStop>();
+
+        [Tooltip("Used when the value is below every threshold.")]
+        [SerializeField] private Color _fallback = Color.white;
+
+        [Tooltip("A standard numeric format string for the number itself.")]
+        [SerializeField] private string _numberFormat = "0.##";
+
+        [Tooltip("The culture the number is formatted with.")]
+        [SerializeField] private CultureInfoMode _culture = CultureInfoMode.CurrentCulture;
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="ThresholdRichTextColorConverter"/> class with no stops.
+        /// </summary>
+        public ThresholdRichTextColorConverter() { }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="ThresholdRichTextColorConverter"/> class.
+        /// </summary>
+        /// <param name="stops">Colours by threshold.</param>
+        /// <param name="fallback">Used when the value is below every threshold.</param>
+        public ThresholdRichTextColorConverter(ColorStop[]? stops, Color fallback)
+        {
+            _stops = stops ?? Array.Empty<ColorStop>();
+            _fallback = fallback;
+        }
+
+        /// <summary>
+        /// Writes the specified number as coloured text.
+        /// </summary>
+        /// <param name="value">The number to write.</param>
+        /// <returns>The tagged number.</returns>
+        public string Convert(float value)
+        {
+            var text = value.ToString(_numberFormat, _culture.ToCultureInfo());
+            return RichTextColorConverter.Wrap(text, ColorFor(value), includeAlpha: false);
+        }
+
+        private Color ColorFor(float value)
+        {
+            if (_stops is not { Length: > 0 }) return _fallback;
+
+            var color = _fallback;
+            var best = float.NegativeInfinity;
+
+            // The stops are authored in whatever order the Inspector left them, so the highest
+            // qualifying threshold has to be found rather than assumed to be last.
+            for (var i = 0; i < _stops.Length; i++)
+                if (value >= _stops[i].Threshold && _stops[i].Threshold > best)
+                {
+                    best = _stops[i].Threshold;
+                    color = _stops[i].Color;
+                }
+
+            return color;
+        }
+    }
+}

--- a/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Unity/Runtime/Converters/Strings/ThresholdRichTextColorConverter.cs.meta
+++ b/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Unity/Runtime/Converters/Strings/ThresholdRichTextColorConverter.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: d8445b409de6444b5ae801147864a0fe

--- a/Aspid.MVVM/Packages/tech.aspid.mvvm/Tests/Editor/Converters/Strings/TextConverterTests.cs
+++ b/Aspid.MVVM/Packages/tech.aspid.mvvm/Tests/Editor/Converters/Strings/TextConverterTests.cs
@@ -1,0 +1,214 @@
+using UnityEngine;
+using NUnit.Framework;
+
+namespace Aspid.MVVM.StarterKit.Tests
+{
+    /// <summary>
+    /// Coverage for the string-manipulation and rich-text converters.
+    /// </summary>
+    [TestFixture]
+    internal sealed class TextConverterTests
+    {
+        [TestCase(null, "—")]
+        [TestCase("", "—")]
+        [TestCase("   ", "—")]
+        [TestCase("abc", "abc")]
+        public void DefaultString_SubstitutesForBlank(string value, string expected) =>
+            Assert.AreEqual(expected, new DefaultStringConverter("—").Convert(value));
+
+        [Test]
+        public void DefaultString_CanTreatSpacesAsContent() =>
+            Assert.AreEqual("   ", new DefaultStringConverter("—", treatWhiteSpaceAsEmpty: false).Convert("   "));
+
+        [TestCase(TextCase.Upper, "hello world", "HELLO WORLD")]
+        [TestCase(TextCase.Lower, "HELLO WORLD", "hello world")]
+        [TestCase(TextCase.FirstUpper, "hello world", "Hello world")]
+        [TestCase(TextCase.Title, "hello world", "Hello World")]
+        public void TextCase_Recases(TextCase textCase, string value, string expected) =>
+            Assert.AreEqual(
+                expected,
+                new TextCaseConverter(textCase, CultureInfoMode.InvariantCulture).Convert(value));
+
+        [Test]
+        public void TextCase_LeavesBlankAlone() =>
+            Assert.AreEqual(string.Empty, new TextCaseConverter(TextCase.Upper).Convert(string.Empty));
+
+        [Test]
+        public void Truncate_CutsTheEnd() =>
+            Assert.AreEqual("abcdefghi…", new TruncateStringConverter(10).Convert("abcdefghijklmnop"));
+
+        [Test]
+        public void Truncate_LeavesShortStringsAlone() =>
+            Assert.AreEqual("abc", new TruncateStringConverter(10).Convert("abc"));
+
+        [Test]
+        public void Truncate_CutsTheStartWhenAsked() =>
+            Assert.AreEqual("…hijklmnop", new TruncateStringConverter(10, TruncateSide.Start).Convert("abcdefghijklmnop"));
+
+        [Test]
+        public void Truncate_CutsTheMiddleWhenAsked() =>
+            Assert.AreEqual("abcde…mnop", new TruncateStringConverter(10, TruncateSide.Middle).Convert("abcdefghijklmnop"));
+
+        [Test]
+        public void Truncate_StopsAtAWordBoundaryWhenAsked() =>
+            Assert.AreEqual(
+                "hello…",
+                new TruncateStringConverter(10, TruncateSide.End, atWordBoundary: true).Convert("hello beautiful world"));
+
+        // A limit shorter than the marker leaves nothing sensible to keep.
+        [Test]
+        public void Truncate_LimitShorterThanTheEllipsis() =>
+            Assert.AreEqual("…", new TruncateStringConverter(1).Convert("abcdef"));
+
+        [TestCase(TrimSide.Both, "  abc  ", "abc")]
+        [TestCase(TrimSide.Start, "  abc  ", "abc  ")]
+        [TestCase(TrimSide.End, "  abc  ", "  abc")]
+        public void Trim_TrimsTheRequestedEnds(TrimSide side, string value, string expected) =>
+            Assert.AreEqual(expected, new TrimStringConverter(side).Convert(value));
+
+        [Test]
+        public void Trim_TakesSpecificCharacters() =>
+            Assert.AreEqual("abc", new TrimStringConverter(TrimSide.Both, "*").Convert("**abc**"));
+
+        [Test]
+        public void Replace_SwapsEveryOccurrence() =>
+            Assert.AreEqual("a-b-c", new ReplaceStringConverter("_", "-").Convert("a_b_c"));
+
+        [Test]
+        public void Replace_CanIgnoreCase() =>
+            Assert.AreEqual("xbx", new ReplaceStringConverter("a", "x", ignoreCase: true).Convert("AbA"));
+
+        [Test]
+        public void Replace_EmptySearchPassesThrough() =>
+            Assert.AreEqual("abc", new ReplaceStringConverter("", "x").Convert("abc"));
+
+        [Test]
+        public void Mask_HidesTheMiddle() =>
+            Assert.AreEqual("ab••••gh", new MaskStringConverter(2, 2).Convert("abcdefgh"));
+
+        // A string too short to keep both ends is masked completely, so a short value never leaks by
+        // being left alone.
+        [Test]
+        public void Mask_ShortStringIsMaskedCompletely() =>
+            Assert.AreEqual("•••", new MaskStringConverter(2, 2).Convert("abc"));
+
+        [Test]
+        public void Repeat_WritesOneUnitPerCount() =>
+            Assert.AreEqual("★★★", new RepeatStringConverter("★").Convert(3));
+
+        [Test]
+        public void Repeat_FillsTheRemainderToTheMaximum() =>
+            Assert.AreEqual("★★★☆☆", new RepeatStringConverter("★", 5, "☆").Convert(3));
+
+        [Test]
+        public void Repeat_ClampsAboveTheMaximum() =>
+            Assert.AreEqual("★★★★★", new RepeatStringConverter("★", 5, "☆").Convert(9));
+
+        [Test]
+        public void Repeat_NegativeCountWritesNothing() =>
+            Assert.AreEqual(string.Empty, new RepeatStringConverter("★").Convert(-3));
+
+        [Test]
+        public void Pad_PadsToWidth()
+        {
+            Assert.AreEqual("     abc", new PadStringConverter(8).Convert("abc"));
+            Assert.AreEqual("abc     ", new PadStringConverter(8, ' ', padLeft: false).Convert("abc"));
+        }
+
+        [Test]
+        public void Substring_TakesTheSlice() =>
+            Assert.AreEqual("bcd", new SubstringConverter(1, 3).Convert("abcdef"));
+
+        [Test]
+        public void Substring_ClampsToWhatIsThere() =>
+            Assert.AreEqual("ef", new SubstringConverter(4, 10).Convert("abcdef"));
+
+        [Test]
+        public void Substring_StartPastTheEndYieldsEmpty() =>
+            Assert.AreEqual(string.Empty, new SubstringConverter(10, 3).Convert("abc"));
+
+        [Test]
+        public void Concat_WrapsTheValue() =>
+            Assert.AreEqual("[abc]", new ConcatStringConverter("[", "]").Convert("abc"));
+
+        [Test]
+        public void Concat_LeavesBlankUndecorated() =>
+            Assert.AreEqual(string.Empty, new ConcatStringConverter("[", "]").Convert(string.Empty));
+
+        [Test]
+        public void Concat_DecoratesBlankWhenAsked() =>
+            Assert.AreEqual("[]", new ConcatStringConverter("[", "]", skipWhenEmpty: false).Convert(string.Empty));
+
+        // A player name like <size=400%> resizes the label it lands in, on every screen showing that
+        // player. noparse makes TMP render the characters instead of obeying them.
+        [Test]
+        public void RichTextNoParse_NeutralisesMarkup() =>
+            Assert.AreEqual(
+                "<noparse><size=400%>troll</noparse>",
+                new RichTextNoParseConverter().Convert("<size=400%>troll"));
+
+        [Test]
+        public void RichTextNoParse_LeavesBlankAlone() =>
+            Assert.AreEqual(string.Empty, new RichTextNoParseConverter().Convert(string.Empty));
+
+        [Test]
+        public void RichTextColor_TagsTheText() =>
+            Assert.AreEqual("<color=#FF0000>hp</color>", new RichTextColorConverter(Color.red).Convert("hp"));
+
+        [Test]
+        public void RichTextColor_IncludesAlphaWhenAsked() =>
+            Assert.AreEqual(
+                "<color=#FF0000FF>hp</color>",
+                new RichTextColorConverter(Color.red, includeAlpha: true).Convert("hp"));
+
+        // Explicit channels rather than Color.yellow, which is #FFEB04 in Unity rather than #FFFF00.
+        private static readonly Color PureYellow = new(1f, 1f, 0f);
+
+        [Test]
+        public void ThresholdRichTextColor_PicksTheHighestQualifyingStop()
+        {
+            var converter = new ThresholdRichTextColorConverter(
+                new[]
+                {
+                    new ColorStop { Threshold = 0.75f, Color = Color.green },
+                    new ColorStop { Threshold = 0.25f, Color = PureYellow },
+                },
+                fallback: Color.red);
+
+            Assert.AreEqual("<color=#00FF00>0.8</color>", converter.Convert(0.8f));
+            Assert.AreEqual("<color=#FFFF00>0.5</color>", converter.Convert(0.5f));
+            Assert.AreEqual("<color=#FF0000>0.1</color>", converter.Convert(0.1f));
+        }
+
+        // The stops are authored in whatever order the Inspector left them.
+        [Test]
+        public void ThresholdRichTextColor_DoesNotDependOnStopOrder()
+        {
+            var ascending = new ThresholdRichTextColorConverter(
+                new[]
+                {
+                    new ColorStop { Threshold = 0.25f, Color = PureYellow },
+                    new ColorStop { Threshold = 0.75f, Color = Color.green },
+                },
+                fallback: Color.red);
+
+            Assert.AreEqual("<color=#00FF00>0.8</color>", ascending.Convert(0.8f));
+        }
+
+        [Test]
+        public void RichTextStyle_WrapsInTheRequestedTags() =>
+            Assert.AreEqual("<i><b>hp</b></i>", new RichTextStyleConverter(bold: true, italic: true).Convert("hp"));
+
+        [Test]
+        public void RichTextStyle_WithNothingSetLeavesTheTextAlone() =>
+            Assert.AreEqual("hp", new RichTextStyleConverter().Convert("hp"));
+
+        [Test]
+        public void RichTextSize_TagsAsPercentByDefault() =>
+            Assert.AreEqual("<size=150%>hp</size>", new RichTextSizeConverter(150f).Convert("hp"));
+
+        [Test]
+        public void RichTextSize_TagsAsPointsWhenAsked() =>
+            Assert.AreEqual("<size=32>hp</size>", new RichTextSizeConverter(32f, isPercent: false).Convert("hp"));
+    }
+}

--- a/Aspid.MVVM/Packages/tech.aspid.mvvm/Tests/Editor/Converters/Strings/TextConverterTests.cs.meta
+++ b/Aspid.MVVM/Packages/tech.aspid.mvvm/Tests/Editor/Converters/Strings/TextConverterTests.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 48c382d9905a34599a34ef2e2a9bc15a


### PR DESCRIPTION
✨ Phase 3 wave 3.3, second half — string manipulation and rich text. Text shaping is presentation: a ViewModel should not know that a label is twenty characters wide.

## Summary

- ✨ `DefaultString`, `TextCase`, `TruncateString`, `TrimString`, `ReplaceString`, `MaskString`, `RepeatString`, `PadString`, `Substring`, `ConcatString`.
- ✨ `RichTextNoParse`, `RichTextColor`, `ThresholdRichTextColor`, `RichTextStyle`, `RichTextSize`.
- 🔒 **`RichTextNoParseConverter` is the one worth reading twice**: TextMeshPro obeys markup in text a player typed, so a name like `<size=400%>` resizes that label on every other player's screen — the other rich-text converters *add* markup and each summary says which side it is on.
- 📝 `RegexStringConverter` is deliberately absent: an Inspector-authored pattern is unbounded work on the hot path and needs a decision about timeouts first.

## Notes for review

- ⚠️ `MaskStringConverter` masks completely when the string is too short to keep both ends — otherwise the shortest identifiers would be the ones shown in full.
- ⚠️ `TextCaseConverter` takes a culture: Turkish has a dotless lower-case i, so a naive upper-casing produces the wrong letter.
- 📝 `ThresholdRichTextColorConverter` searches for the highest qualifying stop rather than trusting Inspector order, and a test pins both orderings.

✅ Local run: 489 total, 487 passed, 0 failed, 2 skipped.

<details>
<summary>🇷🇺 Описание на русском</summary>

✨ Волна 3.3 Фазы 3, вторая половина — строковые манипуляции и rich text. Оформление текста — представление: ViewModel не должна знать, что подпись шириной в двадцать символов.

## Итог

- ✨ `DefaultString`, `TextCase`, `TruncateString`, `TrimString`, `ReplaceString`, `MaskString`, `RepeatString`, `PadString`, `Substring`, `ConcatString`.
- ✨ `RichTextNoParse`, `RichTextColor`, `ThresholdRichTextColor`, `RichTextStyle`, `RichTextSize`.
- 🔒 **`RichTextNoParseConverter` стоит прочитать дважды**: TextMeshPro подчиняется разметке в тексте, который набрал игрок, поэтому ник вида `<size=400%>` растягивает эту подпись на экране у всех остальных — остальные rich-text конвертеры разметку *добавляют*, и в summary каждого сказано, на какой он стороне.
- 📝 `RegexStringConverter` намеренно отсутствует: паттерн из инспектора — неограниченная работа на горячем пути, и сначала нужно решение про таймауты.

## Заметки для ревью

- ⚠️ `MaskStringConverter` маскирует целиком, если строка слишком коротка, чтобы сохранить оба конца, — иначе самые короткие идентификаторы показывались бы полностью.
- ⚠️ `TextCaseConverter` принимает культуру: в турецком есть строчная «i» без точки, и наивный верхний регистр даёт не ту букву.
- 📝 `ThresholdRichTextColorConverter` ищет наибольший подходящий порог, а не полагается на порядок в инспекторе, и тест фиксирует оба порядка.

✅ Локальный прогон: 489 всего, 487 прошло, 0 упало, 2 пропущено.

</details>

