### PR TITLE
feat(starterkit): fill the colour, ColorBlock and texture pickers

### DIFF
--- a/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Unity/Runtime/Converters/Colors/AlphaMode.cs
+++ b/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Unity/Runtime/Converters/Colors/AlphaMode.cs
@@ -1,0 +1,26 @@
+#nullable enable
+
+// ReSharper disable once CheckNamespace
+namespace Aspid.MVVM.StarterKit
+{
+    /// <summary>
+    /// How <see cref="ColorAlphaConverter"/> applies its alpha.
+    /// </summary>
+    public enum AlphaMode
+    {
+        /// <summary>
+        /// Replace the alpha outright.
+        /// </summary>
+        Set,
+
+        /// <summary>
+        /// Scale the existing alpha.
+        /// </summary>
+        Multiply,
+
+        /// <summary>
+        /// Add to the existing alpha.
+        /// </summary>
+        Add,
+    }
+}

--- a/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Unity/Runtime/Converters/Colors/AlphaMode.cs.meta
+++ b/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Unity/Runtime/Converters/Colors/AlphaMode.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 62b286b0d5086d3378347220fa687ccc

--- a/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Unity/Runtime/Converters/Colors/ColorAlphaConverter.cs
+++ b/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Unity/Runtime/Converters/Colors/ColorAlphaConverter.cs
@@ -1,0 +1,60 @@
+#nullable enable
+using System;
+using UnityEngine;
+
+// ReSharper disable once CheckNamespace
+namespace Aspid.MVVM.StarterKit
+{
+    /// <summary>
+    /// Changes the alpha of a colour, leaving its hue alone.
+    /// </summary>
+    /// <remarks>
+    /// Fading a single element without a <see cref="CanvasGroup"/>, which fades everything under it.
+    /// This is the most common edit anyone makes to a bound colour, and until now the colour picker
+    /// on every binder was empty.
+    /// </remarks>
+    [Serializable]
+    public sealed class ColorAlphaConverter : IConverterColor
+    {
+        [Tooltip("The alpha applied to the colour.")]
+        [SerializeField, Range(0f, 1f)] private float _alpha = 1f;
+
+        [Tooltip("How the alpha is applied.")]
+        [SerializeField] private AlphaMode _mode = AlphaMode.Set;
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="ColorAlphaConverter"/> class at full opacity.
+        /// </summary>
+        public ColorAlphaConverter() { }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="ColorAlphaConverter"/> class.
+        /// </summary>
+        /// <param name="alpha">The alpha applied to the colour.</param>
+        /// <param name="mode">How the alpha is applied.</param>
+        public ColorAlphaConverter(float alpha, AlphaMode mode = AlphaMode.Set)
+        {
+            _alpha = alpha;
+            _mode = mode;
+        }
+
+        /// <summary>
+        /// Applies the configured alpha to the specified colour.
+        /// </summary>
+        /// <param name="value">The colour to adjust.</param>
+        /// <returns>The colour with its alpha changed.</returns>
+        /// <exception cref="ArgumentOutOfRangeException">Thrown when the mode is not a declared value.</exception>
+        public Color Convert(Color value)
+        {
+            value.a = _mode switch
+            {
+                AlphaMode.Set => _alpha,
+                AlphaMode.Multiply => Mathf.Clamp01(value.a * _alpha),
+                AlphaMode.Add => Mathf.Clamp01(value.a + _alpha),
+                _ => throw new ArgumentOutOfRangeException(nameof(_mode), _mode, null)
+            };
+
+            return value;
+        }
+    }
+}

--- a/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Unity/Runtime/Converters/Colors/ColorAlphaConverter.cs
+++ b/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Unity/Runtime/Converters/Colors/ColorAlphaConverter.cs
@@ -22,14 +22,9 @@ namespace Aspid.MVVM.StarterKit
         [Tooltip("How the alpha is applied.")]
         [SerializeField] private AlphaMode _mode = AlphaMode.Set;
 
-        /// <summary>
-        /// Initializes a new instance of the <see cref="ColorAlphaConverter"/> class at full opacity.
-        /// </summary>
+        /// <remarks>Default: at full opacity.</remarks>
         public ColorAlphaConverter() { }
 
-        /// <summary>
-        /// Initializes a new instance of the <see cref="ColorAlphaConverter"/> class.
-        /// </summary>
         /// <param name="alpha">The alpha applied to the colour.</param>
         /// <param name="mode">How the alpha is applied.</param>
         public ColorAlphaConverter(float alpha, AlphaMode mode = AlphaMode.Set)

--- a/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Unity/Runtime/Converters/Colors/ColorAlphaConverter.cs.meta
+++ b/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Unity/Runtime/Converters/Colors/ColorAlphaConverter.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 69dce8d6169aed7dafa1287527ff95fd

--- a/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Unity/Runtime/Converters/Colors/ColorBlend.cs
+++ b/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Unity/Runtime/Converters/Colors/ColorBlend.cs
@@ -1,0 +1,31 @@
+#nullable enable
+
+// ReSharper disable once CheckNamespace
+namespace Aspid.MVVM.StarterKit
+{
+    /// <summary>
+    /// How <see cref="ColorTintConverter"/> combines two colours.
+    /// </summary>
+    public enum ColorBlend
+    {
+        /// <summary>
+        /// Multiply each channel.
+        /// </summary>
+        Multiply,
+
+        /// <summary>
+        /// Add each channel.
+        /// </summary>
+        Add,
+
+        /// <summary>
+        /// Move towards the tint by the configured amount.
+        /// </summary>
+        Lerp,
+
+        /// <summary>
+        /// Replace the colour with the tint, keeping the original alpha.
+        /// </summary>
+        Replace,
+    }
+}

--- a/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Unity/Runtime/Converters/Colors/ColorBlend.cs.meta
+++ b/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Unity/Runtime/Converters/Colors/ColorBlend.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 558629ca33b2ea32ba23bc537f70eadf

--- a/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Unity/Runtime/Converters/Colors/ColorBlockAlphaConverter.cs
+++ b/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Unity/Runtime/Converters/Colors/ColorBlockAlphaConverter.cs
@@ -1,0 +1,56 @@
+#nullable enable
+using System;
+using UnityEngine;
+using UnityEngine.UI;
+
+// ReSharper disable once CheckNamespace
+namespace Aspid.MVVM.StarterKit
+{
+    /// <summary>
+    /// Changes the alpha of every colour in a <see cref="ColorBlock"/>.
+    /// </summary>
+    /// <remarks>Dimming a whole interactive element without touching its hues.</remarks>
+    [Serializable]
+    public sealed class ColorBlockAlphaConverter : IConverterColorBlock
+    {
+        [Tooltip("The alpha applied to every state.")]
+        [SerializeField, Range(0f, 1f)] private float _alpha = 1f;
+
+        [Tooltip("How the alpha is applied.")]
+        [SerializeField] private AlphaMode _mode = AlphaMode.Multiply;
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="ColorBlockAlphaConverter"/> class at full opacity.
+        /// </summary>
+        public ColorBlockAlphaConverter() { }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="ColorBlockAlphaConverter"/> class.
+        /// </summary>
+        /// <param name="alpha">The alpha applied to every state.</param>
+        /// <param name="mode">How the alpha is applied.</param>
+        public ColorBlockAlphaConverter(float alpha, AlphaMode mode = AlphaMode.Multiply)
+        {
+            _alpha = alpha;
+            _mode = mode;
+        }
+
+        /// <summary>
+        /// Changes the alpha of every state of the specified block.
+        /// </summary>
+        /// <param name="value">The block to adjust.</param>
+        /// <returns>The adjusted block.</returns>
+        public ColorBlock Convert(ColorBlock value)
+        {
+            var alpha = new ColorAlphaConverter(_alpha, _mode);
+
+            value.normalColor = alpha.Convert(value.normalColor);
+            value.highlightedColor = alpha.Convert(value.highlightedColor);
+            value.pressedColor = alpha.Convert(value.pressedColor);
+            value.selectedColor = alpha.Convert(value.selectedColor);
+            value.disabledColor = alpha.Convert(value.disabledColor);
+
+            return value;
+        }
+    }
+}

--- a/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Unity/Runtime/Converters/Colors/ColorBlockAlphaConverter.cs
+++ b/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Unity/Runtime/Converters/Colors/ColorBlockAlphaConverter.cs
@@ -19,14 +19,9 @@ namespace Aspid.MVVM.StarterKit
         [Tooltip("How the alpha is applied.")]
         [SerializeField] private AlphaMode _mode = AlphaMode.Multiply;
 
-        /// <summary>
-        /// Initializes a new instance of the <see cref="ColorBlockAlphaConverter"/> class at full opacity.
-        /// </summary>
+        /// <remarks>Default: at full opacity.</remarks>
         public ColorBlockAlphaConverter() { }
 
-        /// <summary>
-        /// Initializes a new instance of the <see cref="ColorBlockAlphaConverter"/> class.
-        /// </summary>
         /// <param name="alpha">The alpha applied to every state.</param>
         /// <param name="mode">How the alpha is applied.</param>
         public ColorBlockAlphaConverter(float alpha, AlphaMode mode = AlphaMode.Multiply)

--- a/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Unity/Runtime/Converters/Colors/ColorBlockAlphaConverter.cs.meta
+++ b/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Unity/Runtime/Converters/Colors/ColorBlockAlphaConverter.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 12b46ad11bb40b9d6eadde24d9132815

--- a/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Unity/Runtime/Converters/Colors/ColorBlockFadeDurationConverter.cs
+++ b/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Unity/Runtime/Converters/Colors/ColorBlockFadeDurationConverter.cs
@@ -19,14 +19,8 @@ namespace Aspid.MVVM.StarterKit
         [Tooltip("How long a state change takes.")]
         [SerializeField] private float _fadeDuration = 0.1f;
 
