### PR TITLE
feat(starterkit): add rotation, vector and layout converters

### DIFF
--- a/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Unity/Runtime/Converters/Layouts.meta
+++ b/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Unity/Runtime/Converters/Layouts.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 9dff24975d7284bd091c837fc530ea57
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Unity/Runtime/Converters/Layouts/IntToRectOffsetConverter.cs
+++ b/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Unity/Runtime/Converters/Layouts/IntToRectOffsetConverter.cs
@@ -9,14 +9,9 @@ namespace Aspid.MVVM.StarterKit
     /// Writes one number into the chosen sides of a padding.
     /// </summary>
     /// <remarks>
-    /// A single "UI density" value driving every layout's padding. <c>IConverterRectOffset</c> has
-    /// been declared with no implementation behind it, so the picker on six binders has always been
-    /// empty.
-    /// <para>
     /// <see cref="RectOffset"/> is a class, so returning a new one on every push would allocate once
-    /// per notification. One instance is kept and rewritten instead — which is safe here because
-    /// layout reads the values immediately, but means the result must not be held onto.
-    /// </para>
+    /// per notification. One instance is kept and rewritten instead — safe because layout reads the
+    /// values immediately, but the result must not be held onto.
     /// </remarks>
     [Serializable]
     public sealed class IntToRectOffsetConverter : IConverter<int, RectOffset>

--- a/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Unity/Runtime/Converters/Layouts/IntToRectOffsetConverter.cs
+++ b/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Unity/Runtime/Converters/Layouts/IntToRectOffsetConverter.cs
@@ -24,14 +24,9 @@ namespace Aspid.MVVM.StarterKit
 
         [NonSerialized] private RectOffset? _result;
 
-        /// <summary>
-        /// Initializes a new instance of the <see cref="IntToRectOffsetConverter"/> class writing every side.
-        /// </summary>
+        /// <remarks>Default: writing every side.</remarks>
         public IntToRectOffsetConverter() { }
 