-        /// <summary>
-        /// Initializes a new instance of the <see cref="ColorBlockFadeDurationConverter"/> class.
-        /// </summary>
         public ColorBlockFadeDurationConverter() { }
 
-        /// <summary>
-        /// Initializes a new instance of the <see cref="ColorBlockFadeDurationConverter"/> class.
-        /// </summary>
         /// <param name="fadeDuration">How long a state change takes.</param>
         public ColorBlockFadeDurationConverter(float fadeDuration)
         {

--- a/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Unity/Runtime/Converters/Colors/ColorBlockFadeDurationConverter.cs
+++ b/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Unity/Runtime/Converters/Colors/ColorBlockFadeDurationConverter.cs
@@ -1,0 +1,47 @@
+#nullable enable
+using System;
+using UnityEngine;
+using UnityEngine.UI;
+
+// ReSharper disable once CheckNamespace
+namespace Aspid.MVVM.StarterKit
+{
+    /// <summary>
+    /// Sets how long a <see cref="Selectable"/> takes to change state.
+    /// </summary>
+    /// <remarks>
+    /// A reduce-motion accessibility setting bound straight to the fade, which no other converter
+    /// reaches without rebuilding the whole block.
+    /// </remarks>
+    [Serializable]
+    public sealed class ColorBlockFadeDurationConverter : IConverterColorBlock
+    {
+        [Tooltip("How long a state change takes.")]
+        [SerializeField] private float _fadeDuration = 0.1f;
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="ColorBlockFadeDurationConverter"/> class.
+        /// </summary>
+        public ColorBlockFadeDurationConverter() { }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="ColorBlockFadeDurationConverter"/> class.
+        /// </summary>
+        /// <param name="fadeDuration">How long a state change takes.</param>
+        public ColorBlockFadeDurationConverter(float fadeDuration)
+        {
+            _fadeDuration = fadeDuration;
+        }
+
+        /// <summary>
+        /// Sets the fade duration of the specified block.
+        /// </summary>
+        /// <param name="value">The block to adjust.</param>
+        /// <returns>The adjusted block.</returns>
+        public ColorBlock Convert(ColorBlock value)
+        {
+            value.fadeDuration = _fadeDuration;
+            return value;
+        }
+    }
+}

--- a/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Unity/Runtime/Converters/Colors/ColorBlockFadeDurationConverter.cs.meta
+++ b/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Unity/Runtime/Converters/Colors/ColorBlockFadeDurationConverter.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 63822242391b6894de5a45a0478d9753

--- a/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Unity/Runtime/Converters/Colors/ColorBlockTintConverter.cs
+++ b/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Unity/Runtime/Converters/Colors/ColorBlockTintConverter.cs
@@ -1,0 +1,59 @@
+#nullable enable
+using System;
+using UnityEngine;
+using UnityEngine.UI;
+
+// ReSharper disable once CheckNamespace
+namespace Aspid.MVVM.StarterKit
+{
+    /// <summary>
+    /// Tints every colour of a <see cref="ColorBlock"/>.
+    /// </summary>
+    /// <remarks>Theming a whole button at once — faction colours, a disabled palette.</remarks>
+    [Serializable]
+    public sealed class ColorBlockTintConverter : IConverterColorBlock
+    {
+        [Tooltip("The colour every state is combined with.")]
+        [SerializeField] private Color _tint = Color.white;
+
+        [Tooltip("How the two are combined.")]
+        [SerializeField] private ColorBlend _blend = ColorBlend.Multiply;
+
+        [Tooltip("How far towards the tint to move, for the Lerp blend.")]
+        [SerializeField, Range(0f, 1f)] private float _amount = 1f;
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="ColorBlockTintConverter"/> class that changes nothing.
+        /// </summary>
+        public ColorBlockTintConverter() { }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="ColorBlockTintConverter"/> class.
+        /// </summary>
+        /// <param name="tint">The colour every state is combined with.</param>
+        /// <param name="blend">How the two are combined.</param>
+        public ColorBlockTintConverter(Color tint, ColorBlend blend = ColorBlend.Multiply)
+        {
+            _tint = tint;
+            _blend = blend;
+        }
+
+        /// <summary>
+        /// Tints every state of the specified block.
+        /// </summary>
+        /// <param name="value">The block to tint.</param>
+        /// <returns>The tinted block.</returns>
+        public ColorBlock Convert(ColorBlock value)
+        {
+            var tint = new ColorTintConverter(_tint, _blend, _amount);
+
+            value.normalColor = tint.Convert(value.normalColor);
+            value.highlightedColor = tint.Convert(value.highlightedColor);
+            value.pressedColor = tint.Convert(value.pressedColor);
+            value.selectedColor = tint.Convert(value.selectedColor);
+            value.disabledColor = tint.Convert(value.disabledColor);
+
+            return value;
+        }
+    }
+}

--- a/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Unity/Runtime/Converters/Colors/ColorBlockTintConverter.cs
+++ b/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Unity/Runtime/Converters/Colors/ColorBlockTintConverter.cs
@@ -22,14 +22,8 @@ namespace Aspid.MVVM.StarterKit
         [Tooltip("How far towards the tint to move, for the Lerp blend.")]
         [SerializeField, Range(0f, 1f)] private float _amount = 1f;
 
-        /// <summary>
-        /// Initializes a new instance of the <see cref="ColorBlockTintConverter"/> class that changes nothing.
-        /// </summary>
         public ColorBlockTintConverter() { }
 
-        /// <summary>
-        /// Initializes a new instance of the <see cref="ColorBlockTintConverter"/> class.
-        /// </summary>
         /// <param name="tint">The colour every state is combined with.</param>
         /// <param name="blend">How the two are combined.</param>
         public ColorBlockTintConverter(Color tint, ColorBlend blend = ColorBlend.Multiply)

--- a/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Unity/Runtime/Converters/Colors/ColorBlockTintConverter.cs.meta
+++ b/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Unity/Runtime/Converters/Colors/ColorBlockTintConverter.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 83506f45ae9a11a41e3915e236cbc56d

--- a/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Unity/Runtime/Converters/Colors/ColorGrayscaleConverter.cs
+++ b/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Unity/Runtime/Converters/Colors/ColorGrayscaleConverter.cs
@@ -1,0 +1,49 @@
+#nullable enable
+using System;
+using UnityEngine;
+
+// ReSharper disable once CheckNamespace
+namespace Aspid.MVVM.StarterKit
+{
+    /// <summary>
+    /// Desaturates a colour.
+    /// </summary>
+    /// <remarks>
+    /// Greying out a locked item without a second sprite. The weights are the usual luminance
+    /// coefficients, so the result matches what the eye reads as brightness rather than a flat
+    /// channel average.
+    /// </remarks>
+    [Serializable]
+    public sealed class ColorGrayscaleConverter : IConverterColor
+    {
+        [Tooltip("How much colour to keep. Zero is fully grey, one leaves the colour untouched.")]
+        [SerializeField, Range(0f, 1f)] private float _saturation;
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="ColorGrayscaleConverter"/> class that fully desaturates.
+        /// </summary>
+        public ColorGrayscaleConverter() { }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="ColorGrayscaleConverter"/> class.
+        /// </summary>
+        /// <param name="saturation">How much colour to keep.</param>
+        public ColorGrayscaleConverter(float saturation)
+        {
+            _saturation = saturation;
+        }
+
+        /// <summary>
+        /// Desaturates the specified colour.
+        /// </summary>
+        /// <param name="value">The colour to desaturate.</param>
+        /// <returns>The desaturated colour, with its alpha untouched.</returns>
+        public Color Convert(Color value)
+        {
+            var luminance = value.r * 0.299f + value.g * 0.587f + value.b * 0.114f;
+            var grey = new Color(luminance, luminance, luminance, value.a);
+
+            return Color.Lerp(grey, value, Mathf.Clamp01(_saturation));
+        }
+    }
+}

--- a/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Unity/Runtime/Converters/Colors/ColorGrayscaleConverter.cs
+++ b/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Unity/Runtime/Converters/Colors/ColorGrayscaleConverter.cs
@@ -19,14 +19,9 @@ namespace Aspid.MVVM.StarterKit
         [Tooltip("How much colour to keep. Zero is fully grey, one leaves the colour untouched.")]
         [SerializeField, Range(0f, 1f)] private float _saturation;
 
-        /// <summary>
-        /// Initializes a new instance of the <see cref="ColorGrayscaleConverter"/> class that fully desaturates.
-        /// </summary>
+        /// <remarks>Default: fully desaturating.</remarks>
         public ColorGrayscaleConverter() { }
 
-        /// <summary>
-        /// Initializes a new instance of the <see cref="ColorGrayscaleConverter"/> class.
-        /// </summary>
         /// <param name="saturation">How much colour to keep.</param>
         public ColorGrayscaleConverter(float saturation)
         {

--- a/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Unity/Runtime/Converters/Colors/ColorGrayscaleConverter.cs.meta
+++ b/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Unity/Runtime/Converters/Colors/ColorGrayscaleConverter.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: b88991e1f3d35644177aea2ab0a7a73b

--- a/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Unity/Runtime/Converters/Colors/ColorHsvConverter.cs
+++ b/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Unity/Runtime/Converters/Colors/ColorHsvConverter.cs
@@ -21,14 +21,8 @@ namespace Aspid.MVVM.StarterKit
         [Tooltip("Scales the brightness.")]
         [SerializeField] private float _valueMultiplier = 1f;
 
-        /// <summary>
-        /// Initializes a new instance of the <see cref="ColorHsvConverter"/> class that changes nothing.
-        /// </summary>
         public ColorHsvConverter() { }
 
-        /// <summary>
-        /// Initializes a new instance of the <see cref="ColorHsvConverter"/> class.
-        /// </summary>
         /// <param name="hueShift">How far to rotate the hue, in turns.</param>
         /// <param name="saturationMultiplier">Scales the saturation.</param>
         /// <param name="valueMultiplier">Scales the brightness.</param>

--- a/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Unity/Runtime/Converters/Colors/ColorHsvConverter.cs
+++ b/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Unity/Runtime/Converters/Colors/ColorHsvConverter.cs
@@ -1,0 +1,61 @@
+#nullable enable
+using System;
+using UnityEngine;
+
+// ReSharper disable once CheckNamespace
+namespace Aspid.MVVM.StarterKit
+{
+    /// <summary>
+    /// Shifts a colour in HSV space.
+    /// </summary>
+    /// <remarks>A palette of variations from one authored base colour.</remarks>
+    [Serializable]
+    public sealed class ColorHsvConverter : IConverterColor
+    {
+        [Tooltip("How far to rotate the hue, in turns. 0.5 is the opposite colour.")]
+        [SerializeField] private float _hueShift;
+
+        [Tooltip("Scales the saturation.")]
+        [SerializeField] private float _saturationMultiplier = 1f;
+
+        [Tooltip("Scales the brightness.")]
+        [SerializeField] private float _valueMultiplier = 1f;
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="ColorHsvConverter"/> class that changes nothing.
+        /// </summary>
+        public ColorHsvConverter() { }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="ColorHsvConverter"/> class.
+        /// </summary>
+        /// <param name="hueShift">How far to rotate the hue, in turns.</param>
+        /// <param name="saturationMultiplier">Scales the saturation.</param>
+        /// <param name="valueMultiplier">Scales the brightness.</param>
+        public ColorHsvConverter(float hueShift, float saturationMultiplier = 1f, float valueMultiplier = 1f)
+        {
+            _hueShift = hueShift;
+            _saturationMultiplier = saturationMultiplier;
+            _valueMultiplier = valueMultiplier;
+        }
+
+        /// <summary>
+        /// Shifts the specified colour.
+        /// </summary>
+        /// <param name="value">The colour to shift.</param>
+        /// <returns>The shifted colour, with its alpha untouched.</returns>
+        public Color Convert(Color value)
+        {
+            Color.RGBToHSV(value, out var h, out var s, out var v);
+
+            h = Mathf.Repeat(h + _hueShift, 1f);
+            s = Mathf.Clamp01(s * _saturationMultiplier);
+            v = Mathf.Clamp01(v * _valueMultiplier);
+
+            var shifted = Color.HSVToRGB(h, s, v);
+            shifted.a = value.a;
+
+            return shifted;
+        }
+    }
+}

--- a/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Unity/Runtime/Converters/Colors/ColorHsvConverter.cs.meta
+++ b/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Unity/Runtime/Converters/Colors/ColorHsvConverter.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: ad38fc3bf6a7e4de70d2165d8b5902fe

--- a/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Unity/Runtime/Converters/Colors/ColorLerpConverter.cs
+++ b/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Unity/Runtime/Converters/Colors/ColorLerpConverter.cs
@@ -21,14 +21,9 @@ namespace Aspid.MVVM.StarterKit
         [Tooltip("Hold the incoming amount inside 0..1.")]
         [SerializeField] private bool _clamp = true;
 
-        /// <summary>
-        /// Initializes a new instance of the <see cref="ColorLerpConverter"/> class going red to green.
-        /// </summary>
+        /// <remarks>Default: going red to green.</remarks>
         public ColorLerpConverter() { }
 
-        /// <summary>
-        /// Initializes a new instance of the <see cref="ColorLerpConverter"/> class.
-        /// </summary>
         /// <param name="from">The colour at 0.</param>
         /// <param name="to">The colour at 1.</param>
         public ColorLerpConverter(Color from, Color to)

--- a/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Unity/Runtime/Converters/Colors/ColorLerpConverter.cs
+++ b/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Unity/Runtime/Converters/Colors/ColorLerpConverter.cs
@@ -1,0 +1,48 @@
+#nullable enable
+using System;
+using UnityEngine;
+
+// ReSharper disable once CheckNamespace
+namespace Aspid.MVVM.StarterKit
+{
+    /// <summary>
+    /// Moves between two colours by a 0..1 amount.
+    /// </summary>
+    /// <remarks>A two-stop gradient without a <see cref="Gradient"/> to author.</remarks>
+    [Serializable]
+    public sealed class ColorLerpConverter : IConverter<float, Color>
+    {
+        [Tooltip("The colour at 0.")]
+        [SerializeField] private Color _from = Color.red;
+
+        [Tooltip("The colour at 1.")]
+        [SerializeField] private Color _to = Color.green;
+
+        [Tooltip("Hold the incoming amount inside 0..1.")]
+        [SerializeField] private bool _clamp = true;
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="ColorLerpConverter"/> class going red to green.
+        /// </summary>
+        public ColorLerpConverter() { }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="ColorLerpConverter"/> class.
+        /// </summary>
+        /// <param name="from">The colour at 0.</param>
+        /// <param name="to">The colour at 1.</param>
+        public ColorLerpConverter(Color from, Color to)
+        {
+            _from = from;
+            _to = to;
+        }
+
+        /// <summary>
+        /// Reads the colour at the specified amount.
+        /// </summary>
+        /// <param name="value">The 0..1 amount.</param>
+        /// <returns>The colour there.</returns>
+        public Color Convert(float value) =>
+            _clamp ? Color.Lerp(_from, _to, value) : Color.LerpUnclamped(_from, _to, value);
+    }
+}

--- a/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Unity/Runtime/Converters/Colors/ColorLerpConverter.cs.meta
+++ b/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Unity/Runtime/Converters/Colors/ColorLerpConverter.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: ada078ea1343797d91ef0d1180af2aa4

--- a/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Unity/Runtime/Converters/Colors/ColorTintConverter.cs
+++ b/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Unity/Runtime/Converters/Colors/ColorTintConverter.cs
@@ -1,0 +1,61 @@
+#nullable enable
+using System;
+using UnityEngine;
+
+// ReSharper disable once CheckNamespace
+namespace Aspid.MVVM.StarterKit
+{
+    /// <summary>
+    /// Combines a bound colour with an authored one.
+    /// </summary>
+    /// <remarks>Team colours, rarity tints, disabled states.</remarks>
+    [Serializable]
+    public sealed class ColorTintConverter : IConverterColor
+    {
+        [Tooltip("The colour the bound one is combined with.")]
+        [SerializeField] private Color _tint = Color.white;
+
+        [Tooltip("How the two are combined.")]
+        [SerializeField] private ColorBlend _blend = ColorBlend.Multiply;
+
+        [Tooltip("How far towards the tint to move, for the Lerp blend.")]
+        [SerializeField, Range(0f, 1f)] private float _amount = 1f;
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="ColorTintConverter"/> class that changes nothing.
+        /// </summary>
+        public ColorTintConverter() { }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="ColorTintConverter"/> class.
+        /// </summary>
+        /// <param name="tint">The colour the bound one is combined with.</param>
+        /// <param name="blend">How the two are combined.</param>
+        /// <param name="amount">How far towards the tint to move, for the Lerp blend.</param>
+        public ColorTintConverter(Color tint, ColorBlend blend = ColorBlend.Multiply, float amount = 1f)
+        {
+            _tint = tint;
+            _blend = blend;
+            _amount = amount;
+        }
+
+        /// <summary>
+        /// Combines the specified colour with the authored tint.
+        /// </summary>
+        /// <param name="value">The colour to tint.</param>
+        /// <returns>The combined colour.</returns>
+        /// <exception cref="ArgumentOutOfRangeException">Thrown when the blend is not a declared value.</exception>
+        public Color Convert(Color value) => _blend switch
+        {
+            ColorBlend.Multiply => value * _tint,
+            ColorBlend.Add => new Color(
+                Mathf.Clamp01(value.r + _tint.r),
+                Mathf.Clamp01(value.g + _tint.g),
+                Mathf.Clamp01(value.b + _tint.b),
+                value.a),
+            ColorBlend.Lerp => Color.Lerp(value, _tint, _amount),
+            ColorBlend.Replace => new Color(_tint.r, _tint.g, _tint.b, value.a),
+            _ => throw new ArgumentOutOfRangeException(nameof(_blend), _blend, null)
+        };
+    }
+}

--- a/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Unity/Runtime/Converters/Colors/ColorTintConverter.cs
+++ b/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Unity/Runtime/Converters/Colors/ColorTintConverter.cs
@@ -21,14 +21,8 @@ namespace Aspid.MVVM.StarterKit
         [Tooltip("How far towards the tint to move, for the Lerp blend.")]
         [SerializeField, Range(0f, 1f)] private float _amount = 1f;
 
-        /// <summary>
-        /// Initializes a new instance of the <see cref="ColorTintConverter"/> class that changes nothing.
-        /// </summary>
         public ColorTintConverter() { }
 
-        /// <summary>
-        /// Initializes a new instance of the <see cref="ColorTintConverter"/> class.
-        /// </summary>
         /// <param name="tint">The colour the bound one is combined with.</param>
         /// <param name="blend">How the two are combined.</param>
         /// <param name="amount">How far towards the tint to move, for the Lerp blend.</param>

--- a/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Unity/Runtime/Converters/Colors/ColorTintConverter.cs.meta
+++ b/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Unity/Runtime/Converters/Colors/ColorTintConverter.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 398909b3dda05425ab4848c59dd1f7a1

--- a/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Unity/Runtime/Converters/Colors/ColorToColorBlockConverter.cs
+++ b/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Unity/Runtime/Converters/Colors/ColorToColorBlockConverter.cs
@@ -1,0 +1,78 @@
+#nullable enable
+using System;
+using UnityEngine;
+using UnityEngine.UI;
+
+// ReSharper disable once CheckNamespace
+namespace Aspid.MVVM.StarterKit
+{
+    /// <summary>
+    /// Builds a full <see cref="ColorBlock"/> out of one colour.
+    /// </summary>
+    /// <remarks>
+    /// A <see cref="Selectable"/> keeps five colours and a fade duration, so binding a theme colour
+    /// to a button meant the ViewModel producing all five — teaching it how UGUI models interaction
+    /// states. This derives them from the one colour that actually varies.
+    /// <para>
+    /// <c>IConverterColorBlock</c> has been declared since the first release with no implementation
+    /// behind it, so the picker on six binders has always been empty.
+    /// </para>
+    /// </remarks>
+    [Serializable]
+    public sealed class ColorToColorBlockConverter : IConverter<Color, ColorBlock>
+    {
+        [Tooltip("Scales the colour for the highlighted state.")]
+        [SerializeField] private float _highlightedMultiplier = 1.1f;
+
+        [Tooltip("Scales the colour for the pressed state.")]
+        [SerializeField] private float _pressedMultiplier = 0.9f;
+
+        [Tooltip("Scales the colour for the selected state.")]
+        [SerializeField] private float _selectedMultiplier = 1f;
+
+        [Tooltip("Scales the colour for the disabled state.")]
+        [SerializeField] private float _disabledMultiplier = 0.5f;
+
+        [Tooltip("The alpha of the disabled state.")]
+        [SerializeField, Range(0f, 1f)] private float _disabledAlpha = 0.5f;
+
+        [Tooltip("How long a state change takes.")]
+        [SerializeField] private float _fadeDuration = 0.1f;
+
+        [Tooltip("The overall multiplier UGUI applies on top.")]
+        [SerializeField] private float _colorMultiplier = 1f;
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="ColorToColorBlockConverter"/> class with UGUI-like defaults.
+        /// </summary>
+        public ColorToColorBlockConverter() { }
+
+        /// <summary>
+        /// Builds a <see cref="ColorBlock"/> from the specified colour.
+        /// </summary>
+        /// <param name="value">The colour the states are derived from.</param>
+        /// <returns>The full block of state colours.</returns>
+        public ColorBlock Convert(Color value) => new()
+        {
+            normalColor = value,
+            highlightedColor = Scale(value, _highlightedMultiplier),
+            pressedColor = Scale(value, _pressedMultiplier),
+            selectedColor = Scale(value, _selectedMultiplier),
+            disabledColor = Fade(Scale(value, _disabledMultiplier), _disabledAlpha),
+            colorMultiplier = _colorMultiplier,
+            fadeDuration = _fadeDuration,
+        };
+
+        private static Color Scale(Color color, float multiplier) => new(
+            Mathf.Clamp01(color.r * multiplier),
+            Mathf.Clamp01(color.g * multiplier),
+            Mathf.Clamp01(color.b * multiplier),
+            color.a);
+
+        private static Color Fade(Color color, float alpha)
+        {
+            color.a = alpha;
+            return color;
+        }
+    }
+}

--- a/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Unity/Runtime/Converters/Colors/ColorToColorBlockConverter.cs
+++ b/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Unity/Runtime/Converters/Colors/ColorToColorBlockConverter.cs
@@ -37,9 +37,7 @@ namespace Aspid.MVVM.StarterKit
         [Tooltip("The overall multiplier UGUI applies on top.")]
         [SerializeField] private float _colorMultiplier = 1f;
 
-        /// <summary>
-        /// Initializes a new instance of the <see cref="ColorToColorBlockConverter"/> class with UGUI-like defaults.
-        /// </summary>
+        /// <remarks>Default: with UGUI-like defaults.</remarks>
         public ColorToColorBlockConverter() { }
 
         /// <summary>

--- a/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Unity/Runtime/Converters/Colors/ColorToColorBlockConverter.cs
+++ b/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Unity/Runtime/Converters/Colors/ColorToColorBlockConverter.cs
@@ -10,13 +10,8 @@ namespace Aspid.MVVM.StarterKit
     /// Builds a full <see cref="ColorBlock"/> out of one colour.
     /// </summary>
     /// <remarks>
-    /// A <see cref="Selectable"/> keeps five colours and a fade duration, so binding a theme colour
-    /// to a button meant the ViewModel producing all five — teaching it how UGUI models interaction
-    /// states. This derives them from the one colour that actually varies.
-    /// <para>
-    /// <c>IConverterColorBlock</c> has been declared since the first release with no implementation
-    /// behind it, so the picker on six binders has always been empty.
-    /// </para>
+    /// A <see cref="Selectable"/> keeps five colours and a fade duration; these derive all five from
+    /// the one colour that varies, so the ViewModel does not have to model UGUI interaction states.
     /// </remarks>
     [Serializable]
     public sealed class ColorToColorBlockConverter : IConverter<Color, ColorBlock>

--- a/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Unity/Runtime/Converters/Colors/ColorToColorBlockConverter.cs.meta
+++ b/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Unity/Runtime/Converters/Colors/ColorToColorBlockConverter.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 596548b44ae80451eb768f4460088a6d

--- a/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Unity/Runtime/Converters/Colors/ColorToHtmlStringConverter.cs
+++ b/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Unity/Runtime/Converters/Colors/ColorToHtmlStringConverter.cs
@@ -24,14 +24,8 @@ namespace Aspid.MVVM.StarterKit
         [Tooltip("Write the digits in lower case.")]
         [SerializeField] private bool _lowercase;
 
-        /// <summary>
-        /// Initializes a new instance of the <see cref="ColorToHtmlStringConverter"/> class.
-        /// </summary>
         public ColorToHtmlStringConverter() { }
 
-        /// <summary>
-        /// Initializes a new instance of the <see cref="ColorToHtmlStringConverter"/> class.
-        /// </summary>
         /// <param name="includeAlpha">Whether to include the alpha channel.</param>
         /// <param name="includeHash">Whether to prefix the string with a hash.</param>
         public ColorToHtmlStringConverter(bool includeAlpha, bool includeHash = true)

--- a/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Unity/Runtime/Converters/Colors/ColorToHtmlStringConverter.cs
+++ b/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Unity/Runtime/Converters/Colors/ColorToHtmlStringConverter.cs
@@ -1,0 +1,59 @@
+#nullable enable
+using System;
+using UnityEngine;
+
+// ReSharper disable once CheckNamespace
+namespace Aspid.MVVM.StarterKit
+{
+    /// <summary>
+    /// Writes a colour as an HTML string.
+    /// </summary>
+    /// <remarks>
+    /// The missing inverse of <see cref="ParseHtmlStringConverter"/>, and the piece a rich-text
+    /// colour tag is built from.
+    /// </remarks>
+    [Serializable]
+    public sealed class ColorToHtmlStringConverter : IConverter<Color, string>
+    {
+        [Tooltip("Include the alpha channel.")]
+        [SerializeField] private bool _includeAlpha;
+
+        [Tooltip("Prefix the string with a hash.")]
+        [SerializeField] private bool _includeHash = true;
+
+        [Tooltip("Write the digits in lower case.")]
+        [SerializeField] private bool _lowercase;
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="ColorToHtmlStringConverter"/> class.
+        /// </summary>
+        public ColorToHtmlStringConverter() { }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="ColorToHtmlStringConverter"/> class.
+        /// </summary>
+        /// <param name="includeAlpha">Whether to include the alpha channel.</param>
+        /// <param name="includeHash">Whether to prefix the string with a hash.</param>
+        public ColorToHtmlStringConverter(bool includeAlpha, bool includeHash = true)
+        {
+            _includeAlpha = includeAlpha;
+            _includeHash = includeHash;
+        }
+
+        /// <summary>
+        /// Writes the specified colour as an HTML string.
+        /// </summary>
+        /// <param name="value">The colour to write.</param>
+        /// <returns>The HTML string.</returns>
+        public string Convert(Color value)
+        {
+            var digits = _includeAlpha
+                ? ColorUtility.ToHtmlStringRGBA(value)
+                : ColorUtility.ToHtmlStringRGB(value);
+
+            if (_lowercase) digits = digits.ToLowerInvariant();
+
+            return _includeHash ? "#" + digits : digits;
+        }
+    }
+}

--- a/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Unity/Runtime/Converters/Colors/ColorToHtmlStringConverter.cs.meta
+++ b/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Unity/Runtime/Converters/Colors/ColorToHtmlStringConverter.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 86efbe0059751a468cf7bdf81d035e15

--- a/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Unity/Runtime/Converters/Colors/GradientEvaluateConverter.cs
+++ b/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Unity/Runtime/Converters/Colors/GradientEvaluateConverter.cs
@@ -25,14 +25,9 @@ namespace Aspid.MVVM.StarterKit
         [Tooltip("The input value that maps to the end of the gradient.")]
         [SerializeField] private float _inputMax = 1f;
 
-        /// <summary>
-        /// Initializes a new instance of the <see cref="GradientEvaluateConverter"/> class over 0..1.
-        /// </summary>
+        /// <remarks>Default: over 0..1.</remarks>
         public GradientEvaluateConverter() { }
 
-        /// <summary>
-        /// Initializes a new instance of the <see cref="GradientEvaluateConverter"/> class.
-        /// </summary>
         /// <param name="gradient">The gradient the value is read from.</param>
         /// <param name="inputMin">The input value that maps to the start of the gradient.</param>
         /// <param name="inputMax">The input value that maps to the end of the gradient.</param>

--- a/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Unity/Runtime/Converters/Colors/GradientEvaluateConverter.cs
+++ b/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Unity/Runtime/Converters/Colors/GradientEvaluateConverter.cs
@@ -1,0 +1,61 @@
+#nullable enable
+using System;
+using UnityEngine;
+
+// ReSharper disable once CheckNamespace
+namespace Aspid.MVVM.StarterKit
+{
+    /// <summary>
+    /// Reads a colour off a <see cref="Gradient"/>.
+    /// </summary>
+    /// <remarks>
+    /// The health-bar colour converter. A gradient is edited with Unity's own editor, so the whole
+    /// green-to-red ramp is authored rather than written, and the ViewModel keeps sending the one
+    /// number it already has.
+    /// </remarks>
+    [Serializable]
+    public sealed class GradientEvaluateConverter : IConverter<float, Color>
+    {
+        [Tooltip("The gradient the value is read from.")]
+        [SerializeField] private Gradient _gradient = new();
+
+        [Tooltip("The input value that maps to the start of the gradient.")]
+        [SerializeField] private float _inputMin;
+
+        [Tooltip("The input value that maps to the end of the gradient.")]
+        [SerializeField] private float _inputMax = 1f;
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="GradientEvaluateConverter"/> class over 0..1.
+        /// </summary>
+        public GradientEvaluateConverter() { }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="GradientEvaluateConverter"/> class.
+        /// </summary>
+        /// <param name="gradient">The gradient the value is read from.</param>
+        /// <param name="inputMin">The input value that maps to the start of the gradient.</param>
+        /// <param name="inputMax">The input value that maps to the end of the gradient.</param>
+        public GradientEvaluateConverter(Gradient gradient, float inputMin = 0f, float inputMax = 1f)
+        {
+            _gradient = gradient;
+            _inputMin = inputMin;
+            _inputMax = inputMax;
+        }
+
+        /// <summary>
+        /// Reads the colour at the specified value.
+        /// </summary>
+        /// <param name="value">The value to read at.</param>
+        /// <returns>The colour there, or white when no gradient is assigned.</returns>
+        public Color Convert(float value)
+        {
+            if (_gradient is null) return Color.white;
+
+            var span = _inputMax - _inputMin;
+            var time = span == 0f ? 0f : Mathf.Clamp01((value - _inputMin) / span);
+
+            return _gradient.Evaluate(time);
+        }
+    }
+}

--- a/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Unity/Runtime/Converters/Colors/GradientEvaluateConverter.cs.meta
+++ b/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Unity/Runtime/Converters/Colors/GradientEvaluateConverter.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: deadd9b24043e31716c5b5fab307b5e4

--- a/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Unity/Runtime/Converters/Colors/HashToColorConverter.cs
+++ b/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Unity/Runtime/Converters/Colors/HashToColorConverter.cs
@@ -24,9 +24,6 @@ namespace Aspid.MVVM.StarterKit
         [Tooltip("Used for a null or empty string.")]
         [SerializeField] private Color _fallback = Color.gray;
 
-        /// <summary>
-        /// Initializes a new instance of the <see cref="HashToColorConverter"/> class.
-        /// </summary>
         public HashToColorConverter() { }
 
         /// <summary>

--- a/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Unity/Runtime/Converters/Colors/HashToColorConverter.cs
+++ b/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Unity/Runtime/Converters/Colors/HashToColorConverter.cs
@@ -1,0 +1,53 @@
+#nullable enable
+using System;
+using UnityEngine;
+
+// ReSharper disable once CheckNamespace
+namespace Aspid.MVVM.StarterKit
+{
+    /// <summary>
+    /// Derives a stable colour from a string.
+    /// </summary>
+    /// <remarks>
+    /// Per-player colours in a lobby or chat without the server sending any, and the same name always
+    /// produces the same colour.
+    /// </remarks>
+    [Serializable]
+    public sealed class HashToColorConverter : IConverter<string?, Color>
+    {
+        [Tooltip("The saturation of the produced colour.")]
+        [SerializeField, Range(0f, 1f)] private float _saturation = 0.6f;
+
+        [Tooltip("The brightness of the produced colour.")]
+        [SerializeField, Range(0f, 1f)] private float _value = 0.9f;
+
+        [Tooltip("Used for a null or empty string.")]
+        [SerializeField] private Color _fallback = Color.gray;
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="HashToColorConverter"/> class.
+        /// </summary>
+        public HashToColorConverter() { }
+
+        /// <summary>
+        /// Derives a colour from the specified string.
+        /// </summary>
+        /// <param name="value">The string to hash.</param>
+        /// <returns>The derived colour, or the fallback for a blank string.</returns>
+        public Color Convert(string? value)
+        {
+            if (string.IsNullOrEmpty(value)) return _fallback;
+
+            // FNV-1a: string.GetHashCode is randomised per process in modern runtimes, so the same
+            // name would take a different colour on every launch.
+            var hash = 2166136261u;
+            foreach (var character in value!)
+            {
+                hash ^= character;
+                hash *= 16777619u;
+            }
+
+            return Color.HSVToRGB(hash % 360u / 360f, _saturation, _value);
+        }
+    }
+}

--- a/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Unity/Runtime/Converters/Colors/HashToColorConverter.cs.meta
+++ b/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Unity/Runtime/Converters/Colors/HashToColorConverter.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: ef634f0fe6aab6e0135b8c7bb004a0de

--- a/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Unity/Runtime/Converters/Colors/ThresholdColorConverter.cs
+++ b/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Unity/Runtime/Converters/Colors/ThresholdColorConverter.cs
@@ -1,0 +1,59 @@
+#nullable enable
+using System;
+using UnityEngine;
+
+// ReSharper disable once CheckNamespace
+namespace Aspid.MVVM.StarterKit
+{
+    /// <summary>
+    /// Picks a colour by which threshold a number has passed.
+    /// </summary>
+    /// <remarks>Stepped states — green, amber, red — rather than a continuous ramp.</remarks>
+    [Serializable]
+    public sealed class ThresholdColorConverter : IConverter<float, Color>
+    {
+        [Tooltip("Colours by threshold. The highest threshold at or below the value wins.")]
+        [SerializeField] private ColorStop[] _stops = Array.Empty<ColorStop>();
+
+        [Tooltip("Used when the value is below every threshold.")]
+        [SerializeField] private Color _fallback = Color.white;
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="ThresholdColorConverter"/> class with no stops.
+        /// </summary>
+        public ThresholdColorConverter() { }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="ThresholdColorConverter"/> class.
+        /// </summary>
+        /// <param name="stops">Colours by threshold.</param>
+        /// <param name="fallback">Used when the value is below every threshold.</param>
+        public ThresholdColorConverter(ColorStop[]? stops, Color fallback)
+        {
+            _stops = stops ?? Array.Empty<ColorStop>();
+            _fallback = fallback;
+        }
+
+        /// <summary>
+        /// Picks the colour for the specified value.
+        /// </summary>
+        /// <param name="value">The value to place.</param>
+        /// <returns>The colour of the highest qualifying stop, or the fallback.</returns>
+        public Color Convert(float value)
+        {
+            if (_stops is not { Length: > 0 }) return _fallback;
+
+            var color = _fallback;
+            var best = float.NegativeInfinity;
+
+            for (var i = 0; i < _stops.Length; i++)
+                if (value >= _stops[i].Threshold && _stops[i].Threshold > best)
+                {
+                    best = _stops[i].Threshold;
+                    color = _stops[i].Color;
+                }
+
+            return color;
+        }
+    }
+}

--- a/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Unity/Runtime/Converters/Colors/ThresholdColorConverter.cs
+++ b/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Unity/Runtime/Converters/Colors/ThresholdColorConverter.cs
@@ -18,14 +18,8 @@ namespace Aspid.MVVM.StarterKit
         [Tooltip("Used when the value is below every threshold.")]
         [SerializeField] private Color _fallback = Color.white;
 
-        /// <summary>
-        /// Initializes a new instance of the <see cref="ThresholdColorConverter"/> class with no stops.
-        /// </summary>
         public ThresholdColorConverter() { }
 
-        /// <summary>
-        /// Initializes a new instance of the <see cref="ThresholdColorConverter"/> class.
-        /// </summary>
         /// <param name="stops">Colours by threshold.</param>
         /// <param name="fallback">Used when the value is below every threshold.</param>
         public ThresholdColorConverter(ColorStop[]? stops, Color fallback)

--- a/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Unity/Runtime/Converters/Colors/ThresholdColorConverter.cs.meta
+++ b/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Unity/Runtime/Converters/Colors/ThresholdColorConverter.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 2c1032229caab6ae60d344c7f7a9116e

--- a/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Unity/Runtime/Converters/Textures.meta
+++ b/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Unity/Runtime/Converters/Textures.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 339ec301fe0ec4fb886b741aecdfbbf5
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Unity/Runtime/Converters/Textures/NormalizedToSpriteConverter.cs
+++ b/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Unity/Runtime/Converters/Textures/NormalizedToSpriteConverter.cs
@@ -18,14 +18,8 @@ namespace Aspid.MVVM.StarterKit
         [Tooltip("The frames, from empty to full.")]
         [SerializeField] private Sprite[] _frames = Array.Empty<Sprite>();
 
-        /// <summary>
-        /// Initializes a new instance of the <see cref="NormalizedToSpriteConverter"/> class with no frames.
-        /// </summary>
         public NormalizedToSpriteConverter() { }
 
-        /// <summary>
-        /// Initializes a new instance of the <see cref="NormalizedToSpriteConverter"/> class.
-        /// </summary>
         /// <param name="frames">The frames, from empty to full.</param>
         public NormalizedToSpriteConverter(Sprite[]? frames)
         {

--- a/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Unity/Runtime/Converters/Textures/NormalizedToSpriteConverter.cs
+++ b/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Unity/Runtime/Converters/Textures/NormalizedToSpriteConverter.cs
@@ -1,0 +1,48 @@
+#nullable enable
+using System;
+using UnityEngine;
+
+// ReSharper disable once CheckNamespace
+namespace Aspid.MVVM.StarterKit
+{
+    /// <summary>
+    /// Picks one of a list of sprites by a 0..1 amount.
+    /// </summary>
+    /// <remarks>
+    /// Stepped bars, discrete health hearts, stamina pips — a continuous value rendered as one of a
+    /// fixed set of frames.
+    /// </remarks>
+    [Serializable]
+    public sealed class NormalizedToSpriteConverter : IConverter<float, Sprite?>
+    {
+        [Tooltip("The frames, from empty to full.")]
+        [SerializeField] private Sprite[] _frames = Array.Empty<Sprite>();
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="NormalizedToSpriteConverter"/> class with no frames.
+        /// </summary>
+        public NormalizedToSpriteConverter() { }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="NormalizedToSpriteConverter"/> class.
+        /// </summary>
+        /// <param name="frames">The frames, from empty to full.</param>
+        public NormalizedToSpriteConverter(Sprite[]? frames)
+        {
+            _frames = frames ?? Array.Empty<Sprite>();
+        }
+
+        /// <summary>
+        /// Picks the frame for the specified amount.
+        /// </summary>
+        /// <param name="value">The 0..1 amount.</param>
+        /// <returns>The frame at that amount, or <see langword="null"/> when there are none.</returns>
+        public Sprite? Convert(float value)
+        {
+            if (_frames is not { Length: > 0 }) return null;
+
+            var index = Mathf.Clamp(Mathf.FloorToInt(Mathf.Clamp01(value) * _frames.Length), 0, _frames.Length - 1);
+            return _frames[index];
+        }
+    }
+}

--- a/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Unity/Runtime/Converters/Textures/NormalizedToSpriteConverter.cs.meta
+++ b/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Unity/Runtime/Converters/Textures/NormalizedToSpriteConverter.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: d2e46f77aa832453e8e28bad3c4a4b59

--- a/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Unity/Runtime/Converters/Textures/ObjectNameConverter.cs
+++ b/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Unity/Runtime/Converters/Textures/ObjectNameConverter.cs
@@ -18,14 +18,8 @@ namespace Aspid.MVVM.StarterKit
         [Tooltip("Drop the \"(Clone)\" an instantiated object carries.")]
         [SerializeField] private bool _stripCloneSuffix = true;
 
-        /// <summary>
-        /// Initializes a new instance of the <see cref="ObjectNameConverter"/> class.
-        /// </summary>
         public ObjectNameConverter() { }
 
-        /// <summary>
-        /// Initializes a new instance of the <see cref="ObjectNameConverter"/> class.
-        /// </summary>
         /// <param name="fallback">Shown when the object is missing.</param>
         /// <param name="stripCloneSuffix">Whether to drop the "(Clone)" suffix.</param>
         public ObjectNameConverter(string fallback, bool stripCloneSuffix = true)

--- a/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Unity/Runtime/Converters/Textures/ObjectNameConverter.cs
+++ b/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Unity/Runtime/Converters/Textures/ObjectNameConverter.cs
@@ -1,0 +1,56 @@
+#nullable enable
+using System;
+using UnityEngine;
+
+// ReSharper disable once CheckNamespace
+namespace Aspid.MVVM.StarterKit
+{
+    /// <summary>
+    /// Reads the name of a Unity object.
+    /// </summary>
+    /// <remarks>Debug overlays and tooltips that label whatever they are pointed at.</remarks>
+    [Serializable]
+    public sealed class ObjectNameConverter : IConverter<UnityEngine.Object?, string>
+    {
+        [Tooltip("Shown when the object is missing.")]
+        [SerializeField] private string _fallback = string.Empty;
+
+        [Tooltip("Drop the \"(Clone)\" an instantiated object carries.")]
+        [SerializeField] private bool _stripCloneSuffix = true;
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="ObjectNameConverter"/> class.
+        /// </summary>
+        public ObjectNameConverter() { }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="ObjectNameConverter"/> class.
+        /// </summary>
+        /// <param name="fallback">Shown when the object is missing.</param>
+        /// <param name="stripCloneSuffix">Whether to drop the "(Clone)" suffix.</param>
+        public ObjectNameConverter(string fallback, bool stripCloneSuffix = true)
+        {
+            _fallback = fallback;
+            _stripCloneSuffix = stripCloneSuffix;
+        }
+
+        /// <summary>
+        /// Reads the name of the specified object.
+        /// </summary>
+        /// <param name="value">The object to name.</param>
+        /// <returns>Its name, or the fallback when it is missing or destroyed.</returns>
+        public string Convert(UnityEngine.Object? value)
+        {
+            // Unity's overloaded == also catches a destroyed object, whose name access would throw.
+            if (value == null) return _fallback;
+
+            var name = value.name;
+            if (!_stripCloneSuffix) return name;
+
+            const string clone = "(Clone)";
+            return name.EndsWith(clone, StringComparison.Ordinal)
+                ? name[..^clone.Length].TrimEnd()
+                : name;
+        }
+    }
+}

--- a/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Unity/Runtime/Converters/Textures/ObjectNameConverter.cs.meta
+++ b/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Unity/Runtime/Converters/Textures/ObjectNameConverter.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 2afb24381601c82f2e113ecb1da33ab2

--- a/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Unity/Runtime/Converters/Textures/SpriteToTextureConverter.cs
+++ b/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Unity/Runtime/Converters/Textures/SpriteToTextureConverter.cs
@@ -1,0 +1,25 @@
+#nullable enable
+using System;
+using UnityEngine;
+
+// ReSharper disable once CheckNamespace
+namespace Aspid.MVVM.StarterKit
+{
+    /// <summary>
+    /// Takes the texture a <see cref="Sprite"/> is drawn from.
+    /// </summary>
+    /// <remarks>
+    /// A ViewModel holding a <see cref="Sprite"/> could not feed a <c>RawImage</c>, which wants a
+    /// <see cref="Texture"/> — two properties for one picture.
+    /// </remarks>
+    [Serializable]
+    public sealed class SpriteToTextureConverter : IConverter<Sprite?, Texture?>
+    {
+        /// <summary>
+        /// Takes the texture of the specified sprite.
+        /// </summary>
+        /// <param name="value">The sprite to read.</param>
+        /// <returns>Its texture, or <see langword="null"/> when the sprite is missing.</returns>
+        public Texture? Convert(Sprite? value) => value == null ? null : value.texture;
+    }
+}

--- a/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Unity/Runtime/Converters/Textures/SpriteToTextureConverter.cs.meta
+++ b/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Unity/Runtime/Converters/Textures/SpriteToTextureConverter.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: a0fd82686ca6413f2606a8553f0262b0

--- a/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Unity/Runtime/Converters/Textures/Texture2DToSpriteConverter.cs
+++ b/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Unity/Runtime/Converters/Textures/Texture2DToSpriteConverter.cs
@@ -9,12 +9,9 @@ namespace Aspid.MVVM.StarterKit
     /// Wraps a <see cref="Texture2D"/> in a <see cref="Sprite"/>.
     /// </summary>
     /// <remarks>
-    /// A downloaded avatar or a screenshot arrives as a texture and an <c>Image</c> wants a sprite.
-    /// <para>
     /// <see cref="Sprite.Create(Texture2D, Rect, Vector2)"/> allocates every time it is called, and a
     /// binder pushes on every notification rather than on every change — so the result is cached
     /// against the texture it came from. Without that, a bound avatar leaks a sprite per frame.
-    /// </para>
     /// </remarks>
     [Serializable]
     public sealed class Texture2DToSpriteConverter : IConverter<Texture2D?, Sprite?>

--- a/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Unity/Runtime/Converters/Textures/Texture2DToSpriteConverter.cs
+++ b/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Unity/Runtime/Converters/Textures/Texture2DToSpriteConverter.cs
@@ -25,14 +25,9 @@ namespace Aspid.MVVM.StarterKit
         [NonSerialized] private Texture2D? _lastTexture;
         [NonSerialized] private Sprite? _lastSprite;
 
-        /// <summary>
-        /// Initializes a new instance of the <see cref="Texture2DToSpriteConverter"/> class with a centred pivot.
-        /// </summary>
+        /// <remarks>Default: with a centred pivot.</remarks>
         public Texture2DToSpriteConverter() { }
 
-        /// <summary>
-        /// Initializes a new instance of the <see cref="Texture2DToSpriteConverter"/> class.
-        /// </summary>
         /// <param name="pivot">Where the sprite's pivot sits, in normalised coordinates.</param>
         /// <param name="pixelsPerUnit">How many texture pixels make up one world unit.</param>
         public Texture2DToSpriteConverter(Vector2 pivot, float pixelsPerUnit = 100f)

--- a/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Unity/Runtime/Converters/Textures/Texture2DToSpriteConverter.cs
+++ b/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Unity/Runtime/Converters/Textures/Texture2DToSpriteConverter.cs
@@ -1,0 +1,76 @@
+#nullable enable
+using System;
+using UnityEngine;
+
+// ReSharper disable once CheckNamespace
+namespace Aspid.MVVM.StarterKit
+{
+    /// <summary>
+    /// Wraps a <see cref="Texture2D"/> in a <see cref="Sprite"/>.
+    /// </summary>
+    /// <remarks>
+    /// A downloaded avatar or a screenshot arrives as a texture and an <c>Image</c> wants a sprite.
+    /// <para>
+    /// <see cref="Sprite.Create(Texture2D, Rect, Vector2)"/> allocates every time it is called, and a
+    /// binder pushes on every notification rather than on every change — so the result is cached
+    /// against the texture it came from. Without that, a bound avatar leaks a sprite per frame.
+    /// </para>
+    /// </remarks>
+    [Serializable]
+    public sealed class Texture2DToSpriteConverter : IConverter<Texture2D?, Sprite?>
+    {
+        [Tooltip("Where the sprite's pivot sits, in normalised coordinates.")]
+        [SerializeField] private Vector2 _pivot = new(0.5f, 0.5f);
+
+        [Tooltip("How many texture pixels make up one world unit.")]
+        [SerializeField] private float _pixelsPerUnit = 100f;
+
+        [NonSerialized] private Texture2D? _lastTexture;
+        [NonSerialized] private Sprite? _lastSprite;
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="Texture2DToSpriteConverter"/> class with a centred pivot.
+        /// </summary>
+        public Texture2DToSpriteConverter() { }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="Texture2DToSpriteConverter"/> class.
+        /// </summary>
+        /// <param name="pivot">Where the sprite's pivot sits, in normalised coordinates.</param>
+        /// <param name="pixelsPerUnit">How many texture pixels make up one world unit.</param>
+        public Texture2DToSpriteConverter(Vector2 pivot, float pixelsPerUnit = 100f)
+        {
+            _pivot = pivot;
+            _pixelsPerUnit = pixelsPerUnit;
+        }
+
+        /// <summary>
+        /// Wraps the specified texture in a sprite.
+        /// </summary>
+        /// <param name="value">The texture to wrap.</param>
+        /// <returns>
+        /// A sprite covering the whole texture, reused while the texture is unchanged, or
+        /// <see langword="null"/> when the texture is missing.
+        /// </returns>
+        public Sprite? Convert(Texture2D? value)
+        {
+            if (value == null)
+            {
+                _lastTexture = null;
+                _lastSprite = null;
+                return null;
+            }
+
+            if (ReferenceEquals(_lastTexture, value) && _lastSprite != null) return _lastSprite;
+
+            _lastTexture = value;
+            _lastSprite = Sprite.Create(
+                value,
+                new Rect(0f, 0f, value.width, value.height),
+                _pivot,
+                _pixelsPerUnit <= 0f ? 100f : _pixelsPerUnit);
+
+            return _lastSprite;
+        }
+    }
+}

--- a/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Unity/Runtime/Converters/Textures/Texture2DToSpriteConverter.cs.meta
+++ b/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Unity/Runtime/Converters/Textures/Texture2DToSpriteConverter.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: e9cea273ffbc8463f8cce6b86ebdb397

--- a/Aspid.MVVM/Packages/tech.aspid.mvvm/Tests/Editor/Converters/Colors.meta
+++ b/Aspid.MVVM/Packages/tech.aspid.mvvm/Tests/Editor/Converters/Colors.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 266658bcc765b439492ccf4d72fed87a
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Aspid.MVVM/Packages/tech.aspid.mvvm/Tests/Editor/Converters/Colors/VisualConverterTests.cs
+++ b/Aspid.MVVM/Packages/tech.aspid.mvvm/Tests/Editor/Converters/Colors/VisualConverterTests.cs
@@ -1,0 +1,284 @@
+using UnityEngine;
+using NUnit.Framework;
+using UnityEngine.UI;
+
+namespace Aspid.MVVM.StarterKit.Tests
+{
+    /// <summary>
+    /// Coverage for the colour, ColorBlock and texture converters.
+    /// </summary>
+    /// <remarks>
+    /// This wave fills the two pickers that had been declared but never implemented, so a few of the
+    /// assertions are really about the field being usable at all rather than about arithmetic.
+    /// </remarks>
+    [TestFixture]
+    internal sealed class VisualConverterTests
+    {
+        [Test]
+        public void ColorAlpha_SetsTheAlphaAndLeavesTheHue()
+        {
+            var result = new ColorAlphaConverter(0.5f).Convert(new Color(0.2f, 0.4f, 0.6f, 1f));
+
+            Assert.AreEqual(0.5f, result.a, 1e-5f);
+            Assert.AreEqual(0.2f, result.r, 1e-5f);
+        }
+
+        [Test]
+        public void ColorAlpha_Multiplies() =>
+            Assert.AreEqual(
+                0.25f,
+                new ColorAlphaConverter(0.5f, AlphaMode.Multiply).Convert(new Color(1f, 1f, 1f, 0.5f)).a,
+                1e-5f);
+
+        [Test]
+        public void ColorTint_Multiplies() =>
+            Assert.AreEqual(
+                new Color(0.5f, 0f, 0f, 1f),
+                new ColorTintConverter(Color.red).Convert(new Color(0.5f, 0.5f, 0.5f, 1f)));
+
+        [Test]
+        public void ColorTint_ReplaceKeepsTheOriginalAlpha()
+        {
+            var result = new ColorTintConverter(Color.red, ColorBlend.Replace).Convert(new Color(0f, 0f, 1f, 0.3f));
+
+            Assert.AreEqual(1f, result.r, 1e-5f);
+            Assert.AreEqual(0.3f, result.a, 1e-5f);
+        }
+
+        [Test]
+        public void ColorGrayscale_UsesLuminanceWeightsNotAFlatAverage()
+        {
+            // A flat average of pure green would be 0.333; the eye reads it as 0.587.
+            var result = new ColorGrayscaleConverter(0f).Convert(Color.green);
+
+            Assert.AreEqual(0.587f, result.r, 1e-3f);
+            Assert.AreEqual(result.r, result.g, 1e-6f);
+            Assert.AreEqual(result.r, result.b, 1e-6f);
+        }
+
+        [Test]
+        public void ColorGrayscale_KeepsAlpha() =>
+            Assert.AreEqual(0.4f, new ColorGrayscaleConverter(0f).Convert(new Color(1f, 0f, 0f, 0.4f)).a, 1e-5f);
+
+        [Test]
+        public void ColorHsv_HalfATurnGivesTheOppositeHue()
+        {
+            var result = new ColorHsvConverter(0.5f).Convert(Color.red);
+
+            Color.RGBToHSV(result, out var hue, out _, out _);
+            Assert.AreEqual(0.5f, hue, 1e-3f);
+        }
+
+        [Test]
+        public void ColorToHtmlString_WritesTheHex() =>
+            Assert.AreEqual("#FF0000", new ColorToHtmlStringConverter().Convert(Color.red));
+
+        [Test]
+        public void ColorToHtmlString_RoundTripsThroughParseHtmlString()
+        {
+            var text = new ColorToHtmlStringConverter(includeAlpha: true).Convert(new Color(0.2f, 0.4f, 0.6f, 0.8f));
+            var parsed = new ParseHtmlStringConverter().Convert(text);
+
+            Assert.AreEqual(0.2f, parsed.r, 0.01f);
+            Assert.AreEqual(0.8f, parsed.a, 0.01f);
+        }
+
+        [Test]
+        public void GradientEvaluate_ReadsTheRamp()
+        {
+            var gradient = new Gradient();
+            gradient.SetKeys(
+                new[] { new GradientColorKey(Color.red, 0f), new GradientColorKey(Color.green, 1f) },
+                new[] { new GradientAlphaKey(1f, 0f), new GradientAlphaKey(1f, 1f) });
+
+            var converter = new GradientEvaluateConverter(gradient);
+
+            Assert.AreEqual(Color.red, converter.Convert(0f));
+            Assert.AreEqual(Color.green, converter.Convert(1f));
+        }
+
+        [Test]
+        public void GradientEvaluate_MapsTheInputRange()
+        {
+            var gradient = new Gradient();
+            gradient.SetKeys(
+                new[] { new GradientColorKey(Color.red, 0f), new GradientColorKey(Color.green, 1f) },
+                new[] { new GradientAlphaKey(1f, 0f), new GradientAlphaKey(1f, 1f) });
+
+            Assert.AreEqual(Color.green, new GradientEvaluateConverter(gradient, 0f, 100f).Convert(100f));
+        }
+
+        [Test]
+        public void ColorLerp_MovesBetweenTheStops()
+        {
+            var converter = new ColorLerpConverter(Color.red, Color.green);
+
+            Assert.AreEqual(Color.red, converter.Convert(0f));
+            Assert.AreEqual(Color.green, converter.Convert(1f));
+        }
+
+        [Test]
+        public void ThresholdColor_PicksTheHighestQualifyingStop()
+        {
+            var converter = new ThresholdColorConverter(
+                new[]
+                {
+                    new ColorStop { Threshold = 0.75f, Color = Color.green },
+                    new ColorStop { Threshold = 0.25f, Color = Color.blue },
+                },
+                fallback: Color.red);
+
+            Assert.AreEqual(Color.green, converter.Convert(0.9f));
+            Assert.AreEqual(Color.blue, converter.Convert(0.5f));
+            Assert.AreEqual(Color.red, converter.Convert(0.1f));
+        }
+
+        // string.GetHashCode is randomised per process, so the same name would take a different
+        // colour on every launch. The hash here is FNV-1a, which is not.
+        [Test]
+        public void HashToColor_IsStableForTheSameName()
+        {
+            var converter = new HashToColorConverter();
+
+            Assert.AreEqual(converter.Convert("Vladislav"), converter.Convert("Vladislav"));
+            Assert.AreNotEqual(converter.Convert("Vladislav"), converter.Convert("Someone"));
+        }
+
+        [Test]
+        public void HashToColor_BlankGivesTheFallback() =>
+            Assert.AreEqual(Color.gray, new HashToColorConverter().Convert(null));
+
+        [Test]
+        public void ColorToColorBlock_DerivesEveryState()
+        {
+            var block = new ColorToColorBlockConverter().Convert(Color.white);
+
+            Assert.AreEqual(Color.white, block.normalColor);
+            Assert.Less(block.pressedColor.r, block.normalColor.r);
+            Assert.AreEqual(0.5f, block.disabledColor.a, 1e-5f);
+        }
+
+        [Test]
+        public void ColorBlockTint_TintsEveryState()
+        {
+            var block = new ColorToColorBlockConverter().Convert(Color.white);
+            var tinted = new ColorBlockTintConverter(Color.red).Convert(block);
+
+            Assert.AreEqual(0f, tinted.normalColor.g, 1e-5f);
+            Assert.AreEqual(0f, tinted.pressedColor.g, 1e-5f);
+            Assert.AreEqual(0f, tinted.disabledColor.g, 1e-5f);
+        }
+
+        [Test]
+        public void ColorBlockAlpha_DimsEveryState()
+        {
+            var block = ColorBlock.defaultColorBlock;
+            var dimmed = new ColorBlockAlphaConverter(0.5f).Convert(block);
+
+            Assert.AreEqual(block.normalColor.a * 0.5f, dimmed.normalColor.a, 1e-5f);
+            Assert.AreEqual(block.highlightedColor.a * 0.5f, dimmed.highlightedColor.a, 1e-5f);
+        }
+
+        [Test]
+        public void ColorBlockFadeDuration_SetsOnlyTheDuration()
+        {
+            var block = ColorBlock.defaultColorBlock;
+            var slowed = new ColorBlockFadeDurationConverter(0.5f).Convert(block);
+
+            Assert.AreEqual(0.5f, slowed.fadeDuration, 1e-5f);
+            Assert.AreEqual(block.normalColor, slowed.normalColor);
+        }
+
+        [Test]
+        public void SpriteToTexture_ReadsTheTexture()
+        {
+            var texture = new Texture2D(4, 4);
+            var sprite = Sprite.Create(texture, new Rect(0, 0, 4, 4), Vector2.one * 0.5f);
+
+            try
+            {
+                Assert.AreSame(texture, new SpriteToTextureConverter().Convert(sprite));
+                Assert.IsNull(new SpriteToTextureConverter().Convert(null));
+            }
+            finally
+            {
+                Object.DestroyImmediate(sprite);
+                Object.DestroyImmediate(texture);
+            }
+        }
+
+        // Sprite.Create allocates every call and a binder pushes on every notification, so without
+        // the cache a bound avatar leaks a sprite per frame.
+        [Test]
+        public void Texture2DToSprite_ReusesTheSpriteWhileTheTextureIsUnchanged()
+        {
+            var texture = new Texture2D(4, 4);
+            var converter = new Texture2DToSpriteConverter();
+
+            try
+            {
+                var first = converter.Convert(texture);
+                var second = converter.Convert(texture);
+
+                Assert.IsNotNull(first);
+                Assert.AreSame(first, second);
+            }
+            finally
+            {
+                Object.DestroyImmediate(texture);
+            }
+        }
+
+        [Test]
+        public void Texture2DToSprite_NullClearsTheCache() =>
+            Assert.IsNull(new Texture2DToSpriteConverter().Convert(null));
+
+        [Test]
+        public void NormalizedToSprite_PicksTheFrame()
+        {
+            var texture = new Texture2D(2, 2);
+            var frames = new[]
+            {
+                Sprite.Create(texture, new Rect(0, 0, 2, 2), Vector2.one * 0.5f),
+                Sprite.Create(texture, new Rect(0, 0, 2, 2), Vector2.one * 0.5f),
+            };
+
+            try
+            {
+                var converter = new NormalizedToSpriteConverter(frames);
+
+                Assert.AreSame(frames[0], converter.Convert(0f));
+                Assert.AreSame(frames[1], converter.Convert(1f));
+                Assert.AreSame(frames[1], converter.Convert(0.9f));
+            }
+            finally
+            {
+                foreach (var frame in frames) Object.DestroyImmediate(frame);
+                Object.DestroyImmediate(texture);
+            }
+        }
+
+        [Test]
+        public void NormalizedToSprite_WithNoFramesReturnsNull() =>
+            Assert.IsNull(new NormalizedToSpriteConverter(null).Convert(0.5f));
+
+        [Test]
+        public void ObjectName_StripsTheCloneSuffix()
+        {
+            var gameObject = new GameObject("Enemy(Clone)");
+
+            try
+            {
+                Assert.AreEqual("Enemy", new ObjectNameConverter(string.Empty).Convert(gameObject));
+            }
+            finally
+            {
+                Object.DestroyImmediate(gameObject);
+            }
+        }
+
+        [Test]
+        public void ObjectName_MissingObjectGivesTheFallback() =>
+            Assert.AreEqual("—", new ObjectNameConverter("—").Convert(null));
+    }
+}

--- a/Aspid.MVVM/Packages/tech.aspid.mvvm/Tests/Editor/Converters/Colors/VisualConverterTests.cs.meta
+++ b/Aspid.MVVM/Packages/tech.aspid.mvvm/Tests/Editor/Converters/Colors/VisualConverterTests.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 63b575de640264e379d1d617b9f9702c

--- a/Aspid.MVVM/Packages/tech.aspid.mvvm/Tests/Editor/Converters/ConverterFieldCoverageTests.cs
+++ b/Aspid.MVVM/Packages/tech.aspid.mvvm/Tests/Editor/Converters/ConverterFieldCoverageTests.cs
@@ -48,8 +48,6 @@ namespace Aspid.MVVM.StarterKit.Tests
         /// </summary>
         private static readonly Dictionary<string, string> KnownGaps = new()
         {
-            ["IConverter<Color, Color>"] = "family 9 (Colour) — ColorAlpha, ColorTint, ColorGrayscale…",
-            ["IConverter<ColorBlock, ColorBlock>"] = "family 10 (ColorBlock) — ColorToColorBlock…",
             ["IConverter<Quaternion, Quaternion>"] = "family 14 (Rotations) — AngleToQuaternion, LookRotation…",
         };
 


### PR DESCRIPTION
✨ Phase 3 wave 3.4 — colour, ColorBlock and textures. Two more pickers declared since the first release with nothing behind them are now filled; `IConverterColorBlock` had been offering six binders only `<None>`.

## Summary

- ✨ **Colour**: `ColorAlpha`, `ColorTint`, `ColorGrayscale`, `ColorHsv`, `ColorToHtmlString`, `GradientEvaluate`, `ColorLerp`, `ThresholdColor`, `HashToColor`.
- ✨ **ColorBlock**: `ColorToColorBlockConverter`, plus tint, alpha and fade-duration converters — so a ViewModel need not know UGUI's five-state model.
- ✨ **Textures**: `SpriteToTexture`, `Texture2DToSprite`, `NormalizedToSprite`, `ObjectName`.
- 📝 `GradientEvaluateConverter` is the one worth having: the whole green-to-red ramp is authored in Unity's gradient editor, and the ViewModel keeps sending the number it already has.

## Notes for review

- ⚠️ `Texture2DToSpriteConverter` caches because `Sprite.Create` allocates per call and a binder pushes per notification — a bound avatar would leak a sprite per frame.
- ⚠️ `HashToColorConverter` uses FNV-1a, not `string.GetHashCode`, which is randomised per process: a player's colour would change on every launch.
- 📝 `ColorGrayscaleConverter` weights by luminance rather than averaging channels, and the test asserts the perceptual value so a "simplification" fails loudly.

✅ Local run: 515 total, 513 passed, 0 failed, 2 skipped.

<details>
<summary>🇷🇺 Описание на русском</summary>

✨ Волна 3.4 Фазы 3 — цвет, ColorBlock и текстуры. Закрыты ещё два пикера, объявленных с первого релиза и не имевших за собой ничего; `IConverterColorBlock` предлагал шести биндерам только `<None>`.

## Итог

- ✨ **Цвет**: `ColorAlpha`, `ColorTint`, `ColorGrayscale`, `ColorHsv`, `ColorToHtmlString`, `GradientEvaluate`, `ColorLerp`, `ThresholdColor`, `HashToColor`.
- ✨ **ColorBlock**: `ColorToColorBlockConverter` плюс конвертеры тинта, альфы и длительности перехода — чтобы ViewModel не знала пятисостоянийную модель UGUI.
- ✨ **Текстуры**: `SpriteToTexture`, `Texture2DToSprite`, `NormalizedToSprite`, `ObjectName`.
- 📝 `GradientEvaluateConverter` — тот, ради которого стоит всё остальное: рампа от зелёного к красному авторится в родном градиент-редакторе, а ViewModel продолжает слать то число, которое у неё уже есть.

## Заметки для ревью

- ⚠️ `Texture2DToSpriteConverter` кэширует, потому что `Sprite.Create` аллоцирует на каждом вызове, а биндер толкает на каждое уведомление — забинденный аватар тёк бы спрайтом в кадр.
- ⚠️ `HashToColorConverter` использует FNV-1a, а не `string.GetHashCode`, рандомизированный на процесс: цвет игрока менялся бы при каждом запуске.
- 📝 `ColorGrayscaleConverter` взвешивает по яркости, а не усредняет каналы, и тест проверяет перцептивное значение, чтобы «упрощение» падало громко.

✅ Локальный прогон: 515 всего, 513 прошло, 0 упало, 2 пропущено.

</details>