-        /// <summary>
-        /// Initializes a new instance of the <see cref="IntToRectOffsetConverter"/> class.
-        /// </summary>
         /// <param name="sides">Which sides the number is written into.</param>
         public IntToRectOffsetConverter(RectSides sides)
         {

--- a/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Unity/Runtime/Converters/Layouts/IntToRectOffsetConverter.cs
+++ b/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Unity/Runtime/Converters/Layouts/IntToRectOffsetConverter.cs
@@ -1,0 +1,67 @@
+#nullable enable
+using System;
+using UnityEngine;
+
+// ReSharper disable once CheckNamespace
+namespace Aspid.MVVM.StarterKit
+{
+    /// <summary>
+    /// Writes one number into the chosen sides of a padding.
+    /// </summary>
+    /// <remarks>
+    /// A single "UI density" value driving every layout's padding. <c>IConverterRectOffset</c> has
+    /// been declared with no implementation behind it, so the picker on six binders has always been
+    /// empty.
+    /// <para>
+    /// <see cref="RectOffset"/> is a class, so returning a new one on every push would allocate once
+    /// per notification. One instance is kept and rewritten instead — which is safe here because
+    /// layout reads the values immediately, but means the result must not be held onto.
+    /// </para>
+    /// </remarks>
+    [Serializable]
+    public sealed class IntToRectOffsetConverter : IConverter<int, RectOffset>
+    {
+        [Tooltip("Which sides the number is written into.")]
+        [SerializeField] private RectSides _sides = RectSides.All;
+
+        [Tooltip("The values used for the sides the number does not write.")]
+        [SerializeField] private RectOffset _base = new();
+
+        [NonSerialized] private RectOffset? _result;
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="IntToRectOffsetConverter"/> class writing every side.
+        /// </summary>
+        public IntToRectOffsetConverter() { }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="IntToRectOffsetConverter"/> class.
+        /// </summary>
+        /// <param name="sides">Which sides the number is written into.</param>
+        public IntToRectOffsetConverter(RectSides sides)
+        {
+            _sides = sides;
+        }
+
+        /// <summary>
+        /// Writes the specified number into the chosen sides.
+        /// </summary>
+        /// <param name="value">The number to write.</param>
+        /// <returns>
+        /// The padding. The same instance is returned every call, so copy it if it must outlive the
+        /// next push.
+        /// </returns>
+        public RectOffset Convert(int value)
+        {
+            _result ??= new RectOffset();
+            var fallback = _base ?? new RectOffset();
+
+            _result.left = _sides.HasFlag(RectSides.Left) ? value : fallback.left;
+            _result.right = _sides.HasFlag(RectSides.Right) ? value : fallback.right;
+            _result.top = _sides.HasFlag(RectSides.Top) ? value : fallback.top;
+            _result.bottom = _sides.HasFlag(RectSides.Bottom) ? value : fallback.bottom;
+
+            return _result;
+        }
+    }
+}

--- a/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Unity/Runtime/Converters/Layouts/IntToRectOffsetConverter.cs.meta
+++ b/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Unity/Runtime/Converters/Layouts/IntToRectOffsetConverter.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 3d96b45fa0f494cae3cc187d1edc6a30

--- a/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Unity/Runtime/Converters/Layouts/RectOffsetScaleConverter.cs
+++ b/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Unity/Runtime/Converters/Layouts/RectOffsetScaleConverter.cs
@@ -1,0 +1,80 @@
+#nullable enable
+using System;
+using UnityEngine;
+
+// ReSharper disable once CheckNamespace
+namespace Aspid.MVVM.StarterKit
+{
+    /// <summary>
+    /// Scales a padding.
+    /// </summary>
+    /// <remarks>DPI or safe-area scaling applied to an authored padding.</remarks>
+    [Serializable]
+    public sealed class RectOffsetScaleConverter : IConverterRectOffset
+    {
+        [Tooltip("What the padding is multiplied by.")]
+        [SerializeField] private float _scale = 1f;
+
+        [Tooltip("Which sides are scaled.")]
+        [SerializeField] private RectSides _sides = RectSides.All;
+
+        [Tooltip("Which way to drop the fraction.")]
+        [SerializeField] private RoundMode _rounding;
+
+        [NonSerialized] private RectOffset? _result;
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="RectOffsetScaleConverter"/> class that changes nothing.
+        /// </summary>
+        public RectOffsetScaleConverter() { }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="RectOffsetScaleConverter"/> class.
+        /// </summary>
+        /// <param name="scale">What the padding is multiplied by.</param>
+        /// <param name="sides">Which sides are scaled.</param>
+        public RectOffsetScaleConverter(float scale, RectSides sides = RectSides.All)
+        {
+            _scale = scale;
+            _sides = sides;
+        }
+
+        /// <summary>
+        /// Scales the specified padding.
+        /// </summary>
+        /// <param name="value">The padding to scale.</param>
+        /// <returns>
+        /// The scaled padding. The same instance is returned every call, so copy it if it must
+        /// outlive the next push.
+        /// </returns>
+        public RectOffset Convert(RectOffset value)
+        {
+            _result ??= new RectOffset();
+            var source = value ?? new RectOffset();
+
+            _result.left = Scale(source.left, RectSides.Left);
+            _result.right = Scale(source.right, RectSides.Right);
+            _result.top = Scale(source.top, RectSides.Top);
+            _result.bottom = Scale(source.bottom, RectSides.Bottom);
+
+            return _result;
+        }
+
+        /// <exception cref="ArgumentOutOfRangeException">Thrown when the rounding is not a declared value.</exception>
+        private int Scale(int value, RectSides side)
+        {
+            if (!_sides.HasFlag(side)) return value;
+
+            var scaled = value * _scale;
+
+            return _rounding switch
+            {
+                RoundMode.Round => Mathf.RoundToInt(scaled),
+                RoundMode.Floor => Mathf.FloorToInt(scaled),
+                RoundMode.Ceil => Mathf.CeilToInt(scaled),
+                RoundMode.Truncate => (int)scaled,
+                _ => throw new ArgumentOutOfRangeException(nameof(_rounding), _rounding, null)
+            };
+        }
+    }
+}

--- a/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Unity/Runtime/Converters/Layouts/RectOffsetScaleConverter.cs
+++ b/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Unity/Runtime/Converters/Layouts/RectOffsetScaleConverter.cs
@@ -23,14 +23,8 @@ namespace Aspid.MVVM.StarterKit
 
         [NonSerialized] private RectOffset? _result;
 
-        /// <summary>
-        /// Initializes a new instance of the <see cref="RectOffsetScaleConverter"/> class that changes nothing.
-        /// </summary>
         public RectOffsetScaleConverter() { }
 
-        /// <summary>
-        /// Initializes a new instance of the <see cref="RectOffsetScaleConverter"/> class.
-        /// </summary>
         /// <param name="scale">What the padding is multiplied by.</param>
         /// <param name="sides">Which sides are scaled.</param>
         public RectOffsetScaleConverter(float scale, RectSides sides = RectSides.All)

--- a/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Unity/Runtime/Converters/Layouts/RectOffsetScaleConverter.cs.meta
+++ b/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Unity/Runtime/Converters/Layouts/RectOffsetScaleConverter.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: d7611a4d399094e168a67b864bb06dfb

--- a/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Unity/Runtime/Converters/Layouts/RectSides.cs
+++ b/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Unity/Runtime/Converters/Layouts/RectSides.cs
@@ -1,0 +1,54 @@
+#nullable enable
+using System;
+using UnityEngine;
+
+// ReSharper disable once CheckNamespace
+namespace Aspid.MVVM.StarterKit
+{
+    /// <summary>
+    /// Which sides of a <see cref="RectOffset"/> a converter writes.
+    /// </summary>
+    [Flags]
+    public enum RectSides
+    {
+        /// <summary>
+        /// No side.
+        /// </summary>
+        None = 0,
+
+        /// <summary>
+        /// The left side.
+        /// </summary>
+        Left = 1,
+
+        /// <summary>
+        /// The right side.
+        /// </summary>
+        Right = 2,
+
+        /// <summary>
+        /// The top side.
+        /// </summary>
+        Top = 4,
+
+        /// <summary>
+        /// The bottom side.
+        /// </summary>
+        Bottom = 8,
+
+        /// <summary>
+        /// Left and right.
+        /// </summary>
+        Horizontal = Left | Right,
+
+        /// <summary>
+        /// Top and bottom.
+        /// </summary>
+        Vertical = Top | Bottom,
+
+        /// <summary>
+        /// Every side.
+        /// </summary>
+        All = Left | Right | Top | Bottom,
+    }
+}

--- a/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Unity/Runtime/Converters/Layouts/RectSides.cs.meta
+++ b/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Unity/Runtime/Converters/Layouts/RectSides.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 86f50a3e9b17e8e76dab36a5f7cc7374

--- a/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Unity/Runtime/Converters/Layouts/Vector4ToRectOffsetConverter.cs
+++ b/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Unity/Runtime/Converters/Layouts/Vector4ToRectOffsetConverter.cs
@@ -1,0 +1,67 @@
+#nullable enable
+using System;
+using UnityEngine;
+
+// ReSharper disable once CheckNamespace
+namespace Aspid.MVVM.StarterKit
+{
+    /// <summary>
+    /// Turns the four numbers of a <see cref="Vector4"/> into a padding.
+    /// </summary>
+    /// <remarks>
+    /// Lets the ViewModel keep a struct rather than a <see cref="RectOffset"/>, which is a class and
+    /// would have to be allocated on its side.
+    /// </remarks>
+    [Serializable]
+    public sealed class Vector4ToRectOffsetConverter : IConverter<Vector4, RectOffset>
+    {
+        [Tooltip("Which way to drop the fraction.")]
+        [SerializeField] private RoundMode _rounding;
+
+        [NonSerialized] private RectOffset? _result;
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="Vector4ToRectOffsetConverter"/> class rounding to nearest.
+        /// </summary>
+        public Vector4ToRectOffsetConverter() { }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="Vector4ToRectOffsetConverter"/> class.
+        /// </summary>
+        /// <param name="rounding">Which way to drop the fraction.</param>
+        public Vector4ToRectOffsetConverter(RoundMode rounding)
+        {
+            _rounding = rounding;
+        }
+
+        /// <summary>
+        /// Turns the specified vector into a padding, reading x, y, z and w as left, right, top and bottom.
+        /// </summary>
+        /// <param name="value">The vector to convert.</param>
+        /// <returns>
+        /// The padding. The same instance is returned every call, so copy it if it must outlive the
+        /// next push.
+        /// </returns>
+        public RectOffset Convert(Vector4 value)
+        {
+            _result ??= new RectOffset();
+
+            _result.left = Round(value.x);
+            _result.right = Round(value.y);
+            _result.top = Round(value.z);
+            _result.bottom = Round(value.w);
+
+            return _result;
+        }
+
+        /// <exception cref="ArgumentOutOfRangeException">Thrown when the rounding is not a declared value.</exception>
+        private int Round(float value) => _rounding switch
+        {
+            RoundMode.Round => Mathf.RoundToInt(value),
+            RoundMode.Floor => Mathf.FloorToInt(value),
+            RoundMode.Ceil => Mathf.CeilToInt(value),
+            RoundMode.Truncate => (int)value,
+            _ => throw new ArgumentOutOfRangeException(nameof(_rounding), _rounding, null)
+        };
+    }
+}

--- a/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Unity/Runtime/Converters/Layouts/Vector4ToRectOffsetConverter.cs
+++ b/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Unity/Runtime/Converters/Layouts/Vector4ToRectOffsetConverter.cs
@@ -20,14 +20,9 @@ namespace Aspid.MVVM.StarterKit
 
         [NonSerialized] private RectOffset? _result;
 
-        /// <summary>
-        /// Initializes a new instance of the <see cref="Vector4ToRectOffsetConverter"/> class rounding to nearest.
-        /// </summary>
+        /// <remarks>Default: rounding to nearest.</remarks>
         public Vector4ToRectOffsetConverter() { }
 
-        /// <summary>
-        /// Initializes a new instance of the <see cref="Vector4ToRectOffsetConverter"/> class.
-        /// </summary>
         /// <param name="rounding">Which way to drop the fraction.</param>
         public Vector4ToRectOffsetConverter(RoundMode rounding)
         {

--- a/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Unity/Runtime/Converters/Layouts/Vector4ToRectOffsetConverter.cs.meta
+++ b/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Unity/Runtime/Converters/Layouts/Vector4ToRectOffsetConverter.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: a8d18b8d93b561bbe5a872bdf810aa75

--- a/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Unity/Runtime/Converters/Rotations.meta
+++ b/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Unity/Runtime/Converters/Rotations.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 53deb65fc88f344aaaa68d0aeb07fe59
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Unity/Runtime/Converters/Rotations/AngleRange.cs
+++ b/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Unity/Runtime/Converters/Rotations/AngleRange.cs
@@ -1,0 +1,21 @@
+#nullable enable
+
+// ReSharper disable once CheckNamespace
+namespace Aspid.MVVM.StarterKit
+{
+    /// <summary>
+    /// The range <see cref="AngleWrapConverter"/> reports angles in.
+    /// </summary>
+    public enum AngleRange
+    {
+        /// <summary>
+        /// 0 to 360.
+        /// </summary>
+        Zero360,
+
+        /// <summary>
+        /// -180 to 180.
+        /// </summary>
+        Signed180,
+    }
+}

--- a/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Unity/Runtime/Converters/Rotations/AngleRange.cs.meta
+++ b/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Unity/Runtime/Converters/Rotations/AngleRange.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 9013c3113b402a1c8494a9656f647781

--- a/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Unity/Runtime/Converters/Rotations/AngleToDirectionConverter.cs
+++ b/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Unity/Runtime/Converters/Rotations/AngleToDirectionConverter.cs
@@ -18,14 +18,9 @@ namespace Aspid.MVVM.StarterKit
         [Tooltip("How long the produced direction is.")]
         [SerializeField] private float _magnitude = 1f;
 
-        /// <summary>
-        /// Initializes a new instance of the <see cref="AngleToDirectionConverter"/> class producing a unit vector.
-        /// </summary>
+        /// <remarks>Default: producing a unit vector.</remarks>
         public AngleToDirectionConverter() { }
 
-        /// <summary>
-        /// Initializes a new instance of the <see cref="AngleToDirectionConverter"/> class.
-        /// </summary>
         /// <param name="magnitude">How long the produced direction is.</param>
         public AngleToDirectionConverter(float magnitude)
         {

--- a/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Unity/Runtime/Converters/Rotations/AngleToDirectionConverter.cs
+++ b/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Unity/Runtime/Converters/Rotations/AngleToDirectionConverter.cs
@@ -1,0 +1,46 @@
+#nullable enable
+using System;
+using UnityEngine;
+
+// ReSharper disable once CheckNamespace
+namespace Aspid.MVVM.StarterKit
+{
+    /// <summary>
+    /// Turns an angle into a direction.
+    /// </summary>
+    /// <remarks>Placing a marker on a radial HUD.</remarks>
+    [Serializable]
+    public sealed class AngleToDirectionConverter : IConverter<float, Vector2>
+    {
+        [Tooltip("The angle is in degrees rather than radians.")]
+        [SerializeField] private bool _degrees = true;
+
+        [Tooltip("How long the produced direction is.")]
+        [SerializeField] private float _magnitude = 1f;
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="AngleToDirectionConverter"/> class producing a unit vector.
+        /// </summary>
+        public AngleToDirectionConverter() { }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="AngleToDirectionConverter"/> class.
+        /// </summary>
+        /// <param name="magnitude">How long the produced direction is.</param>
+        public AngleToDirectionConverter(float magnitude)
+        {
+            _magnitude = magnitude;
+        }
+
+        /// <summary>
+        /// Turns the specified angle into a direction.
+        /// </summary>
+        /// <param name="value">The angle.</param>
+        /// <returns>The direction.</returns>
+        public Vector2 Convert(float value)
+        {
+            var radians = _degrees ? value * Mathf.Deg2Rad : value;
+            return new Vector2(Mathf.Cos(radians), Mathf.Sin(radians)) * _magnitude;
+        }
+    }
+}

--- a/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Unity/Runtime/Converters/Rotations/AngleToDirectionConverter.cs.meta
+++ b/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Unity/Runtime/Converters/Rotations/AngleToDirectionConverter.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 8d0a4a8e8f5d938beacc699002385770

--- a/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Unity/Runtime/Converters/Rotations/AngleToQuaternionConverter.cs
+++ b/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Unity/Runtime/Converters/Rotations/AngleToQuaternionConverter.cs
@@ -24,14 +24,9 @@ namespace Aspid.MVVM.StarterKit
         [Tooltip("Turn the other way.")]
         [SerializeField] private bool _clockwise;
 
-        /// <summary>
-        /// Initializes a new instance of the <see cref="AngleToQuaternionConverter"/> class turning around Z.
-        /// </summary>
+        /// <remarks>Default: turning around Z.</remarks>
         public AngleToQuaternionConverter() { }
 
-        /// <summary>
-        /// Initializes a new instance of the <see cref="AngleToQuaternionConverter"/> class.
-        /// </summary>
         /// <param name="axis">The axis the angle turns around.</param>
         /// <param name="offset">Added to the angle before it is applied.</param>
         /// <param name="clockwise">If <see langword="true"/>, turns the other way.</param>

--- a/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Unity/Runtime/Converters/Rotations/AngleToQuaternionConverter.cs
+++ b/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Unity/Runtime/Converters/Rotations/AngleToQuaternionConverter.cs
@@ -1,0 +1,85 @@
+#nullable enable
+using System;
+using UnityEngine;
+
+// ReSharper disable once CheckNamespace
+namespace Aspid.MVVM.StarterKit
+{
+    /// <summary>
+    /// Turns a single angle into a rotation.
+    /// </summary>
+    /// <remarks>
+    /// Compass needles, dials, gauge hands, radar sweeps: one number from the ViewModel, a rotation
+    /// on the View. Until now <c>IConverterQuaternion</c> had no implementation at all.
+    /// </remarks>
+    [Serializable]
+    public sealed class AngleToQuaternionConverter : ITwoWayConverter<float, Quaternion>
+    {
+        [Tooltip("The axis the angle turns around. Z is the one a 2D UI element spins on.")]
+        [SerializeField] private RotationAxis _axis = RotationAxis.Z;
+
+        [Tooltip("Added to the angle before it is applied.")]
+        [SerializeField] private float _offset;
+
+        [Tooltip("Turn the other way.")]
+        [SerializeField] private bool _clockwise;
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="AngleToQuaternionConverter"/> class turning around Z.
+        /// </summary>
+        public AngleToQuaternionConverter() { }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="AngleToQuaternionConverter"/> class.
+        /// </summary>
+        /// <param name="axis">The axis the angle turns around.</param>
+        /// <param name="offset">Added to the angle before it is applied.</param>
+        /// <param name="clockwise">If <see langword="true"/>, turns the other way.</param>
+        public AngleToQuaternionConverter(RotationAxis axis, float offset = 0f, bool clockwise = false)
+        {
+            _axis = axis;
+            _offset = offset;
+            _clockwise = clockwise;
+        }
+
+        /// <summary>
+        /// Turns the specified angle into a rotation.
+        /// </summary>
+        /// <param name="value">The angle, in degrees.</param>
+        /// <returns>The rotation.</returns>
+        /// <exception cref="ArgumentOutOfRangeException">Thrown when the axis is not a declared value.</exception>
+        public Quaternion Convert(float value)
+        {
+            var angle = (_clockwise ? -value : value) + _offset;
+
+            return _axis switch
+            {
+                RotationAxis.X => Quaternion.Euler(angle, 0f, 0f),
+                RotationAxis.Y => Quaternion.Euler(0f, angle, 0f),
+                RotationAxis.Z => Quaternion.Euler(0f, 0f, angle),
+                _ => throw new ArgumentOutOfRangeException(nameof(_axis), _axis, null)
+            };
+        }
+
+        /// <summary>
+        /// Reads the angle back off a rotation.
+        /// </summary>
+        /// <param name="value">The rotation to read.</param>
+        /// <returns>The angle, in degrees.</returns>
+        public float ConvertBack(Quaternion value)
+        {
+            var euler = value.eulerAngles;
+
+            var angle = _axis switch
+            {
+                RotationAxis.X => euler.x,
+                RotationAxis.Y => euler.y,
+                RotationAxis.Z => euler.z,
+                _ => throw new ArgumentOutOfRangeException(nameof(_axis), _axis, null)
+            };
+
+            angle -= _offset;
+            return _clockwise ? -angle : angle;
+        }
+    }
+}

--- a/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Unity/Runtime/Converters/Rotations/AngleToQuaternionConverter.cs.meta
+++ b/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Unity/Runtime/Converters/Rotations/AngleToQuaternionConverter.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 2cc478c11b0704a508d2e4146bbecb9b

--- a/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Unity/Runtime/Converters/Rotations/AngleWrapConverter.cs
+++ b/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Unity/Runtime/Converters/Rotations/AngleWrapConverter.cs
@@ -1,0 +1,58 @@
+#nullable enable
+using System;
+using UnityEngine;
+
+// ReSharper disable once CheckNamespace
+namespace Aspid.MVVM.StarterKit
+{
+    /// <summary>
+    /// Folds an angle into a standard range.
+    /// </summary>
+    /// <remarks>
+    /// Removes the 359°-to-1° discontinuity that makes an angle look like it jumped most of the way
+    /// round when it moved two degrees.
+    /// </remarks>
+    [Serializable]
+    public sealed class AngleWrapConverter : IConverterFloat
+    {
+        [Tooltip("Which range to report in.")]
+        [SerializeField] private AngleRange _range = AngleRange.Zero360;
+
+        [Tooltip("Added before wrapping.")]
+        [SerializeField] private float _offset;
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="AngleWrapConverter"/> class reporting 0..360.
+        /// </summary>
+        public AngleWrapConverter() { }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="AngleWrapConverter"/> class.
+        /// </summary>
+        /// <param name="range">Which range to report in.</param>
+        /// <param name="offset">Added before wrapping.</param>
+        public AngleWrapConverter(AngleRange range, float offset = 0f)
+        {
+            _range = range;
+            _offset = offset;
+        }
+
+        /// <summary>
+        /// Folds the specified angle into the configured range.
+        /// </summary>
+        /// <param name="value">The angle, in degrees.</param>
+        /// <returns>The folded angle.</returns>
+        /// <exception cref="ArgumentOutOfRangeException">Thrown when the range is not a declared value.</exception>
+        public float Convert(float value)
+        {
+            var wrapped = Mathf.Repeat(value + _offset, 360f);
+
+            return _range switch
+            {
+                AngleRange.Zero360 => wrapped,
+                AngleRange.Signed180 => wrapped > 180f ? wrapped - 360f : wrapped,
+                _ => throw new ArgumentOutOfRangeException(nameof(_range), _range, null)
+            };
+        }
+    }
+}

--- a/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Unity/Runtime/Converters/Rotations/AngleWrapConverter.cs
+++ b/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Unity/Runtime/Converters/Rotations/AngleWrapConverter.cs
@@ -21,14 +21,9 @@ namespace Aspid.MVVM.StarterKit
         [Tooltip("Added before wrapping.")]
         [SerializeField] private float _offset;
 
-        /// <summary>
-        /// Initializes a new instance of the <see cref="AngleWrapConverter"/> class reporting 0..360.
-        /// </summary>
+        /// <remarks>Default: reporting 0..360.</remarks>
         public AngleWrapConverter() { }
 
-        /// <summary>
-        /// Initializes a new instance of the <see cref="AngleWrapConverter"/> class.
-        /// </summary>
         /// <param name="range">Which range to report in.</param>
         /// <param name="offset">Added before wrapping.</param>
         public AngleWrapConverter(AngleRange range, float offset = 0f)

--- a/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Unity/Runtime/Converters/Rotations/AngleWrapConverter.cs.meta
+++ b/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Unity/Runtime/Converters/Rotations/AngleWrapConverter.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: ed22da18246b5bc16d79dc8d1cdd689f

--- a/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Unity/Runtime/Converters/Rotations/DegreesToRadiansConverter.cs
+++ b/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Unity/Runtime/Converters/Rotations/DegreesToRadiansConverter.cs
@@ -1,0 +1,29 @@
+#nullable enable
+using System;
+using UnityEngine;
+
+// ReSharper disable once CheckNamespace
+namespace Aspid.MVVM.StarterKit
+{
+    /// <summary>
+    /// Converts between degrees and radians.
+    /// </summary>
+    /// <remarks>Physics and backend data usually speak radians; Unity's Inspector speaks degrees.</remarks>
+    [Serializable]
+    public sealed class DegreesToRadiansConverter : ITwoWayConverter<float, float>
+    {
+        /// <summary>
+        /// Converts the specified angle to radians.
+        /// </summary>
+        /// <param name="value">The angle, in degrees.</param>
+        /// <returns>The angle, in radians.</returns>
+        public float Convert(float value) => value * Mathf.Deg2Rad;
+
+        /// <summary>
+        /// Converts the specified angle to degrees.
+        /// </summary>
+        /// <param name="value">The angle, in radians.</param>
+        /// <returns>The angle, in degrees.</returns>
+        public float ConvertBack(float value) => value * Mathf.Rad2Deg;
+    }
+}

--- a/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Unity/Runtime/Converters/Rotations/DegreesToRadiansConverter.cs.meta
+++ b/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Unity/Runtime/Converters/Rotations/DegreesToRadiansConverter.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: faac51bf64f5254f682f9c2942afd8f7

--- a/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Unity/Runtime/Converters/Rotations/DirectionToAngleConverter.cs
+++ b/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Unity/Runtime/Converters/Rotations/DirectionToAngleConverter.cs
@@ -1,0 +1,58 @@
+#nullable enable
+using System;
+using UnityEngine;
+
+// ReSharper disable once CheckNamespace
+namespace Aspid.MVVM.StarterKit
+{
+    /// <summary>
+    /// Reads the angle a direction points in.
+    /// </summary>
+    /// <remarks>
+    /// Off-screen enemy indicators, waypoint arrows, minimap markers — everything that has a
+    /// direction and needs a rotation.
+    /// </remarks>
+    [Serializable]
+    public sealed class DirectionToAngleConverter : IConverter<Vector2, float>
+    {
+        [Tooltip("Report the angle in degrees rather than radians.")]
+        [SerializeField] private bool _degrees = true;
+
+        [Tooltip("Added to the angle.")]
+        [SerializeField] private float _offset;
+
+        [Tooltip("Measure clockwise rather than counter-clockwise.")]
+        [SerializeField] private bool _clockwise;
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="DirectionToAngleConverter"/> class reporting degrees.
+        /// </summary>
+        public DirectionToAngleConverter() { }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="DirectionToAngleConverter"/> class.
+        /// </summary>
+        /// <param name="offset">Added to the angle.</param>
+        /// <param name="clockwise">Whether to measure clockwise.</param>
+        public DirectionToAngleConverter(float offset, bool clockwise = false)
+        {
+            _offset = offset;
+            _clockwise = clockwise;
+        }
+
+        /// <summary>
+        /// Reads the angle of the specified direction.
+        /// </summary>
+        /// <param name="value">The direction to read.</param>
+        /// <returns>The angle. A zero-length direction reads as the offset alone.</returns>
+        public float Convert(Vector2 value)
+        {
+            if (value == Vector2.zero) return _offset;
+
+            var radians = Mathf.Atan2(value.y, value.x);
+            var angle = _degrees ? radians * Mathf.Rad2Deg : radians;
+
+            return (_clockwise ? -angle : angle) + _offset;
+        }
+    }
+}

--- a/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Unity/Runtime/Converters/Rotations/DirectionToAngleConverter.cs
+++ b/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Unity/Runtime/Converters/Rotations/DirectionToAngleConverter.cs
@@ -24,14 +24,9 @@ namespace Aspid.MVVM.StarterKit
         [Tooltip("Measure clockwise rather than counter-clockwise.")]
         [SerializeField] private bool _clockwise;
 
-        /// <summary>
-        /// Initializes a new instance of the <see cref="DirectionToAngleConverter"/> class reporting degrees.
-        /// </summary>
+        /// <remarks>Default: reporting degrees.</remarks>
         public DirectionToAngleConverter() { }
 
-        /// <summary>
-        /// Initializes a new instance of the <see cref="DirectionToAngleConverter"/> class.
-        /// </summary>
         /// <param name="offset">Added to the angle.</param>
         /// <param name="clockwise">Whether to measure clockwise.</param>
         public DirectionToAngleConverter(float offset, bool clockwise = false)

--- a/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Unity/Runtime/Converters/Rotations/DirectionToAngleConverter.cs.meta
+++ b/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Unity/Runtime/Converters/Rotations/DirectionToAngleConverter.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 5da2b7ccbdf98cb278358e90ec253614

--- a/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Unity/Runtime/Converters/Rotations/EulerToQuaternionConverter.cs
+++ b/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Unity/Runtime/Converters/Rotations/EulerToQuaternionConverter.cs
@@ -1,0 +1,32 @@
+#nullable enable
+using System;
+using UnityEngine;
+
+// ReSharper disable once CheckNamespace
+namespace Aspid.MVVM.StarterKit
+{
+    /// <summary>
+    /// Turns Euler angles into a rotation.
+    /// </summary>
+    /// <remarks>
+    /// A ViewModel naturally stores angles; a binder wants a <see cref="Quaternion"/>. Both
+    /// directions are here because the pair round-trips within the ±180 convention.
+    /// </remarks>
+    [Serializable]
+    public sealed class EulerToQuaternionConverter : ITwoWayConverter<Vector3, Quaternion>
+    {
+        /// <summary>
+        /// Turns the specified angles into a rotation.
+        /// </summary>
+        /// <param name="value">The Euler angles, in degrees.</param>
+        /// <returns>The rotation.</returns>
+        public Quaternion Convert(Vector3 value) => Quaternion.Euler(value);
+
+        /// <summary>
+        /// Reads Euler angles off a rotation.
+        /// </summary>
+        /// <param name="value">The rotation to read.</param>
+        /// <returns>The angles, in degrees.</returns>
+        public Vector3 ConvertBack(Quaternion value) => value.eulerAngles;
+    }
+}

--- a/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Unity/Runtime/Converters/Rotations/EulerToQuaternionConverter.cs.meta
+++ b/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Unity/Runtime/Converters/Rotations/EulerToQuaternionConverter.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 386807b213c43cdd7e742bb299503bc0

--- a/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Unity/Runtime/Converters/Rotations/LookRotationConverter.cs
+++ b/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Unity/Runtime/Converters/Rotations/LookRotationConverter.cs
@@ -1,0 +1,52 @@
+#nullable enable
+using System;
+using UnityEngine;
+
+// ReSharper disable once CheckNamespace
+namespace Aspid.MVVM.StarterKit
+{
+    /// <summary>
+    /// Builds a rotation that looks along a direction.
+    /// </summary>
+    [Serializable]
+    public sealed class LookRotationConverter : IConverter<Vector3, Quaternion>
+    {
+        [Tooltip("Which way is up for the produced rotation.")]
+        [SerializeField] private Vector3 _up = Vector3.up;
+
+        [Tooltip("Drop the vertical component before looking, keeping the rotation level.")]
+        [SerializeField] private bool _flatten;
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="LookRotationConverter"/> class with world up.
+        /// </summary>
+        public LookRotationConverter() { }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="LookRotationConverter"/> class.
+        /// </summary>
+        /// <param name="up">Which way is up for the produced rotation.</param>
+        /// <param name="flatten">Whether to drop the vertical component before looking.</param>
+        public LookRotationConverter(Vector3 up, bool flatten = false)
+        {
+            _up = up;
+            _flatten = flatten;
+        }
+
+        /// <summary>
+        /// Builds a rotation looking along the specified direction.
+        /// </summary>
+        /// <param name="value">The direction to look along.</param>
+        /// <returns>The rotation, or the identity for a zero-length direction.</returns>
+        public Quaternion Convert(Vector3 value)
+        {
+            var direction = _flatten ? new Vector3(value.x, 0f, value.z) : value;
+
+            // LookRotation warns and returns identity on a zero vector; checking first keeps the
+            // console clean when a target has not been picked yet.
+            return direction.sqrMagnitude <= Mathf.Epsilon
+                ? Quaternion.identity
+                : Quaternion.LookRotation(direction, _up);
+        }
+    }
+}

--- a/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Unity/Runtime/Converters/Rotations/LookRotationConverter.cs
+++ b/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Unity/Runtime/Converters/Rotations/LookRotationConverter.cs
@@ -17,14 +17,9 @@ namespace Aspid.MVVM.StarterKit
         [Tooltip("Drop the vertical component before looking, keeping the rotation level.")]
         [SerializeField] private bool _flatten;
 
-        /// <summary>
-        /// Initializes a new instance of the <see cref="LookRotationConverter"/> class with world up.
-        /// </summary>
+        /// <remarks>Default: with world up.</remarks>
         public LookRotationConverter() { }
 
-        /// <summary>
-        /// Initializes a new instance of the <see cref="LookRotationConverter"/> class.
-        /// </summary>
         /// <param name="up">Which way is up for the produced rotation.</param>
         /// <param name="flatten">Whether to drop the vertical component before looking.</param>
         public LookRotationConverter(Vector3 up, bool flatten = false)

--- a/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Unity/Runtime/Converters/Rotations/LookRotationConverter.cs.meta
+++ b/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Unity/Runtime/Converters/Rotations/LookRotationConverter.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: c1c0b8ed07b2278396a1e28d1b376f23

--- a/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Unity/Runtime/Converters/Rotations/QuaternionOffsetConverter.cs
+++ b/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Unity/Runtime/Converters/Rotations/QuaternionOffsetConverter.cs
@@ -21,14 +21,8 @@ namespace Aspid.MVVM.StarterKit
         [Tooltip("Apply the offset before the bound rotation rather than after.")]
         [SerializeField] private bool _applyFirst;
 
-        /// <summary>
-        /// Initializes a new instance of the <see cref="QuaternionOffsetConverter"/> class with no offset.
-        /// </summary>
         public QuaternionOffsetConverter() { }
 
-        /// <summary>
-        /// Initializes a new instance of the <see cref="QuaternionOffsetConverter"/> class.
-        /// </summary>
         /// <param name="offsetEuler">The rotation applied on top of the bound one, in Euler degrees.</param>
         /// <param name="applyFirst">Whether to apply the offset before the bound rotation.</param>
         public QuaternionOffsetConverter(Vector3 offsetEuler, bool applyFirst = false)

--- a/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Unity/Runtime/Converters/Rotations/QuaternionOffsetConverter.cs
+++ b/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Unity/Runtime/Converters/Rotations/QuaternionOffsetConverter.cs
@@ -1,0 +1,62 @@
+#nullable enable
+using System;
+using UnityEngine;
+
+// ReSharper disable once CheckNamespace
+namespace Aspid.MVVM.StarterKit
+{
+    /// <summary>
+    /// Applies a fixed rotation on top of a bound one.
+    /// </summary>
+    /// <remarks>
+    /// Correcting for a model that was authored facing the wrong way, without the ViewModel knowing
+    /// which way the art faces.
+    /// </remarks>
+    [Serializable]
+    public sealed class QuaternionOffsetConverter : ITwoWayConverter<Quaternion, Quaternion>
+    {
+        [Tooltip("The rotation applied on top of the bound one, in Euler degrees.")]
+        [SerializeField] private Vector3 _offsetEuler;
+
+        [Tooltip("Apply the offset before the bound rotation rather than after.")]
+        [SerializeField] private bool _applyFirst;
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="QuaternionOffsetConverter"/> class with no offset.
+        /// </summary>
+        public QuaternionOffsetConverter() { }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="QuaternionOffsetConverter"/> class.
+        /// </summary>
+        /// <param name="offsetEuler">The rotation applied on top of the bound one, in Euler degrees.</param>
+        /// <param name="applyFirst">Whether to apply the offset before the bound rotation.</param>
+        public QuaternionOffsetConverter(Vector3 offsetEuler, bool applyFirst = false)
+        {
+            _offsetEuler = offsetEuler;
+            _applyFirst = applyFirst;
+        }
+
+        /// <summary>
+        /// Applies the offset to the specified rotation.
+        /// </summary>
+        /// <param name="value">The rotation to adjust.</param>
+        /// <returns>The adjusted rotation.</returns>
+        public Quaternion Convert(Quaternion value)
+        {
+            var offset = Quaternion.Euler(_offsetEuler);
+            return _applyFirst ? offset * value : value * offset;
+        }
+
+        /// <summary>
+        /// Removes the offset from the specified rotation.
+        /// </summary>
+        /// <param name="value">The rotation to adjust.</param>
+        /// <returns>The rotation without the offset.</returns>
+        public Quaternion ConvertBack(Quaternion value)
+        {
+            var inverse = Quaternion.Inverse(Quaternion.Euler(_offsetEuler));
+            return _applyFirst ? inverse * value : value * inverse;
+        }
+    }
+}

--- a/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Unity/Runtime/Converters/Rotations/QuaternionOffsetConverter.cs.meta
+++ b/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Unity/Runtime/Converters/Rotations/QuaternionOffsetConverter.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 428c0fef89a7159f17dafb794ea42e53

--- a/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Unity/Runtime/Converters/Rotations/QuaternionToEulerConverter.cs
+++ b/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Unity/Runtime/Converters/Rotations/QuaternionToEulerConverter.cs
@@ -19,14 +19,9 @@ namespace Aspid.MVVM.StarterKit
         [Tooltip("Report angles as -180..180 rather than Unity's 0..360.")]
         [SerializeField] private bool _normalizeToSigned180 = true;
 
-        /// <summary>
-        /// Initializes a new instance of the <see cref="QuaternionToEulerConverter"/> class normalising to ±180.
-        /// </summary>
+        /// <remarks>Default: normalising to ±180.</remarks>
         public QuaternionToEulerConverter() { }
 
-        /// <summary>
-        /// Initializes a new instance of the <see cref="QuaternionToEulerConverter"/> class.
-        /// </summary>
         /// <param name="normalizeToSigned180">Whether to report angles as -180..180.</param>
         public QuaternionToEulerConverter(bool normalizeToSigned180)
         {

--- a/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Unity/Runtime/Converters/Rotations/QuaternionToEulerConverter.cs
+++ b/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Unity/Runtime/Converters/Rotations/QuaternionToEulerConverter.cs
@@ -1,0 +1,51 @@
+#nullable enable
+using System;
+using UnityEngine;
+
+// ReSharper disable once CheckNamespace
+namespace Aspid.MVVM.StarterKit
+{
+    /// <summary>
+    /// Reads Euler angles off a rotation.
+    /// </summary>
+    /// <remarks>
+    /// Unity reports Euler angles in 0..360, so a needle a little past zero reads as 359 rather than
+    /// -1 — which makes a "rotation below zero" test fail exactly when it matters. Normalising to
+    /// ±180 is the option that removes the trap.
+    /// </remarks>
+    [Serializable]
+    public sealed class QuaternionToEulerConverter : IConverter<Quaternion, Vector3>
+    {
+        [Tooltip("Report angles as -180..180 rather than Unity's 0..360.")]
+        [SerializeField] private bool _normalizeToSigned180 = true;
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="QuaternionToEulerConverter"/> class normalising to ±180.
+        /// </summary>
+        public QuaternionToEulerConverter() { }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="QuaternionToEulerConverter"/> class.
+        /// </summary>
+        /// <param name="normalizeToSigned180">Whether to report angles as -180..180.</param>
+        public QuaternionToEulerConverter(bool normalizeToSigned180)
+        {
+            _normalizeToSigned180 = normalizeToSigned180;
+        }
+
+        /// <summary>
+        /// Reads the angles off the specified rotation.
+        /// </summary>
+        /// <param name="value">The rotation to read.</param>
+        /// <returns>The angles, in degrees.</returns>
+        public Vector3 Convert(Quaternion value)
+        {
+            var euler = value.eulerAngles;
+            if (!_normalizeToSigned180) return euler;
+
+            return new Vector3(Signed(euler.x), Signed(euler.y), Signed(euler.z));
+        }
+
+        private static float Signed(float angle) => angle > 180f ? angle - 360f : angle;
+    }
+}

--- a/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Unity/Runtime/Converters/Rotations/QuaternionToEulerConverter.cs.meta
+++ b/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Unity/Runtime/Converters/Rotations/QuaternionToEulerConverter.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: a51753baa5bce9ebf3959a165eb2262a

--- a/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Unity/Runtime/Converters/Rotations/RotationAxis.cs
+++ b/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Unity/Runtime/Converters/Rotations/RotationAxis.cs
@@ -1,0 +1,26 @@
+#nullable enable
+
+// ReSharper disable once CheckNamespace
+namespace Aspid.MVVM.StarterKit
+{
+    /// <summary>
+    /// Which axis a rotation converter turns around.
+    /// </summary>
+    public enum RotationAxis
+    {
+        /// <summary>
+        /// The X axis.
+        /// </summary>
+        X,
+
+        /// <summary>
+        /// The Y axis.
+        /// </summary>
+        Y,
+
+        /// <summary>
+        /// The Z axis — the one a 2D UI element spins on.
+        /// </summary>
+        Z,
+    }
+}

--- a/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Unity/Runtime/Converters/Rotations/RotationAxis.cs.meta
+++ b/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Unity/Runtime/Converters/Rotations/RotationAxis.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 4189e0949a93d14a9003482ad13d6316

--- a/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Unity/Runtime/Converters/Vectors/AxisMask.cs
+++ b/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Unity/Runtime/Converters/Vectors/AxisMask.cs
@@ -1,0 +1,38 @@
+#nullable enable
+using System;
+
+// ReSharper disable once CheckNamespace
+namespace Aspid.MVVM.StarterKit
+{
+    /// <summary>
+    /// Which axes <see cref="FloatToVector3Converter"/> writes a number into.
+    /// </summary>
+    [Flags]
+    public enum AxisMask
+    {
+        /// <summary>
+        /// No axis.
+        /// </summary>
+        None = 0,
+
+        /// <summary>
+        /// The X axis.
+        /// </summary>
+        X = 1,
+
+        /// <summary>
+        /// The Y axis.
+        /// </summary>
+        Y = 2,
+
+        /// <summary>
+        /// The Z axis.
+        /// </summary>
+        Z = 4,
+
+        /// <summary>
+        /// Every axis — a uniform value.
+        /// </summary>
+        All = X | Y | Z,
+    }
+}

--- a/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Unity/Runtime/Converters/Vectors/AxisMask.cs.meta
+++ b/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Unity/Runtime/Converters/Vectors/AxisMask.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: f81654d4c7ebef0f7444ba46624884a5

--- a/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Unity/Runtime/Converters/Vectors/FloatToVector2Converter.cs
+++ b/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Unity/Runtime/Converters/Vectors/FloatToVector2Converter.cs
@@ -1,0 +1,45 @@
+#nullable enable
+using System;
+using UnityEngine;
+
+// ReSharper disable once CheckNamespace
+namespace Aspid.MVVM.StarterKit
+{
+    /// <summary>
+    /// Writes one number into the chosen axes of a 2D vector.
+    /// </summary>
+    [Serializable]
+    public sealed class FloatToVector2Converter : IConverter<float, Vector2>
+    {
+        [Tooltip("Which axes the number is written into.")]
+        [SerializeField] private AxisMask _axes = AxisMask.X | AxisMask.Y;
+
+        [Tooltip("The value used for the axes the number does not write.")]
+        [SerializeField] private Vector2 _base = Vector2.one;
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="FloatToVector2Converter"/> class writing both axes.
+        /// </summary>
+        public FloatToVector2Converter() { }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="FloatToVector2Converter"/> class.
+        /// </summary>
+        /// <param name="axes">Which axes the number is written into.</param>
+        /// <param name="base">The value used for the axes the number does not write.</param>
+        public FloatToVector2Converter(AxisMask axes, Vector2 @base = default)
+        {
+            _axes = axes;
+            _base = @base;
+        }
+
+        /// <summary>
+        /// Writes the specified number into the chosen axes.
+        /// </summary>
+        /// <param name="value">The number to write.</param>
+        /// <returns>The vector.</returns>
+        public Vector2 Convert(float value) => new(
+            _axes.HasFlag(AxisMask.X) ? value : _base.x,
+            _axes.HasFlag(AxisMask.Y) ? value : _base.y);
+    }
+}

--- a/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Unity/Runtime/Converters/Vectors/FloatToVector2Converter.cs
+++ b/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Unity/Runtime/Converters/Vectors/FloatToVector2Converter.cs
@@ -17,14 +17,9 @@ namespace Aspid.MVVM.StarterKit
         [Tooltip("The value used for the axes the number does not write.")]
         [SerializeField] private Vector2 _base = Vector2.one;
 
-        /// <summary>
-        /// Initializes a new instance of the <see cref="FloatToVector2Converter"/> class writing both axes.
-        /// </summary>
+        /// <remarks>Default: writing both axes.</remarks>
         public FloatToVector2Converter() { }
 
-        /// <summary>
-        /// Initializes a new instance of the <see cref="FloatToVector2Converter"/> class.
-        /// </summary>
         /// <param name="axes">Which axes the number is written into.</param>
         /// <param name="base">The value used for the axes the number does not write.</param>
         public FloatToVector2Converter(AxisMask axes, Vector2 @base = default)

--- a/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Unity/Runtime/Converters/Vectors/FloatToVector2Converter.cs.meta
+++ b/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Unity/Runtime/Converters/Vectors/FloatToVector2Converter.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 8565b7039d698b3b03730dcf3b90a466

--- a/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Unity/Runtime/Converters/Vectors/FloatToVector3Converter.cs
+++ b/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Unity/Runtime/Converters/Vectors/FloatToVector3Converter.cs
@@ -21,14 +21,9 @@ namespace Aspid.MVVM.StarterKit
         [Tooltip("The value used for the axes the number does not write.")]
         [SerializeField] private Vector3 _base = Vector3.one;
 
-        /// <summary>
-        /// Initializes a new instance of the <see cref="FloatToVector3Converter"/> class writing every axis.
-        /// </summary>
+        /// <remarks>Default: writing every axis.</remarks>
         public FloatToVector3Converter() { }
 
-        /// <summary>
-        /// Initializes a new instance of the <see cref="FloatToVector3Converter"/> class.
-        /// </summary>
         /// <param name="axes">Which axes the number is written into.</param>
         /// <param name="base">The value used for the axes the number does not write.</param>
         public FloatToVector3Converter(AxisMask axes, Vector3 @base = default)

--- a/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Unity/Runtime/Converters/Vectors/FloatToVector3Converter.cs
+++ b/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Unity/Runtime/Converters/Vectors/FloatToVector3Converter.cs
@@ -1,0 +1,50 @@
+#nullable enable
+using System;
+using UnityEngine;
+
+// ReSharper disable once CheckNamespace
+namespace Aspid.MVVM.StarterKit
+{
+    /// <summary>
+    /// Writes one number into the chosen axes of a vector.
+    /// </summary>
+    /// <remarks>
+    /// Uniform scale from one number, a slider driving only Y, a bar growing along X. The binders
+    /// currently hard-code this fan-out, so the choice of axes is theirs rather than the author's.
+    /// </remarks>
+    [Serializable]
+    public sealed class FloatToVector3Converter : IConverter<float, Vector3>
+    {
+        [Tooltip("Which axes the number is written into.")]
+        [SerializeField] private AxisMask _axes = AxisMask.All;
+
+        [Tooltip("The value used for the axes the number does not write.")]
+        [SerializeField] private Vector3 _base = Vector3.one;
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="FloatToVector3Converter"/> class writing every axis.
+        /// </summary>
+        public FloatToVector3Converter() { }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="FloatToVector3Converter"/> class.
+        /// </summary>
+        /// <param name="axes">Which axes the number is written into.</param>
+        /// <param name="base">The value used for the axes the number does not write.</param>
+        public FloatToVector3Converter(AxisMask axes, Vector3 @base = default)
+        {
+            _axes = axes;
+            _base = @base;
+        }
+
+        /// <summary>
+        /// Writes the specified number into the chosen axes.
+        /// </summary>
+        /// <param name="value">The number to write.</param>
+        /// <returns>The vector.</returns>
+        public Vector3 Convert(float value) => new(
+            _axes.HasFlag(AxisMask.X) ? value : _base.x,
+            _axes.HasFlag(AxisMask.Y) ? value : _base.y,
+            _axes.HasFlag(AxisMask.Z) ? value : _base.z);
+    }
+}

--- a/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Unity/Runtime/Converters/Vectors/FloatToVector3Converter.cs.meta
+++ b/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Unity/Runtime/Converters/Vectors/FloatToVector3Converter.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 2ed7102789da923e04d8914bed9fab37

--- a/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Unity/Runtime/Converters/Vectors/Vector2ToVector2IntConverter.cs
+++ b/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Unity/Runtime/Converters/Vectors/Vector2ToVector2IntConverter.cs
@@ -14,14 +14,9 @@ namespace Aspid.MVVM.StarterKit
         [Tooltip("Which way to drop the fraction.")]
         [SerializeField] private RoundMode _mode;
 
-        /// <summary>
-        /// Initializes a new instance of the <see cref="Vector2ToVector2IntConverter"/> class rounding to nearest.
-        /// </summary>
+        /// <remarks>Default: rounding to nearest.</remarks>
         public Vector2ToVector2IntConverter() { }
 
-        /// <summary>
-        /// Initializes a new instance of the <see cref="Vector2ToVector2IntConverter"/> class.
-        /// </summary>
         /// <param name="mode">Which way to drop the fraction.</param>
         public Vector2ToVector2IntConverter(RoundMode mode)
         {

--- a/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Unity/Runtime/Converters/Vectors/Vector2ToVector2IntConverter.cs
+++ b/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Unity/Runtime/Converters/Vectors/Vector2ToVector2IntConverter.cs
@@ -1,0 +1,53 @@
+#nullable enable
+using System;
+using UnityEngine;
+
+// ReSharper disable once CheckNamespace
+namespace Aspid.MVVM.StarterKit
+{
+    /// <summary>
+    /// Converts a 2D vector to its integer form.
+    /// </summary>
+    [Serializable]
+    public sealed class Vector2ToVector2IntConverter : ITwoWayConverter<Vector2, Vector2Int>
+    {
+        [Tooltip("Which way to drop the fraction.")]
+        [SerializeField] private RoundMode _mode;
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="Vector2ToVector2IntConverter"/> class rounding to nearest.
+        /// </summary>
+        public Vector2ToVector2IntConverter() { }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="Vector2ToVector2IntConverter"/> class.
+        /// </summary>
+        /// <param name="mode">Which way to drop the fraction.</param>
+        public Vector2ToVector2IntConverter(RoundMode mode)
+        {
+            _mode = mode;
+        }
+
+        /// <summary>
+        /// Converts the specified vector to its integer form.
+        /// </summary>
+        /// <param name="value">The vector to convert.</param>
+        /// <returns>The integer vector.</returns>
+        /// <exception cref="ArgumentOutOfRangeException">Thrown when the mode is not a declared value.</exception>
+        public Vector2Int Convert(Vector2 value) => _mode switch
+        {
+            RoundMode.Round => Vector2Int.RoundToInt(value),
+            RoundMode.Floor => Vector2Int.FloorToInt(value),
+            RoundMode.Ceil => Vector2Int.CeilToInt(value),
+            RoundMode.Truncate => new Vector2Int((int)value.x, (int)value.y),
+            _ => throw new ArgumentOutOfRangeException(nameof(_mode), _mode, null)
+        };
+
+        /// <summary>
+        /// Converts an integer vector back to a floating-point one.
+        /// </summary>
+        /// <param name="value">The vector to convert.</param>
+        /// <returns>The floating-point vector.</returns>
+        public Vector2 ConvertBack(Vector2Int value) => value;
+    }
+}

--- a/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Unity/Runtime/Converters/Vectors/Vector2ToVector2IntConverter.cs.meta
+++ b/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Unity/Runtime/Converters/Vectors/Vector2ToVector2IntConverter.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 3f37742a0cb689d84379b5b69c90cf3f

--- a/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Unity/Runtime/Converters/Vectors/Vector3ArithmeticConverter.cs
+++ b/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Unity/Runtime/Converters/Vectors/Vector3ArithmeticConverter.cs
@@ -1,0 +1,63 @@
+#nullable enable
+using System;
+using UnityEngine;
+
+// ReSharper disable once CheckNamespace
+namespace Aspid.MVVM.StarterKit
+{
+    /// <summary>
+    /// Combines a bound vector with an authored one.
+    /// </summary>
+    /// <remarks>
+    /// The vector counterpart of <see cref="ArithmeticNumberConverter"/>, which only ever existed for
+    /// scalars.
+    /// </remarks>
+    [Serializable]
+    public sealed class Vector3ArithmeticConverter : IConverterVector3
+    {
+        [Tooltip("What to do with the operand.")]
+        [SerializeField] private VectorOperation _operation = VectorOperation.Add;
+
+        [Tooltip("The vector the bound one is combined with.")]
+        [SerializeField] private Vector3 _operand;
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="Vector3ArithmeticConverter"/> class that adds nothing.
+        /// </summary>
+        public Vector3ArithmeticConverter() { }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="Vector3ArithmeticConverter"/> class.
+        /// </summary>
+        /// <param name="operation">What to do with the operand.</param>
+        /// <param name="operand">The vector the bound one is combined with.</param>
+        public Vector3ArithmeticConverter(VectorOperation operation, Vector3 operand)
+        {
+            _operation = operation;
+            _operand = operand;
+        }
+
+        /// <summary>
+        /// Combines the specified vector with the authored operand.
+        /// </summary>
+        /// <param name="value">The vector to combine.</param>
+        /// <returns>The combined vector.</returns>
+        /// <exception cref="ArgumentOutOfRangeException">Thrown when the operation is not a declared value.</exception>
+        public Vector3 Convert(Vector3 value) => _operation switch
+        {
+            VectorOperation.Add => value + _operand,
+            VectorOperation.Subtract => value - _operand,
+            VectorOperation.Scale => Vector3.Scale(value, _operand),
+            VectorOperation.Divide => Divide(value, _operand),
+            VectorOperation.Reflect => Vector3.Reflect(value, _operand),
+            _ => throw new ArgumentOutOfRangeException(nameof(_operation), _operation, null)
+        };
+
+        // A zero axis in the operand leaves that axis alone rather than producing an infinity, for
+        // the same reason the scalar converter degrades instead of dividing by zero.
+        private static Vector3 Divide(Vector3 value, Vector3 operand) => new(
+            operand.x == 0f ? value.x : value.x / operand.x,
+            operand.y == 0f ? value.y : value.y / operand.y,
+            operand.z == 0f ? value.z : value.z / operand.z);
+    }
+}

--- a/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Unity/Runtime/Converters/Vectors/Vector3ArithmeticConverter.cs
+++ b/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Unity/Runtime/Converters/Vectors/Vector3ArithmeticConverter.cs
@@ -21,14 +21,8 @@ namespace Aspid.MVVM.StarterKit
         [Tooltip("The vector the bound one is combined with.")]
         [SerializeField] private Vector3 _operand;
 
-        /// <summary>
-        /// Initializes a new instance of the <see cref="Vector3ArithmeticConverter"/> class that adds nothing.
-        /// </summary>
         public Vector3ArithmeticConverter() { }
 
-        /// <summary>
-        /// Initializes a new instance of the <see cref="Vector3ArithmeticConverter"/> class.
-        /// </summary>
         /// <param name="operation">What to do with the operand.</param>
         /// <param name="operand">The vector the bound one is combined with.</param>
         public Vector3ArithmeticConverter(VectorOperation operation, Vector3 operand)

--- a/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Unity/Runtime/Converters/Vectors/Vector3ArithmeticConverter.cs.meta
+++ b/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Unity/Runtime/Converters/Vectors/Vector3ArithmeticConverter.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 6b6c4fb72048047f798f87c093d641d5

--- a/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Unity/Runtime/Converters/Vectors/Vector3ToFloatConverter.cs
+++ b/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Unity/Runtime/Converters/Vectors/Vector3ToFloatConverter.cs
@@ -15,14 +15,9 @@ namespace Aspid.MVVM.StarterKit
         [Tooltip("Which number to take.")]
         [SerializeField] private VectorComponent _component = VectorComponent.Magnitude;
 
-        /// <summary>
-        /// Initializes a new instance of the <see cref="Vector3ToFloatConverter"/> class measuring length.
-        /// </summary>
+        /// <remarks>Default: measuring length.</remarks>
         public Vector3ToFloatConverter() { }
 
-        /// <summary>
-        /// Initializes a new instance of the <see cref="Vector3ToFloatConverter"/> class.
-        /// </summary>
         /// <param name="component">Which number to take.</param>
         public Vector3ToFloatConverter(VectorComponent component)
         {

--- a/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Unity/Runtime/Converters/Vectors/Vector3ToFloatConverter.cs
+++ b/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Unity/Runtime/Converters/Vectors/Vector3ToFloatConverter.cs
@@ -1,0 +1,48 @@
+#nullable enable
+using System;
+using UnityEngine;
+
+// ReSharper disable once CheckNamespace
+namespace Aspid.MVVM.StarterKit
+{
+    /// <summary>
+    /// Measures one number out of a vector.
+    /// </summary>
+    /// <remarks>Driving a bar or a label from one axis, or from how long the vector is.</remarks>
+    [Serializable]
+    public sealed class Vector3ToFloatConverter : IConverter<Vector3, float>
+    {
+        [Tooltip("Which number to take.")]
+        [SerializeField] private VectorComponent _component = VectorComponent.Magnitude;
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="Vector3ToFloatConverter"/> class measuring length.
+        /// </summary>
+        public Vector3ToFloatConverter() { }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="Vector3ToFloatConverter"/> class.
+        /// </summary>
+        /// <param name="component">Which number to take.</param>
+        public Vector3ToFloatConverter(VectorComponent component)
+        {
+            _component = component;
+        }
+
+        /// <summary>
+        /// Measures the specified vector.
+        /// </summary>
+        /// <param name="value">The vector to measure.</param>
+        /// <returns>The measurement.</returns>
+        /// <exception cref="ArgumentOutOfRangeException">Thrown when the component is not a declared value.</exception>
+        public float Convert(Vector3 value) => _component switch
+        {
+            VectorComponent.X => value.x,
+            VectorComponent.Y => value.y,
+            VectorComponent.Z => value.z,
+            VectorComponent.Magnitude => value.magnitude,
+            VectorComponent.SqrMagnitude => value.sqrMagnitude,
+            _ => throw new ArgumentOutOfRangeException(nameof(_component), _component, null)
+        };
+    }
+}

--- a/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Unity/Runtime/Converters/Vectors/Vector3ToFloatConverter.cs.meta
+++ b/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Unity/Runtime/Converters/Vectors/Vector3ToFloatConverter.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 64417cb98c98cb7282ab6c3ac547f1b6

--- a/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Unity/Runtime/Converters/Vectors/Vector3ToVector3IntConverter.cs
+++ b/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Unity/Runtime/Converters/Vectors/Vector3ToVector3IntConverter.cs
@@ -1,0 +1,57 @@
+#nullable enable
+using System;
+using UnityEngine;
+
+// ReSharper disable once CheckNamespace
+namespace Aspid.MVVM.StarterKit
+{
+    /// <summary>
+    /// Converts a vector to its integer form.
+    /// </summary>
+    /// <remarks>
+    /// <see cref="Vector2Int"/> and <see cref="Vector3Int"/> are what grid and tile games count in,
+    /// and the package had no way to reach them.
+    /// </remarks>
+    [Serializable]
+    public sealed class Vector3ToVector3IntConverter : ITwoWayConverter<Vector3, Vector3Int>
+    {
+        [Tooltip("Which way to drop the fraction.")]
+        [SerializeField] private RoundMode _mode;
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="Vector3ToVector3IntConverter"/> class rounding to nearest.
+        /// </summary>
+        public Vector3ToVector3IntConverter() { }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="Vector3ToVector3IntConverter"/> class.
+        /// </summary>
+        /// <param name="mode">Which way to drop the fraction.</param>
+        public Vector3ToVector3IntConverter(RoundMode mode)
+        {
+            _mode = mode;
+        }
+
+        /// <summary>
+        /// Converts the specified vector to its integer form.
+        /// </summary>
+        /// <param name="value">The vector to convert.</param>
+        /// <returns>The integer vector.</returns>
+        /// <exception cref="ArgumentOutOfRangeException">Thrown when the mode is not a declared value.</exception>
+        public Vector3Int Convert(Vector3 value) => _mode switch
+        {
+            RoundMode.Round => Vector3Int.RoundToInt(value),
+            RoundMode.Floor => Vector3Int.FloorToInt(value),
+            RoundMode.Ceil => Vector3Int.CeilToInt(value),
+            RoundMode.Truncate => new Vector3Int((int)value.x, (int)value.y, (int)value.z),
+            _ => throw new ArgumentOutOfRangeException(nameof(_mode), _mode, null)
+        };
+
+        /// <summary>
+        /// Converts an integer vector back to a floating-point one.
+        /// </summary>
+        /// <param name="value">The vector to convert.</param>
+        /// <returns>The floating-point vector.</returns>
+        public Vector3 ConvertBack(Vector3Int value) => value;
+    }
+}

--- a/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Unity/Runtime/Converters/Vectors/Vector3ToVector3IntConverter.cs
+++ b/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Unity/Runtime/Converters/Vectors/Vector3ToVector3IntConverter.cs
@@ -18,14 +18,9 @@ namespace Aspid.MVVM.StarterKit
         [Tooltip("Which way to drop the fraction.")]
         [SerializeField] private RoundMode _mode;
 
-        /// <summary>
-        /// Initializes a new instance of the <see cref="Vector3ToVector3IntConverter"/> class rounding to nearest.
-        /// </summary>
+        /// <remarks>Default: rounding to nearest.</remarks>
         public Vector3ToVector3IntConverter() { }
 
-        /// <summary>
-        /// Initializes a new instance of the <see cref="Vector3ToVector3IntConverter"/> class.
-        /// </summary>
         /// <param name="mode">Which way to drop the fraction.</param>
         public Vector3ToVector3IntConverter(RoundMode mode)
         {

--- a/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Unity/Runtime/Converters/Vectors/Vector3ToVector3IntConverter.cs.meta
+++ b/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Unity/Runtime/Converters/Vectors/Vector3ToVector3IntConverter.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 6dcb84ce373e01e42e264235cb019d90

--- a/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Unity/Runtime/Converters/Vectors/VectorClampMagnitudeConverter.cs
+++ b/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Unity/Runtime/Converters/Vectors/VectorClampMagnitudeConverter.cs
@@ -18,14 +18,9 @@ namespace Aspid.MVVM.StarterKit
         [Tooltip("The shortest the vector is allowed to be. Zero disables the lower bound.")]
         [SerializeField] private float _minMagnitude;
 
-        /// <summary>
-        /// Initializes a new instance of the <see cref="VectorClampMagnitudeConverter"/> class clamping to one.
-        /// </summary>
+        /// <remarks>Default: clamping to one.</remarks>
         public VectorClampMagnitudeConverter() { }
 
-        /// <summary>
-        /// Initializes a new instance of the <see cref="VectorClampMagnitudeConverter"/> class.
-        /// </summary>
         /// <param name="maxMagnitude">The longest the vector is allowed to be.</param>
         /// <param name="minMagnitude">The shortest the vector is allowed to be.</param>
         public VectorClampMagnitudeConverter(float maxMagnitude, float minMagnitude = 0f)

--- a/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Unity/Runtime/Converters/Vectors/VectorClampMagnitudeConverter.cs
+++ b/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Unity/Runtime/Converters/Vectors/VectorClampMagnitudeConverter.cs
@@ -1,0 +1,53 @@
+#nullable enable
+using System;
+using UnityEngine;
+
+// ReSharper disable once CheckNamespace
+namespace Aspid.MVVM.StarterKit
+{
+    /// <summary>
+    /// Keeps a vector inside a length.
+    /// </summary>
+    /// <remarks>Holding a joystick offset or a drag inside a panel's radius.</remarks>
+    [Serializable]
+    public sealed class VectorClampMagnitudeConverter : IConverterVector3
+    {
+        [Tooltip("The longest the vector is allowed to be.")]
+        [SerializeField] private float _maxMagnitude = 1f;
+
+        [Tooltip("The shortest the vector is allowed to be. Zero disables the lower bound.")]
+        [SerializeField] private float _minMagnitude;
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="VectorClampMagnitudeConverter"/> class clamping to one.
+        /// </summary>
+        public VectorClampMagnitudeConverter() { }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="VectorClampMagnitudeConverter"/> class.
+        /// </summary>
+        /// <param name="maxMagnitude">The longest the vector is allowed to be.</param>
+        /// <param name="minMagnitude">The shortest the vector is allowed to be.</param>
+        public VectorClampMagnitudeConverter(float maxMagnitude, float minMagnitude = 0f)
+        {
+            _maxMagnitude = maxMagnitude;
+            _minMagnitude = minMagnitude;
+        }
+
+        /// <summary>
+        /// Clamps the length of the specified vector.
+        /// </summary>
+        /// <param name="value">The vector to clamp.</param>
+        /// <returns>The clamped vector.</returns>
+        public Vector3 Convert(Vector3 value)
+        {
+            var magnitude = value.magnitude;
+            if (magnitude == 0f) return value;
+
+            if (magnitude > _maxMagnitude) return value * (_maxMagnitude / magnitude);
+            if (_minMagnitude > 0f && magnitude < _minMagnitude) return value * (_minMagnitude / magnitude);
+
+            return value;
+        }
+    }
+}

--- a/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Unity/Runtime/Converters/Vectors/VectorClampMagnitudeConverter.cs.meta
+++ b/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Unity/Runtime/Converters/Vectors/VectorClampMagnitudeConverter.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 00f5eed254d91cb4467edbb8ce009789

--- a/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Unity/Runtime/Converters/Vectors/VectorComponent.cs
+++ b/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Unity/Runtime/Converters/Vectors/VectorComponent.cs
@@ -1,0 +1,36 @@
+#nullable enable
+
+// ReSharper disable once CheckNamespace
+namespace Aspid.MVVM.StarterKit
+{
+    /// <summary>
+    /// What <see cref="Vector3ToFloatConverter"/> measures.
+    /// </summary>
+    public enum VectorComponent
+    {
+        /// <summary>
+        /// The X axis.
+        /// </summary>
+        X,
+
+        /// <summary>
+        /// The Y axis.
+        /// </summary>
+        Y,
+
+        /// <summary>
+        /// The Z axis.
+        /// </summary>
+        Z,
+
+        /// <summary>
+        /// The length of the vector.
+        /// </summary>
+        Magnitude,
+
+        /// <summary>
+        /// The squared length, which needs no square root.
+        /// </summary>
+        SqrMagnitude,
+    }
+}

--- a/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Unity/Runtime/Converters/Vectors/VectorComponent.cs.meta
+++ b/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Unity/Runtime/Converters/Vectors/VectorComponent.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 9c3504e6bd821b3ee9769cfe0ec6c420

--- a/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Unity/Runtime/Converters/Vectors/VectorLerpConverter.cs
+++ b/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Unity/Runtime/Converters/Vectors/VectorLerpConverter.cs
@@ -1,0 +1,48 @@
+#nullable enable
+using System;
+using UnityEngine;
+
+// ReSharper disable once CheckNamespace
+namespace Aspid.MVVM.StarterKit
+{
+    /// <summary>
+    /// Moves between two vectors by a 0..1 amount.
+    /// </summary>
+    /// <remarks>A marker travelling along a track as progress advances.</remarks>
+    [Serializable]
+    public sealed class VectorLerpConverter : IConverter<float, Vector3>
+    {
+        [Tooltip("The vector at 0.")]
+        [SerializeField] private Vector3 _from;
+
+        [Tooltip("The vector at 1.")]
+        [SerializeField] private Vector3 _to = Vector3.one;
+
+        [Tooltip("Hold the incoming amount inside 0..1.")]
+        [SerializeField] private bool _clamp = true;
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="VectorLerpConverter"/> class going zero to one.
+        /// </summary>
+        public VectorLerpConverter() { }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="VectorLerpConverter"/> class.
+        /// </summary>
+        /// <param name="from">The vector at 0.</param>
+        /// <param name="to">The vector at 1.</param>
+        public VectorLerpConverter(Vector3 from, Vector3 to)
+        {
+            _from = from;
+            _to = to;
+        }
+
+        /// <summary>
+        /// Reads the vector at the specified amount.
+        /// </summary>
+        /// <param name="value">The 0..1 amount.</param>
+        /// <returns>The vector there.</returns>
+        public Vector3 Convert(float value) =>
+            _clamp ? Vector3.Lerp(_from, _to, value) : Vector3.LerpUnclamped(_from, _to, value);
+    }
+}

--- a/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Unity/Runtime/Converters/Vectors/VectorLerpConverter.cs
+++ b/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Unity/Runtime/Converters/Vectors/VectorLerpConverter.cs
@@ -21,14 +21,9 @@ namespace Aspid.MVVM.StarterKit
         [Tooltip("Hold the incoming amount inside 0..1.")]
         [SerializeField] private bool _clamp = true;
 
-        /// <summary>
-        /// Initializes a new instance of the <see cref="VectorLerpConverter"/> class going zero to one.
-        /// </summary>
+        /// <remarks>Default: going zero to one.</remarks>
         public VectorLerpConverter() { }
 
-        /// <summary>
-        /// Initializes a new instance of the <see cref="VectorLerpConverter"/> class.
-        /// </summary>
         /// <param name="from">The vector at 0.</param>
         /// <param name="to">The vector at 1.</param>
         public VectorLerpConverter(Vector3 from, Vector3 to)

--- a/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Unity/Runtime/Converters/Vectors/VectorLerpConverter.cs.meta
+++ b/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Unity/Runtime/Converters/Vectors/VectorLerpConverter.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 016b1672a7f7343c8a0ccf7bf25e5db2

--- a/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Unity/Runtime/Converters/Vectors/VectorNormalizeConverter.cs
+++ b/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Unity/Runtime/Converters/Vectors/VectorNormalizeConverter.cs
@@ -1,0 +1,24 @@
+#nullable enable
+using System;
+using UnityEngine;
+
+// ReSharper disable once CheckNamespace
+namespace Aspid.MVVM.StarterKit
+{
+    /// <summary>
+    /// Reduces a vector to its direction.
+    /// </summary>
+    [Serializable]
+    public sealed class VectorNormalizeConverter : IConverterVector3
+    {
+        /// <summary>
+        /// Normalises the specified vector.
+        /// </summary>
+        /// <param name="value">The vector to normalise.</param>
+        /// <returns>
+        /// The unit vector pointing the same way, or zero for a zero-length input — Unity's own
+        /// <c>normalized</c> does the same rather than producing a NaN.
+        /// </returns>
+        public Vector3 Convert(Vector3 value) => value.normalized;
+    }
+}

--- a/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Unity/Runtime/Converters/Vectors/VectorNormalizeConverter.cs.meta
+++ b/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Unity/Runtime/Converters/Vectors/VectorNormalizeConverter.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: dca48b467b413292568c2d23f5473477

--- a/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Unity/Runtime/Converters/Vectors/VectorOperation.cs
+++ b/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Unity/Runtime/Converters/Vectors/VectorOperation.cs
@@ -1,0 +1,36 @@
+#nullable enable
+
+// ReSharper disable once CheckNamespace
+namespace Aspid.MVVM.StarterKit
+{
+    /// <summary>
+    /// The arithmetic <see cref="Vector3ArithmeticConverter"/> can apply.
+    /// </summary>
+    public enum VectorOperation
+    {
+        /// <summary>
+        /// Add the operand.
+        /// </summary>
+        Add,
+
+        /// <summary>
+        /// Subtract the operand.
+        /// </summary>
+        Subtract,
+
+        /// <summary>
+        /// Multiply each axis by the operand's.
+        /// </summary>
+        Scale,
+
+        /// <summary>
+        /// Divide each axis by the operand's. A zero axis is left alone.
+        /// </summary>
+        Divide,
+
+        /// <summary>
+        /// Reflect off the operand as a normal.
+        /// </summary>
+        Reflect,
+    }
+}

--- a/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Unity/Runtime/Converters/Vectors/VectorOperation.cs.meta
+++ b/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Unity/Runtime/Converters/Vectors/VectorOperation.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 8c68c479c0b0a382e3696df2f3f9414f

--- a/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Unity/Runtime/Converters/Vectors/VectorRoundConverter.cs
+++ b/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Unity/Runtime/Converters/Vectors/VectorRoundConverter.cs
@@ -18,14 +18,9 @@ namespace Aspid.MVVM.StarterKit
         [Tooltip("The size of one grid step. Zero rounds to whole numbers.")]
         [SerializeField] private float _step;
 
-        /// <summary>
-        /// Initializes a new instance of the <see cref="VectorRoundConverter"/> class rounding to whole numbers.
-        /// </summary>
+        /// <remarks>Default: rounding to whole numbers.</remarks>
         public VectorRoundConverter() { }
 
-        /// <summary>
-        /// Initializes a new instance of the <see cref="VectorRoundConverter"/> class.
-        /// </summary>
         /// <param name="mode">Which way to drop the fraction.</param>
         /// <param name="step">The size of one grid step.</param>
         public VectorRoundConverter(RoundMode mode, float step = 0f)

--- a/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Unity/Runtime/Converters/Vectors/VectorRoundConverter.cs
+++ b/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Unity/Runtime/Converters/Vectors/VectorRoundConverter.cs
@@ -1,0 +1,62 @@
+#nullable enable
+using System;
+using UnityEngine;
+
+// ReSharper disable once CheckNamespace
+namespace Aspid.MVVM.StarterKit
+{
+    /// <summary>
+    /// Rounds every axis of a vector.
+    /// </summary>
+    /// <remarks>Snapping to a grid, for tile-based UI and level tools.</remarks>
+    [Serializable]
+    public sealed class VectorRoundConverter : IConverterVector3
+    {
+        [Tooltip("Which way to drop the fraction.")]
+        [SerializeField] private RoundMode _mode;
+
+        [Tooltip("The size of one grid step. Zero rounds to whole numbers.")]
+        [SerializeField] private float _step;
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="VectorRoundConverter"/> class rounding to whole numbers.
+        /// </summary>
+        public VectorRoundConverter() { }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="VectorRoundConverter"/> class.
+        /// </summary>
+        /// <param name="mode">Which way to drop the fraction.</param>
+        /// <param name="step">The size of one grid step.</param>
+        public VectorRoundConverter(RoundMode mode, float step = 0f)
+        {
+            _mode = mode;
+            _step = step;
+        }
+
+        /// <summary>
+        /// Rounds every axis of the specified vector.
+        /// </summary>
+        /// <param name="value">The vector to round.</param>
+        /// <returns>The rounded vector.</returns>
+        public Vector3 Convert(Vector3 value) => new(Apply(value.x), Apply(value.y), Apply(value.z));
+
+        /// <exception cref="ArgumentOutOfRangeException">Thrown when the mode is not a declared value.</exception>
+        private float Apply(float value)
+        {
+            var step = _step == 0f ? 1f : _step;
+            var scaled = value / step;
+
+            var rounded = _mode switch
+            {
+                RoundMode.Round => Mathf.Round(scaled),
+                RoundMode.Floor => Mathf.Floor(scaled),
+                RoundMode.Ceil => Mathf.Ceil(scaled),
+                RoundMode.Truncate => (float)Math.Truncate(scaled),
+                _ => throw new ArgumentOutOfRangeException(nameof(_mode), _mode, null)
+            };
+
+            return rounded * step;
+        }
+    }
+}

--- a/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Unity/Runtime/Converters/Vectors/VectorRoundConverter.cs.meta
+++ b/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Unity/Runtime/Converters/Vectors/VectorRoundConverter.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: c4bb8fd0cb1ea6a61e6f3db395113978

--- a/Aspid.MVVM/Packages/tech.aspid.mvvm/Tests/Editor/Converters/ConverterFieldCoverageTests.cs
+++ b/Aspid.MVVM/Packages/tech.aspid.mvvm/Tests/Editor/Converters/ConverterFieldCoverageTests.cs
@@ -46,10 +46,7 @@ namespace Aspid.MVVM.StarterKit.Tests
         /// fill it. Shrinking this list is the point of it — <see cref="TheGapListHasNoStaleEntries"/>
         /// fails once an entry stops being a gap.
         /// </summary>
-        private static readonly Dictionary<string, string> KnownGaps = new()
-        {
-            ["IConverter<Quaternion, Quaternion>"] = "family 14 (Rotations) — AngleToQuaternion, LookRotation…",
-        };
+        private static readonly Dictionary<string, string> KnownGaps = new();
 
         [Test]
         public void EveryConverterFieldHasAPickableConverter()

--- a/Aspid.MVVM/Packages/tech.aspid.mvvm/Tests/Editor/Converters/Vectors/GeometryConverterTests.cs
+++ b/Aspid.MVVM/Packages/tech.aspid.mvvm/Tests/Editor/Converters/Vectors/GeometryConverterTests.cs
@@ -1,0 +1,237 @@
+using UnityEngine;
+using NUnit.Framework;
+
+namespace Aspid.MVVM.StarterKit.Tests
+{
+    /// <summary>
+    /// Coverage for the rotation, vector and layout converters.
+    /// </summary>
+    [TestFixture]
+    internal sealed class GeometryConverterTests
+    {
+        [Test]
+        public void AngleToQuaternion_TurnsAroundTheChosenAxis() =>
+            Assert.AreEqual(90f, new AngleToQuaternionConverter().Convert(90f).eulerAngles.z, 1e-3f);
+
+        [Test]
+        public void AngleToQuaternion_RoundTrips()
+        {
+            var converter = new AngleToQuaternionConverter(RotationAxis.Z, offset: 30f);
+
+            Assert.AreEqual(45f, converter.ConvertBack(converter.Convert(45f)), 1e-2f);
+        }
+
+        [Test]
+        public void EulerToQuaternion_RoundTrips()
+        {
+            var converter = new EulerToQuaternionConverter();
+            var euler = new Vector3(0f, 45f, 0f);
+
+            Assert.AreEqual(euler.y, converter.ConvertBack(converter.Convert(euler)).y, 1e-2f);
+        }
+
+        // Unity reports Euler angles in 0..360, so a needle a little past zero reads as 359 rather
+        // than -1 — which makes a "below zero" test fail exactly when it matters.
+        [Test]
+        public void QuaternionToEuler_NormalisesToSigned180()
+        {
+            var rotation = Quaternion.Euler(0f, 0f, 350f);
+
+            Assert.AreEqual(-10f, new QuaternionToEulerConverter().Convert(rotation).z, 1e-2f);
+            Assert.AreEqual(350f, new QuaternionToEulerConverter(false).Convert(rotation).z, 1e-2f);
+        }
+
+        [Test]
+        public void QuaternionOffset_RoundTrips()
+        {
+            var converter = new QuaternionOffsetConverter(new Vector3(0f, 90f, 0f));
+            var rotation = Quaternion.Euler(0f, 30f, 0f);
+
+            Assert.AreEqual(30f, converter.ConvertBack(converter.Convert(rotation)).eulerAngles.y, 1e-2f);
+        }
+
+        [TestCase(1f, 0f, 0f)]
+        [TestCase(0f, 1f, 90f)]
+        [TestCase(-1f, 0f, 180f)]
+        public void DirectionToAngle_ReadsTheAngle(float x, float y, float expected) =>
+            Assert.AreEqual(expected, new DirectionToAngleConverter(0f).Convert(new Vector2(x, y)), 1e-2f);
+
+        [Test]
+        public void DirectionToAngle_ZeroLengthReadsAsTheOffsetAlone() =>
+            Assert.AreEqual(15f, new DirectionToAngleConverter(15f).Convert(Vector2.zero), 1e-4f);
+
+        [Test]
+        public void AngleToDirection_IsTheInverseOfDirectionToAngle()
+        {
+            var angle = new DirectionToAngleConverter(0f).Convert(new Vector2(0f, 1f));
+            var direction = new AngleToDirectionConverter().Convert(angle);
+
+            Assert.AreEqual(0f, direction.x, 1e-4f);
+            Assert.AreEqual(1f, direction.y, 1e-4f);
+        }
+
+        [TestCase(AngleRange.Zero360, 370f, 10f)]
+        [TestCase(AngleRange.Zero360, -10f, 350f)]
+        [TestCase(AngleRange.Signed180, 350f, -10f)]
+        [TestCase(AngleRange.Signed180, 190f, -170f)]
+        public void AngleWrap_FoldsIntoTheRange(AngleRange range, float value, float expected) =>
+            Assert.AreEqual(expected, new AngleWrapConverter(range).Convert(value), 1e-3f);
+
+        [Test]
+        public void DegreesToRadians_RoundTrips()
+        {
+            var converter = new DegreesToRadiansConverter();
+
+            Assert.AreEqual(Mathf.PI, converter.Convert(180f), 1e-5f);
+            Assert.AreEqual(180f, converter.ConvertBack(Mathf.PI), 1e-3f);
+        }
+
+        // LookRotation warns and returns identity on a zero vector; checking first keeps the console
+        // clean when a target has not been picked yet.
+        [Test]
+        public void LookRotation_ZeroDirectionIsTheIdentityWithoutAWarning() =>
+            Assert.AreEqual(Quaternion.identity, new LookRotationConverter().Convert(Vector3.zero));
+
+        [Test]
+        public void LookRotation_FlattensWhenAsked()
+        {
+            var rotation = new LookRotationConverter(Vector3.up, flatten: true).Convert(new Vector3(0f, 5f, 1f));
+
+            Assert.AreEqual(0f, rotation.eulerAngles.x, 1e-2f);
+        }
+
+        [Test]
+        public void FloatToVector3_WritesTheChosenAxes()
+        {
+            Assert.AreEqual(new Vector3(3f, 3f, 3f), new FloatToVector3Converter().Convert(3f));
+            Assert.AreEqual(
+                new Vector3(1f, 3f, 1f),
+                new FloatToVector3Converter(AxisMask.Y, Vector3.one).Convert(3f));
+        }
+
+        [Test]
+        public void FloatToVector2_WritesTheChosenAxes() =>
+            Assert.AreEqual(new Vector2(1f, 3f), new FloatToVector2Converter(AxisMask.Y, Vector2.one).Convert(3f));
+
+        [TestCase(VectorComponent.X, 3f)]
+        [TestCase(VectorComponent.Y, 4f)]
+        [TestCase(VectorComponent.Magnitude, 5f)]
+        [TestCase(VectorComponent.SqrMagnitude, 25f)]
+        public void Vector3ToFloat_Measures(VectorComponent component, float expected) =>
+            Assert.AreEqual(expected, new Vector3ToFloatConverter(component).Convert(new Vector3(3f, 4f, 0f)), 1e-4f);
+
+        [Test]
+        public void VectorArithmetic_Adds() =>
+            Assert.AreEqual(
+                new Vector3(2f, 3f, 4f),
+                new Vector3ArithmeticConverter(VectorOperation.Add, Vector3.one).Convert(new Vector3(1f, 2f, 3f)));
+
+        [Test]
+        public void VectorArithmetic_Scales() =>
+            Assert.AreEqual(
+                new Vector3(2f, 6f, 12f),
+                new Vector3ArithmeticConverter(VectorOperation.Scale, new Vector3(2f, 3f, 4f))
+                    .Convert(new Vector3(1f, 2f, 3f)));
+
+        // A zero axis leaves that axis alone rather than producing an infinity.
+        [Test]
+        public void VectorArithmetic_DivideByAZeroAxisLeavesItAlone() =>
+            Assert.AreEqual(
+                new Vector3(0.5f, 2f, 3f),
+                new Vector3ArithmeticConverter(VectorOperation.Divide, new Vector3(2f, 0f, 0f))
+                    .Convert(new Vector3(1f, 2f, 3f)));
+
+        [Test]
+        public void VectorClampMagnitude_HoldsTheLength() =>
+            Assert.AreEqual(
+                1f,
+                new VectorClampMagnitudeConverter(1f).Convert(new Vector3(3f, 4f, 0f)).magnitude,
+                1e-4f);
+
+        [Test]
+        public void VectorClampMagnitude_RaisesToTheMinimum() =>
+            Assert.AreEqual(
+                2f,
+                new VectorClampMagnitudeConverter(10f, 2f).Convert(new Vector3(0.3f, 0.4f, 0f)).magnitude,
+                1e-4f);
+
+        [Test]
+        public void VectorClampMagnitude_ZeroStaysZero() =>
+            Assert.AreEqual(Vector3.zero, new VectorClampMagnitudeConverter(1f, 2f).Convert(Vector3.zero));
+
+        [Test]
+        public void VectorRound_SnapsToAGrid() =>
+            Assert.AreEqual(
+                new Vector3(0.5f, 1f, 1.5f),
+                new VectorRoundConverter(RoundMode.Round, 0.5f).Convert(new Vector3(0.6f, 0.9f, 1.4f)));
+
+        [Test]
+        public void VectorNormalize_ZeroStaysZero() =>
+            Assert.AreEqual(Vector3.zero, new VectorNormalizeConverter().Convert(Vector3.zero));
+
+        [Test]
+        public void VectorLerp_MovesBetweenTheStops()
+        {
+            var converter = new VectorLerpConverter(Vector3.zero, new Vector3(10f, 0f, 0f));
+
+            Assert.AreEqual(new Vector3(5f, 0f, 0f), converter.Convert(0.5f));
+        }
+
+        [Test]
+        public void Vector3ToVector3Int_RoundTrips()
+        {
+            var converter = new Vector3ToVector3IntConverter();
+
+            Assert.AreEqual(new Vector3Int(1, 2, 3), converter.Convert(new Vector3(1.4f, 2.4f, 3.4f)));
+            Assert.AreEqual(new Vector3(1f, 2f, 3f), converter.ConvertBack(new Vector3Int(1, 2, 3)));
+        }
+
+        [Test]
+        public void Vector2ToVector2Int_Floors() =>
+            Assert.AreEqual(
+                new Vector2Int(1, 2),
+                new Vector2ToVector2IntConverter(RoundMode.Floor).Convert(new Vector2(1.9f, 2.9f)));
+
+        [Test]
+        public void IntToRectOffset_WritesTheChosenSides()
+        {
+            var padding = new IntToRectOffsetConverter(RectSides.Horizontal).Convert(8);
+
+            Assert.AreEqual(8, padding.left);
+            Assert.AreEqual(8, padding.right);
+            Assert.AreEqual(0, padding.top);
+        }
+
+        // RectOffset is a class, so a new one per push would allocate once per notification.
+        [Test]
+        public void IntToRectOffset_ReusesOneInstance()
+        {
+            var converter = new IntToRectOffsetConverter();
+
+            Assert.AreSame(converter.Convert(4), converter.Convert(8));
+            Assert.AreEqual(8, converter.Convert(8).left);
+        }
+
+        [Test]
+        public void RectOffsetScale_ScalesTheChosenSides()
+        {
+            var scaled = new RectOffsetScaleConverter(2f, RectSides.Vertical)
+                .Convert(new RectOffset(3, 3, 3, 3));
+
+            Assert.AreEqual(3, scaled.left);
+            Assert.AreEqual(6, scaled.top);
+            Assert.AreEqual(6, scaled.bottom);
+        }
+
+        [Test]
+        public void Vector4ToRectOffset_ReadsTheFourNumbersInOrder()
+        {
+            var padding = new Vector4ToRectOffsetConverter().Convert(new Vector4(1f, 2f, 3f, 4f));
+
+            Assert.AreEqual(1, padding.left);
+            Assert.AreEqual(2, padding.right);
+            Assert.AreEqual(3, padding.top);
+            Assert.AreEqual(4, padding.bottom);
+        }
+    }
+}

--- a/Aspid.MVVM/Packages/tech.aspid.mvvm/Tests/Editor/Converters/Vectors/GeometryConverterTests.cs.meta
+++ b/Aspid.MVVM/Packages/tech.aspid.mvvm/Tests/Editor/Converters/Vectors/GeometryConverterTests.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: a8856634cddf54900a8612027b5219b8


### PR DESCRIPTION
✨ Phase 3 wave 3.5 — rotations, vectors and layout. Closes the `Quaternion` and `RectOffset` pickers, both declared since the first release with no implementation; only `Enum→OptionData` is left.

## Summary

- ✨ **Rotations**: `AngleToQuaternion`, `EulerToQuaternion`, `QuaternionToEuler`, `QuaternionOffset`, `DirectionToAngle`, `AngleToDirection`, `AngleWrap`, `DegreesToRadians`, `LookRotation`.
- ✨ **Vectors**: `FloatToVector3` and its 2D form, `Vector3ToFloat`, `Vector3Arithmetic`, `VectorClampMagnitude`, `VectorRound`, `VectorNormalize`, `VectorLerp`, plus the `Vector2Int`/`Vector3Int` pair the package could not reach at all.
- ✨ **Layout**: `IntToRectOffset`, `RectOffsetScale`, `Vector4ToRectOffset`.
- ✨ `FloatToVector3Converter` takes the fan-out away from `ComponentVector3MonoBinder`, which hard-coded `new Vector3(v, v, v)`.

## Notes for review

- ⚠️ `QuaternionToEulerConverter` normalises to ±180 by default — Unity reports 0..360, so a needle just past zero reads as 359 and a "rotation below zero" check fails exactly when it matters.
- 📝 `LookRotationConverter` checks for a zero-length direction, and `Vector3ArithmeticConverter` leaves an axis alone when dividing by zero — a NaN reaching a `Transform` corrupts it silently.
- 📝 The `RectOffset` converters reuse one instance because `RectOffset` is a class and a binder pushes per notification; each summary states that the result must be copied to outlive the next push.

✅ Local run: 553 total, 551 passed, 0 failed, 2 skipped.

<details>
<summary>🇷🇺 Описание на русском</summary>

✨ Волна 3.5 Фазы 3 — вращения, векторы и layout. Закрывает пикеры `Quaternion` и `RectOffset`, объявленные с первого релиза без реализаций; остался только `Enum→OptionData`.

## Итог

- ✨ **Вращения**: `AngleToQuaternion`, `EulerToQuaternion`, `QuaternionToEuler`, `QuaternionOffset`, `DirectionToAngle`, `AngleToDirection`, `AngleWrap`, `DegreesToRadians`, `LookRotation`.
- ✨ **Векторы**: `FloatToVector3` и его 2D-форма, `Vector3ToFloat`, `Vector3Arithmetic`, `VectorClampMagnitude`, `VectorRound`, `VectorNormalize`, `VectorLerp` плюс пара `Vector2Int`/`Vector3Int`, до которой пакет не дотягивался вовсе.
- ✨ **Layout**: `IntToRectOffset`, `RectOffsetScale`, `Vector4ToRectOffset`.
- ✨ `FloatToVector3Converter` забирает fan-out у `ComponentVector3MonoBinder`, который зашивал `new Vector3(v, v, v)`.

## Заметки для ревью

- ⚠️ `QuaternionToEulerConverter` по умолчанию нормализует к ±180 — Unity отдаёт 0..360, поэтому стрелка чуть за нулём читается как 359, и проверка «поворот меньше нуля» падает ровно тогда, когда нужна.
- 📝 `LookRotationConverter` проверяет нулевое направление, а `Vector3ArithmeticConverter` оставляет ось как есть при делении на ноль — NaN, дошедший до `Transform`, портит его молча.
- 📝 Конвертеры `RectOffset` переиспользуют один экземпляр, потому что `RectOffset` — класс, а биндер толкает на каждое уведомление; в summary сказано, что результат надо копировать, чтобы он пережил следующий push.

✅ Локальный прогон: 553 всего, 551 прошло, 0 упало, 2 пропущено.

</details>

