### PR TITLE
feat(starterkit): add parsing and localization converters

### DIFF
--- a/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Runtime/Converters/Strings/StringToBoolParseConverter.cs
+++ b/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Runtime/Converters/Strings/StringToBoolParseConverter.cs
@@ -20,14 +20,9 @@ namespace Aspid.MVVM.StarterKit
         [Tooltip("Returned when the text matches nothing.")]
         [SerializeField] private bool _fallback;
 
-        /// <summary>
-        /// Initializes a new instance of the <see cref="StringToBoolParseConverter"/> class with the usual spellings.
-        /// </summary>
+        /// <remarks>Default: with the usual spellings.</remarks>
         public StringToBoolParseConverter() { }
 
-        /// <summary>
-        /// Initializes a new instance of the <see cref="StringToBoolParseConverter"/> class.
-        /// </summary>
         /// <param name="trueTokens">The spellings read as <see langword="true"/>.</param>
         /// <param name="fallback">Returned when the text matches nothing.</param>
         public StringToBoolParseConverter(string[]? trueTokens, bool fallback = false)

--- a/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Runtime/Converters/Strings/StringToBoolParseConverter.cs
+++ b/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Runtime/Converters/Strings/StringToBoolParseConverter.cs
@@ -1,0 +1,57 @@
+using System;
+using UnityEngine;
+
+// ReSharper disable once CheckNamespace
+namespace Aspid.MVVM.StarterKit
+{
+    /// <summary>
+    /// Reads a boolean out of text.
+    /// </summary>
+    /// <remarks>
+    /// Configuration and backend payloads say "on", "1" and "yes" as often as they say "true", so the
+    /// accepted spellings are authored rather than fixed.
+    /// </remarks>
+    [Serializable]
+    public sealed class StringToBoolParseConverter : IConverterStringToBool
+    {
+        [Tooltip("The spellings read as true. Matched without regard to case.")]
+        [SerializeField] private string[] _trueTokens = { "true", "1", "yes", "on" };
+
+        [Tooltip("Returned when the text matches nothing.")]
+        [SerializeField] private bool _fallback;
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="StringToBoolParseConverter"/> class with the usual spellings.
+        /// </summary>
+        public StringToBoolParseConverter() { }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="StringToBoolParseConverter"/> class.
+        /// </summary>
+        /// <param name="trueTokens">The spellings read as <see langword="true"/>.</param>
+        /// <param name="fallback">Returned when the text matches nothing.</param>
+        public StringToBoolParseConverter(string[]? trueTokens, bool fallback = false)
+        {
+            if (trueTokens is { Length: > 0 }) _trueTokens = trueTokens;
+            _fallback = fallback;
+        }
+
+        /// <summary>
+        /// Reads a boolean out of the specified text.
+        /// </summary>
+        /// <param name="value">The text to read.</param>
+        /// <returns>Whether it matches one of the accepted spellings, or the fallback.</returns>
+        public bool Convert(string? value)
+        {
+            if (string.IsNullOrWhiteSpace(value) || _trueTokens is not { Length: > 0 }) return _fallback;
+
+            var trimmed = value!.Trim();
+
+            for (var i = 0; i < _trueTokens.Length; i++)
+                if (string.Equals(trimmed, _trueTokens[i], StringComparison.OrdinalIgnoreCase))
+                    return true;
+
+            return _fallback;
+        }
+    }
+}

--- a/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Runtime/Converters/Strings/StringToBoolParseConverter.cs.meta
+++ b/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Runtime/Converters/Strings/StringToBoolParseConverter.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 9e44057dbacdede882f958c3884eb501

--- a/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Runtime/Converters/Strings/StringToDateTimeConverter.cs
+++ b/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Runtime/Converters/Strings/StringToDateTimeConverter.cs
@@ -1,0 +1,56 @@
+using System;
+using UnityEngine;
+using System.Globalization;
+
+// ReSharper disable once CheckNamespace
+namespace Aspid.MVVM.StarterKit
+{
+    /// <summary>
+    /// Reads a date out of text.
+    /// </summary>
+    [Serializable]
+    public sealed class StringToDateTimeConverter : IConverter<string?, DateTime>
+    {
+        [Tooltip("The exact format expected. When empty, any format the culture understands is accepted.")]
+        [SerializeField] private string _format = string.Empty;
+
+        [Tooltip("The culture the text is read with.")]
+        [SerializeField] private CultureInfoMode _culture = CultureInfoMode.CurrentCulture;
+
+        [Tooltip("Ticks of the date returned when the text is not one.")]
+        [SerializeField] private long _fallbackTicks;
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="StringToDateTimeConverter"/> class accepting any format.
+        /// </summary>
+        public StringToDateTimeConverter() { }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="StringToDateTimeConverter"/> class.
+        /// </summary>
+        /// <param name="format">The exact format expected.</param>
+        /// <param name="fallback">Returned when the text is not a date.</param>
+        public StringToDateTimeConverter(string format, DateTime fallback = default)
+        {
+            _format = format;
+            _fallbackTicks = fallback.Ticks;
+        }
+
+        /// <summary>
+        /// Reads a date out of the specified text.
+        /// </summary>
+        /// <param name="value">The text to read.</param>
+        /// <returns>The date, or the fallback when the text is not one.</returns>
+        public DateTime Convert(string? value)
+        {
+            var culture = _culture.ToCultureInfo();
+            var fallback = new DateTime(_fallbackTicks);
+
+            if (string.IsNullOrWhiteSpace(value)) return fallback;
+
+            return string.IsNullOrWhiteSpace(_format)
+                ? DateTime.TryParse(value, culture, DateTimeStyles.None, out var any) ? any : fallback
+                : DateTime.TryParseExact(value, _format, culture, DateTimeStyles.None, out var exact) ? exact : fallback;
+        }
+    }
+}

--- a/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Runtime/Converters/Strings/StringToDateTimeConverter.cs
+++ b/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Runtime/Converters/Strings/StringToDateTimeConverter.cs
@@ -20,14 +20,9 @@ namespace Aspid.MVVM.StarterKit
         [Tooltip("Ticks of the date returned when the text is not one.")]
         [SerializeField] private long _fallbackTicks;
 
-        /// <summary>
-        /// Initializes a new instance of the <see cref="StringToDateTimeConverter"/> class accepting any format.
-        /// </summary>
+        /// <remarks>Default: accepting any format.</remarks>
         public StringToDateTimeConverter() { }
 
-        /// <summary>
-        /// Initializes a new instance of the <see cref="StringToDateTimeConverter"/> class.
-        /// </summary>
         /// <param name="format">The exact format expected.</param>
         /// <param name="fallback">Returned when the text is not a date.</param>
         public StringToDateTimeConverter(string format, DateTime fallback = default)

--- a/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Runtime/Converters/Strings/StringToDateTimeConverter.cs.meta
+++ b/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Runtime/Converters/Strings/StringToDateTimeConverter.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 78d5e553ba665053079f0609de14a8de

--- a/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Runtime/Converters/Strings/StringToEnumConverter.cs
+++ b/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Runtime/Converters/Strings/StringToEnumConverter.cs
@@ -1,0 +1,61 @@
+using System;
+using UnityEngine;
+
+// ReSharper disable once CheckNamespace
+namespace Aspid.MVVM.StarterKit
+{
+    /// <summary>
+    /// Reads an enum member out of text.
+    /// </summary>
+    /// <typeparam name="TEnum">The enum type being read.</typeparam>
+    /// <remarks>State names arriving from a backend or a configuration file.</remarks>
+    [Serializable]
+    public sealed class StringToEnumConverter<TEnum> : ITwoWayConverter<string?, TEnum>
+        where TEnum : struct, Enum
+    {
+        [Tooltip("Match member names without regard to case.")]
+        [SerializeField] private bool _ignoreCase = true;
+
+        [Tooltip("Returned when the text names no member.")]
+        [SerializeField] private TEnum _fallback;
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="StringToEnumConverter{TEnum}"/> class.
+        /// </summary>
+        public StringToEnumConverter() { }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="StringToEnumConverter{TEnum}"/> class.
+        /// </summary>
+        /// <param name="fallback">Returned when the text names no member.</param>
+        /// <param name="ignoreCase">Whether to match without regard to case.</param>
+        public StringToEnumConverter(TEnum fallback, bool ignoreCase = true)
+        {
+            _fallback = fallback;
+            _ignoreCase = ignoreCase;
+        }
+
+        /// <summary>
+        /// Reads an enum member out of the specified text.
+        /// </summary>
+        /// <param name="value">The text to read.</param>
+        /// <returns>The member, or the fallback when the text names none.</returns>
+        public TEnum Convert(string? value)
+        {
+            if (string.IsNullOrWhiteSpace(value)) return _fallback;
+
+            // Enum.TryParse accepts a bare number and returns an undeclared member for it, which is
+            // rarely what a name-shaped input means.
+            return Enum.TryParse<TEnum>(value, _ignoreCase, out var parsed) && Enum.IsDefined(typeof(TEnum), parsed)
+                ? parsed
+                : _fallback;
+        }
+
+        /// <summary>
+        /// Writes the specified member as text.
+        /// </summary>
+        /// <param name="value">The member to write.</param>
+        /// <returns>Its name.</returns>
+        public string ConvertBack(TEnum value) => value.ToString();
+    }
+}

--- a/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Runtime/Converters/Strings/StringToEnumConverter.cs
+++ b/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Runtime/Converters/Strings/StringToEnumConverter.cs
@@ -19,14 +19,8 @@ namespace Aspid.MVVM.StarterKit
         [Tooltip("Returned when the text names no member.")]
         [SerializeField] private TEnum _fallback;
 
-        /// <summary>
-        /// Initializes a new instance of the <see cref="StringToEnumConverter{TEnum}"/> class.
-        /// </summary>
         public StringToEnumConverter() { }
 
-        /// <summary>
-        /// Initializes a new instance of the <see cref="StringToEnumConverter{TEnum}"/> class.
-        /// </summary>
         /// <param name="fallback">Returned when the text names no member.</param>
         /// <param name="ignoreCase">Whether to match without regard to case.</param>
         public StringToEnumConverter(TEnum fallback, bool ignoreCase = true)

--- a/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Runtime/Converters/Strings/StringToEnumConverter.cs.meta
+++ b/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Runtime/Converters/Strings/StringToEnumConverter.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 4e473da424dd730806edc74299c3a3b8

--- a/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Runtime/Converters/Strings/StringToFloatConverter.cs
+++ b/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Runtime/Converters/Strings/StringToFloatConverter.cs
@@ -30,14 +30,9 @@ namespace Aspid.MVVM.StarterKit
         [Tooltip("The culture the text is read with.")]
         [SerializeField] private CultureInfoMode _culture = CultureInfoMode.CurrentCulture;
 
-        /// <summary>
-        /// Initializes a new instance of the <see cref="StringToFloatConverter"/> class falling back to zero.
-        /// </summary>
+        /// <remarks>Default: falling back to zero.</remarks>
         public StringToFloatConverter() { }
 
-        /// <summary>
-        /// Initializes a new instance of the <see cref="StringToFloatConverter"/> class.
-        /// </summary>
         /// <param name="fallback">Returned when the text is not a number.</param>
         /// <param name="culture">The culture the text is read with.</param>
         public StringToFloatConverter(float fallback, CultureInfoMode culture = CultureInfoMode.CurrentCulture)

--- a/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Runtime/Converters/Strings/StringToFloatConverter.cs
+++ b/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Runtime/Converters/Strings/StringToFloatConverter.cs
@@ -1,0 +1,71 @@
+using System;
+using UnityEngine;
+using System.Globalization;
+
+// ReSharper disable once CheckNamespace
+namespace Aspid.MVVM.StarterKit
+{
+    /// <summary>
+    /// Reads a decimal number out of text.
+    /// </summary>
+    /// <remarks>
+    /// The culture matters more here than anywhere else: a German player typing <c>1,5</c> means one
+    /// and a half, and reading it as invariant gives fifteen or nothing at all.
+    /// </remarks>
+    [Serializable]
+    public sealed class StringToFloatConverter : ITwoWayConverter<string?, float>
+    {
+        [Tooltip("Returned when the text is not a number.")]
+        [SerializeField] private float _fallback;
+
+        [Tooltip("Hold the result inside the bounds below.")]
+        [SerializeField] private bool _clamp;
+
+        [Tooltip("The lowest value allowed through when clamping.")]
+        [SerializeField] private float _min = float.MinValue;
+
+        [Tooltip("The highest value allowed through when clamping.")]
+        [SerializeField] private float _max = float.MaxValue;
+
+        [Tooltip("The culture the text is read with.")]
+        [SerializeField] private CultureInfoMode _culture = CultureInfoMode.CurrentCulture;
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="StringToFloatConverter"/> class falling back to zero.
+        /// </summary>
+        public StringToFloatConverter() { }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="StringToFloatConverter"/> class.
+        /// </summary>
+        /// <param name="fallback">Returned when the text is not a number.</param>
+        /// <param name="culture">The culture the text is read with.</param>
+        public StringToFloatConverter(float fallback, CultureInfoMode culture = CultureInfoMode.CurrentCulture)
+        {
+            _fallback = fallback;
+            _culture = culture;
+        }
+
+        /// <summary>
+        /// Reads a number out of the specified text.
+        /// </summary>
+        /// <param name="value">The text to read.</param>
+        /// <returns>The number, or the fallback when the text is not one.</returns>
+        public float Convert(string? value)
+        {
+            const NumberStyles styles = NumberStyles.Float | NumberStyles.AllowThousands;
+
+            if (!float.TryParse(value, styles, _culture.ToCultureInfo(), out var parsed))
+                return _fallback;
+
+            return _clamp ? Mathf.Clamp(parsed, _min, _max) : parsed;
+        }
+
+        /// <summary>
+        /// Writes the specified number as text.
+        /// </summary>
+        /// <param name="value">The number to write.</param>
+        /// <returns>The text.</returns>
+        public string ConvertBack(float value) => value.ToString(_culture.ToCultureInfo());
+    }
+}

--- a/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Runtime/Converters/Strings/StringToFloatConverter.cs.meta
+++ b/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Runtime/Converters/Strings/StringToFloatConverter.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 2911337558ed54a5967b665ec0dc0efd

--- a/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Runtime/Converters/Strings/StringToIntConverter.cs
+++ b/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Runtime/Converters/Strings/StringToIntConverter.cs
@@ -1,0 +1,75 @@
+using System;
+using UnityEngine;
+using System.Globalization;
+
+// ReSharper disable once CheckNamespace
+namespace Aspid.MVVM.StarterKit
+{
+    /// <summary>
+    /// Reads a number out of text.
+    /// </summary>
+    /// <remarks>
+    /// Parsing currently lives inside <c>InputFieldBinder</c>, hard-coded: no choice of culture, no
+    /// fallback, and a failed parse silently swallows the event. As a converter the decisions belong
+    /// to whoever authored the field.
+    /// <para>
+    /// Both directions are here, but the binder API has nowhere to put a cross-type two-way
+    /// converter yet — its converter field is same-type. Until that changes these are for use from
+    /// code and inside <see cref="ComposeConverter{TFrom, TMid, TTo}"/>.
+    /// </para>
+    /// </remarks>
+    [Serializable]
+    public sealed class StringToIntConverter : ITwoWayConverter<string?, int>
+    {
+        [Tooltip("Returned when the text is not a number.")]
+        [SerializeField] private int _fallback;
+
+        [Tooltip("Hold the result inside the bounds below.")]
+        [SerializeField] private bool _clamp;
+
+        [Tooltip("The lowest value allowed through when clamping.")]
+        [SerializeField] private int _min = int.MinValue;
+
+        [Tooltip("The highest value allowed through when clamping.")]
+        [SerializeField] private int _max = int.MaxValue;
+
+        [Tooltip("The culture the text is read with.")]
+        [SerializeField] private CultureInfoMode _culture = CultureInfoMode.CurrentCulture;
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="StringToIntConverter"/> class falling back to zero.
+        /// </summary>
+        public StringToIntConverter() { }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="StringToIntConverter"/> class.
+        /// </summary>
+        /// <param name="fallback">Returned when the text is not a number.</param>
+        /// <param name="culture">The culture the text is read with.</param>
+        public StringToIntConverter(int fallback, CultureInfoMode culture = CultureInfoMode.CurrentCulture)
+        {
+            _fallback = fallback;
+            _culture = culture;
+        }
+
+        /// <summary>
+        /// Reads a number out of the specified text.
+        /// </summary>
+        /// <param name="value">The text to read.</param>
+        /// <returns>The number, or the fallback when the text is not one.</returns>
+        public int Convert(string? value)
+        {
+            if (!int.TryParse(value, NumberStyles.Integer, _culture.ToCultureInfo(), out var parsed))
+                return _fallback;
+
+            return _clamp ? Math.Clamp(parsed, _min, _max) : parsed;
+        }
+
+        /// <summary>
+        /// Writes the specified number as text.
+        /// </summary>
+        /// <param name="value">The number to write.</param>
+        /// <returns>The text.</returns>
+        public string ConvertBack(int value) => value.ToString(_culture.ToCultureInfo());
+    }
+}

--- a/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Runtime/Converters/Strings/StringToIntConverter.cs
+++ b/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Runtime/Converters/Strings/StringToIntConverter.cs
@@ -9,14 +9,9 @@ namespace Aspid.MVVM.StarterKit
     /// Reads a number out of text.
     /// </summary>
     /// <remarks>
-    /// Parsing currently lives inside <c>InputFieldBinder</c>, hard-coded: no choice of culture, no
-    /// fallback, and a failed parse silently swallows the event. As a converter the decisions belong
-    /// to whoever authored the field.
-    /// <para>
-    /// Both directions are here, but the binder API has nowhere to put a cross-type two-way
-    /// converter yet — its converter field is same-type. Until that changes these are for use from
-    /// code and inside <see cref="ComposeConverter{TFrom, TMid, TTo}"/>.
-    /// </para>
+    /// Both directions are here, but the binder converter field is same-type, so a cross-type two-way
+    /// converter has nowhere to sit yet: until that changes these are for use from code and inside
+    /// <see cref="ComposeConverter{TFrom, TMid, TTo}"/>.
     /// </remarks>
     [Serializable]
     public sealed class StringToIntConverter : ITwoWayConverter<string?, int>

--- a/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Runtime/Converters/Strings/StringToIntConverter.cs
+++ b/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Runtime/Converters/Strings/StringToIntConverter.cs
@@ -31,14 +31,9 @@ namespace Aspid.MVVM.StarterKit
         [Tooltip("The culture the text is read with.")]
         [SerializeField] private CultureInfoMode _culture = CultureInfoMode.CurrentCulture;
 
-        /// <summary>
-        /// Initializes a new instance of the <see cref="StringToIntConverter"/> class falling back to zero.
-        /// </summary>
+        /// <remarks>Default: falling back to zero.</remarks>
         public StringToIntConverter() { }
 
-        /// <summary>
-        /// Initializes a new instance of the <see cref="StringToIntConverter"/> class.
-        /// </summary>
         /// <param name="fallback">Returned when the text is not a number.</param>
         /// <param name="culture">The culture the text is read with.</param>
         public StringToIntConverter(int fallback, CultureInfoMode culture = CultureInfoMode.CurrentCulture)

--- a/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Runtime/Converters/Strings/StringToIntConverter.cs.meta
+++ b/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Runtime/Converters/Strings/StringToIntConverter.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: b35c1ed45ee1840368df35fd6b9e8f16

--- a/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Runtime/Converters/Strings/StringToLongConverter.cs
+++ b/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Runtime/Converters/Strings/StringToLongConverter.cs
@@ -1,0 +1,50 @@
+using System;
+using UnityEngine;
+using System.Globalization;
+
+// ReSharper disable once CheckNamespace
+namespace Aspid.MVVM.StarterKit
+{
+    /// <summary>
+    /// Reads a whole number out of text.
+    /// </summary>
+    /// <inheritdoc cref="StringToIntConverter" path="/remarks"/>
+    [Serializable]
+    public sealed class StringToLongConverter : ITwoWayConverter<string?, long>
+    {
+        [Tooltip("Returned when the text is not a number.")]
+        [SerializeField] private long _fallback;
+
+        [Tooltip("The culture the text is read with.")]
+        [SerializeField] private CultureInfoMode _culture = CultureInfoMode.CurrentCulture;
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="StringToLongConverter"/> class falling back to zero.
+        /// </summary>
+        public StringToLongConverter() { }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="StringToLongConverter"/> class.
+        /// </summary>
+        /// <param name="fallback">Returned when the text is not a number.</param>
+        public StringToLongConverter(long fallback)
+        {
+            _fallback = fallback;
+        }
+
+        /// <summary>
+        /// Reads a number out of the specified text.
+        /// </summary>
+        /// <param name="value">The text to read.</param>
+        /// <returns>The number, or the fallback when the text is not one.</returns>
+        public long Convert(string? value) =>
+            long.TryParse(value, NumberStyles.Integer, _culture.ToCultureInfo(), out var parsed) ? parsed : _fallback;
+
+        /// <summary>
+        /// Writes the specified number as text.
+        /// </summary>
+        /// <param name="value">The number to write.</param>
+        /// <returns>The text.</returns>
+        public string ConvertBack(long value) => value.ToString(_culture.ToCultureInfo());
+    }
+}

--- a/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Runtime/Converters/Strings/StringToLongConverter.cs
+++ b/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Runtime/Converters/Strings/StringToLongConverter.cs
@@ -18,14 +18,9 @@ namespace Aspid.MVVM.StarterKit
         [Tooltip("The culture the text is read with.")]
         [SerializeField] private CultureInfoMode _culture = CultureInfoMode.CurrentCulture;
 
-        /// <summary>
-        /// Initializes a new instance of the <see cref="StringToLongConverter"/> class falling back to zero.
-        /// </summary>
+        /// <remarks>Default: falling back to zero.</remarks>
         public StringToLongConverter() { }
 
-        /// <summary>
-        /// Initializes a new instance of the <see cref="StringToLongConverter"/> class.
-        /// </summary>
         /// <param name="fallback">Returned when the text is not a number.</param>
         public StringToLongConverter(long fallback)
         {

--- a/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Runtime/Converters/Strings/StringToLongConverter.cs.meta
+++ b/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Runtime/Converters/Strings/StringToLongConverter.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: dcb13818f8aeed6a4f7f459892a943e6

--- a/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Unity/Runtime/Converters/Localizations.meta
+++ b/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Unity/Runtime/Converters/Localizations.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 6c14380288ad242d2a1070ad6d5427d6
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Unity/Runtime/Converters/Localizations/LocaleToStringConverter.cs
+++ b/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Unity/Runtime/Converters/Localizations/LocaleToStringConverter.cs
@@ -1,0 +1,44 @@
+#if ASPID_MVVM_UNITY_LOCALIZATION_INTEGRATION
+#nullable enable
+using System;
+using UnityEngine;
+using UnityEngine.Localization;
+
+// ReSharper disable once CheckNamespace
+namespace Aspid.MVVM.StarterKit
+{
+    /// <summary>
+    /// Writes the name of a locale.
+    /// </summary>
+    /// <remarks>Labelling the entries of a language dropdown.</remarks>
+    [Serializable]
+    public sealed class LocaleToStringConverter : IConverter<Locale?, string>
+    {
+        [Tooltip("Use the locale's own name for itself rather than its English name.")]
+        [SerializeField] private bool _nativeName = true;
+
+        [Tooltip("Shown when there is no locale.")]
+        [SerializeField] private string _fallback = string.Empty;
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="LocaleToStringConverter"/> class.
+        /// </summary>
+        public LocaleToStringConverter() { }
+
+        /// <summary>
+        /// Writes the name of the specified locale.
+        /// </summary>
+        /// <param name="value">The locale to name.</param>
+        /// <returns>Its name, or the fallback when there is none.</returns>
+        public string Convert(Locale? value)
+        {
+            if (value == null) return _fallback;
+
+            var culture = value.Identifier.CultureInfo;
+            if (culture is null) return value.LocaleName;
+
+            return _nativeName ? culture.NativeName : culture.EnglishName;
+        }
+    }
+}
+#endif

--- a/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Unity/Runtime/Converters/Localizations/LocaleToStringConverter.cs
+++ b/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Unity/Runtime/Converters/Localizations/LocaleToStringConverter.cs
@@ -20,9 +20,6 @@ namespace Aspid.MVVM.StarterKit
         [Tooltip("Shown when there is no locale.")]
         [SerializeField] private string _fallback = string.Empty;
 
-        /// <summary>
-        /// Initializes a new instance of the <see cref="LocaleToStringConverter"/> class.
-        /// </summary>
         public LocaleToStringConverter() { }
 
         /// <summary>

--- a/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Unity/Runtime/Converters/Localizations/LocaleToStringConverter.cs.meta
+++ b/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Unity/Runtime/Converters/Localizations/LocaleToStringConverter.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 606bfb5263a5fdfbb5306228cf180790

--- a/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Unity/Runtime/Converters/Localizations/LocalizedEnumConverter.cs
+++ b/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Unity/Runtime/Converters/Localizations/LocalizedEnumConverter.cs
@@ -28,9 +28,6 @@ namespace Aspid.MVVM.StarterKit
         [Tooltip("Show the member name when it has no entry.")]
         [SerializeField] private bool _fallbackToName = true;
 
-        /// <summary>
-        /// Initializes a new instance of the <see cref="LocalizedEnumConverter{TEnum}"/> class.
-        /// </summary>
         public LocalizedEnumConverter() { }
 
         /// <summary>

--- a/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Unity/Runtime/Converters/Localizations/LocalizedEnumConverter.cs
+++ b/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Unity/Runtime/Converters/Localizations/LocalizedEnumConverter.cs
@@ -1,0 +1,55 @@
+#if ASPID_MVVM_UNITY_LOCALIZATION_INTEGRATION
+#nullable enable
+using System;
+using UnityEngine;
+using UnityEngine.Localization;
+
+// ReSharper disable once CheckNamespace
+namespace Aspid.MVVM.StarterKit
+{
+    /// <summary>
+    /// Looks an enum member's name up in a localization table.
+    /// </summary>
+    /// <typeparam name="TEnum">The enum type being localized.</typeparam>
+    /// <remarks>
+    /// State, rarity and difficulty names, keyed by member name with an authored prefix — so adding a
+    /// member adds a key rather than a switch branch.
+    /// </remarks>
+    [Serializable]
+    public sealed class LocalizedEnumConverter<TEnum> : IConverter<TEnum, string>
+        where TEnum : struct, Enum
+    {
+        [Tooltip("The string table the keys are looked up in.")]
+        [SerializeField] private LocalizedStringTable _table = new();
+
+        [Tooltip("Placed before the member name to form the key.")]
+        [SerializeField] private string _keyPrefix = string.Empty;
+
+        [Tooltip("Show the member name when it has no entry.")]
+        [SerializeField] private bool _fallbackToName = true;
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="LocalizedEnumConverter{TEnum}"/> class.
+        /// </summary>
+        public LocalizedEnumConverter() { }
+
+        /// <summary>
+        /// Looks the specified member up.
+        /// </summary>
+        /// <param name="value">The member to localize.</param>
+        /// <returns>The localized text, or the member name when it has no entry.</returns>
+        public string Convert(TEnum value)
+        {
+            var name = Enum.GetName(typeof(TEnum), value) ?? value.ToString();
+            var key = _keyPrefix + name;
+
+            var table = _table.GetTable();
+            var entry = table?.GetEntry(key);
+
+            if (entry is not null) return entry.GetLocalizedString();
+
+            return _fallbackToName ? name : key;
+        }
+    }
+}
+#endif

--- a/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Unity/Runtime/Converters/Localizations/LocalizedEnumConverter.cs.meta
+++ b/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Unity/Runtime/Converters/Localizations/LocalizedEnumConverter.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: bced7aadbf38dd9eb4facb9f420ba241

--- a/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Unity/Runtime/Converters/Localizations/LocalizedNumberConverter.cs
+++ b/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Unity/Runtime/Converters/Localizations/LocalizedNumberConverter.cs
@@ -21,14 +21,8 @@ namespace Aspid.MVVM.StarterKit
         [Tooltip("A standard numeric format string.")]
         [SerializeField] private string _format = "N0";
 
-        /// <summary>
-        /// Initializes a new instance of the <see cref="LocalizedNumberConverter"/> class.
-        /// </summary>
         public LocalizedNumberConverter() { }
 
-        /// <summary>
-        /// Initializes a new instance of the <see cref="LocalizedNumberConverter"/> class.
-        /// </summary>
         /// <param name="format">A standard numeric format string.</param>
         public LocalizedNumberConverter(string format)
         {

--- a/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Unity/Runtime/Converters/Localizations/LocalizedNumberConverter.cs
+++ b/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Unity/Runtime/Converters/Localizations/LocalizedNumberConverter.cs
@@ -1,0 +1,53 @@
+#if ASPID_MVVM_UNITY_LOCALIZATION_INTEGRATION
+#nullable enable
+using System;
+using UnityEngine;
+using UnityEngine.Localization.Settings;
+
+// ReSharper disable once CheckNamespace
+namespace Aspid.MVVM.StarterKit
+{
+    /// <summary>
+    /// Formats a number with the culture of the selected locale.
+    /// </summary>
+    /// <remarks>
+    /// <see cref="CultureInfoMode"/> can name the device's culture but not the game's — and a player
+    /// who chose German inside a game running on an English device expects German numbers. This is
+    /// the option that mode cannot express.
+    /// </remarks>
+    [Serializable]
+    public sealed class LocalizedNumberConverter : IConverter<double, string>
+    {
+        [Tooltip("A standard numeric format string.")]
+        [SerializeField] private string _format = "N0";
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="LocalizedNumberConverter"/> class.
+        /// </summary>
+        public LocalizedNumberConverter() { }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="LocalizedNumberConverter"/> class.
+        /// </summary>
+        /// <param name="format">A standard numeric format string.</param>
+        public LocalizedNumberConverter(string format)
+        {
+            _format = format;
+        }
+
+        /// <summary>
+        /// Formats the specified number with the selected locale's culture.
+        /// </summary>
+        /// <param name="value">The number to format.</param>
+        /// <returns>The formatted number.</returns>
+        public string Convert(double value)
+        {
+            var culture = LocalizationSettings.SelectedLocaleAsync.IsDone
+                ? LocalizationSettings.SelectedLocale?.Identifier.CultureInfo
+                : null;
+
+            return value.ToString(_format, culture ?? System.Globalization.CultureInfo.CurrentCulture);
+        }
+    }
+}
+#endif

--- a/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Unity/Runtime/Converters/Localizations/LocalizedNumberConverter.cs.meta
+++ b/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Unity/Runtime/Converters/Localizations/LocalizedNumberConverter.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: def31362e0e50193e4a7959d09df0c14

--- a/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Unity/Runtime/Converters/Localizations/LocalizedStringConverter.cs
+++ b/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Unity/Runtime/Converters/Localizations/LocalizedStringConverter.cs
@@ -11,13 +11,8 @@ namespace Aspid.MVVM.StarterKit
     /// Looks a key up in a localization table.
     /// </summary>
     /// <remarks>
-    /// The package has localized binders, but they are a separate path — a localized label cannot
-    /// also be truncated, recased or wrapped in rich text, because those are converters and the
-    /// localized binder has no converter slot. As a converter, localization joins the same chain as
-    /// everything else.
-    /// <para>
-    /// Only compiled when <c>com.unity.localization</c> is installed.
-    /// </para>
+    /// Only compiled when <c>com.unity.localization</c> is installed. Unlike the localized binders,
+    /// localization here joins the same converter chain as truncation, casing and rich text.
     /// </remarks>
     [Serializable]
     public sealed class LocalizedStringConverter : IConverterString

--- a/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Unity/Runtime/Converters/Localizations/LocalizedStringConverter.cs
+++ b/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Unity/Runtime/Converters/Localizations/LocalizedStringConverter.cs
@@ -26,9 +26,6 @@ namespace Aspid.MVVM.StarterKit
         [Tooltip("A composite format for a missing entry: {0} is the key.")]
         [SerializeField] private string _missingFormat = "#{0}#";
 
-        /// <summary>
-        /// Initializes a new instance of the <see cref="LocalizedStringConverter"/> class.
-        /// </summary>
         public LocalizedStringConverter() { }
 
         /// <summary>

--- a/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Unity/Runtime/Converters/Localizations/LocalizedStringConverter.cs
+++ b/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Unity/Runtime/Converters/Localizations/LocalizedStringConverter.cs
@@ -1,0 +1,62 @@
+#if ASPID_MVVM_UNITY_LOCALIZATION_INTEGRATION
+#nullable enable
+using System;
+using UnityEngine;
+using UnityEngine.Localization;
+
+// ReSharper disable once CheckNamespace
+namespace Aspid.MVVM.StarterKit
+{
+    /// <summary>
+    /// Looks a key up in a localization table.
+    /// </summary>
+    /// <remarks>
+    /// The package has localized binders, but they are a separate path — a localized label cannot
+    /// also be truncated, recased or wrapped in rich text, because those are converters and the
+    /// localized binder has no converter slot. As a converter, localization joins the same chain as
+    /// everything else.
+    /// <para>
+    /// Only compiled when <c>com.unity.localization</c> is installed.
+    /// </para>
+    /// </remarks>
+    [Serializable]
+    public sealed class LocalizedStringConverter : IConverterString
+    {
+        [Tooltip("The string table the key is looked up in.")]
+        [SerializeField] private LocalizedStringTable _table = new();
+
+        [Tooltip("Show the key itself when it has no entry, rather than the format below.")]
+        [SerializeField] private bool _fallbackToKey = true;
+
+        [Tooltip("A composite format for a missing entry: {0} is the key.")]
+        [SerializeField] private string _missingFormat = "#{0}#";
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="LocalizedStringConverter"/> class.
+        /// </summary>
+        public LocalizedStringConverter() { }
+
+        /// <summary>
+        /// Looks the specified key up.
+        /// </summary>
+        /// <param name="value">The key to look up.</param>
+        /// <returns>
+        /// The localized text, the key itself, or the missing format — whichever the settings call
+        /// for. A blank key comes back unchanged.
+        /// </returns>
+        public string? Convert(string? value)
+        {
+            if (string.IsNullOrEmpty(value)) return value;
+
+            var table = _table.GetTable();
+            var entry = table?.GetEntry(value);
+
+            if (entry is not null) return entry.GetLocalizedString();
+
+            return _fallbackToKey || string.IsNullOrEmpty(_missingFormat)
+                ? value
+                : string.Format(_missingFormat, value);
+        }
+    }
+}
+#endif

--- a/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Unity/Runtime/Converters/Localizations/LocalizedStringConverter.cs.meta
+++ b/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Unity/Runtime/Converters/Localizations/LocalizedStringConverter.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 599dd4a4bdd944e95a8a3f481a6deaf1

--- a/Aspid.MVVM/Packages/tech.aspid.mvvm/Tests/Editor/Converters/Strings/ParseConverterTests.cs
+++ b/Aspid.MVVM/Packages/tech.aspid.mvvm/Tests/Editor/Converters/Strings/ParseConverterTests.cs
@@ -1,0 +1,139 @@
+using System;
+using System.Threading;
+using NUnit.Framework;
+using System.Globalization;
+
+namespace Aspid.MVVM.StarterKit.Tests
+{
+    /// <summary>
+    /// Coverage for the parsing converters — the direction from text back into a value.
+    /// </summary>
+    /// <remarks>
+    /// Parsing currently lives inside <c>InputFieldBinder</c>, hard-coded: no culture, no fallback,
+    /// and a failed parse silently swallows the event. These make those decisions authorable, and the
+    /// failure rows below are the ones the binder gets wrong today.
+    /// </remarks>
+    [TestFixture]
+    internal sealed class ParseConverterTests
+    {
+        private CultureInfo _previous;
+
+        [SetUp]
+        public void UseInvariantCulture()
+        {
+            _previous = Thread.CurrentThread.CurrentCulture;
+            Thread.CurrentThread.CurrentCulture = CultureInfo.InvariantCulture;
+        }
+
+        [TearDown]
+        public void RestoreCulture() =>
+            Thread.CurrentThread.CurrentCulture = _previous;
+
+        [TestCase("42", 42)]
+        [TestCase("-7", -7)]
+        [TestCase("", 0)]
+        [TestCase(null, 0)]
+        [TestCase("abc", 0)]
+        [TestCase("1.5", 0)]
+        public void StringToInt_ReadsOrFallsBack(string value, int expected) =>
+            Assert.AreEqual(expected, new StringToIntConverter().Convert(value));
+
+        [Test]
+        public void StringToInt_UsesTheAuthoredFallback() =>
+            Assert.AreEqual(-1, new StringToIntConverter(-1).Convert("nonsense"));
+
+        [Test]
+        public void StringToInt_RoundTrips()
+        {
+            var converter = new StringToIntConverter();
+
+            Assert.AreEqual(42, converter.Convert(converter.ConvertBack(42)));
+        }
+
+        [Test]
+        public void StringToLong_Reads() =>
+            Assert.AreEqual(9_000_000_000L, new StringToLongConverter().Convert("9000000000"));
+
+        [TestCase("1.5", 1.5f)]
+        [TestCase("-0.25", -0.25f)]
+        [TestCase("abc", 0f)]
+        public void StringToFloat_ReadsOrFallsBack(string value, float expected) =>
+            Assert.AreEqual(expected, new StringToFloatConverter().Convert(value), 1e-5f);
+
+        // A German player typing "1,5" means one and a half; reading it as invariant gives fifteen
+        // or nothing at all.
+        [Test]
+        public void StringToFloat_HonoursTheCulture()
+        {
+            var german = new StringToFloatConverter(0f, CultureInfoMode.CurrentCulture);
+            var previous = Thread.CurrentThread.CurrentCulture;
+
+            try
+            {
+                Thread.CurrentThread.CurrentCulture = CultureInfo.GetCultureInfo("de-DE");
+                Assert.AreEqual(1.5f, german.Convert("1,5"), 1e-5f);
+            }
+            finally
+            {
+                Thread.CurrentThread.CurrentCulture = previous;
+            }
+        }
+
+        [TestCase("true", true)]
+        [TestCase("TRUE", true)]
+        [TestCase("1", true)]
+        [TestCase("yes", true)]
+        [TestCase("on", true)]
+        [TestCase("false", false)]
+        [TestCase("0", false)]
+        [TestCase("", false)]
+        [TestCase(null, false)]
+        public void StringToBool_ReadsTheUsualSpellings(string value, bool expected) =>
+            Assert.AreEqual(expected, new StringToBoolParseConverter().Convert(value));
+
+        [Test]
+        public void StringToBool_TakesAuthoredSpellings() =>
+            Assert.IsTrue(new StringToBoolParseConverter(new[] { "да" }).Convert("ДА"));
+
+        [TestCase("Rain", Weather.Rain)]
+        [TestCase("rain", Weather.Rain)]
+        [TestCase("nonsense", Weather.Clear)]
+        [TestCase("", Weather.Clear)]
+        public void StringToEnum_ReadsTheMember(string value, Weather expected) =>
+            Assert.AreEqual(expected, new StringToEnumConverter<Weather>(Weather.Clear).Convert(value));
+
+        // Enum.TryParse accepts a bare number and hands back an undeclared member for it, which is
+        // rarely what a name-shaped input means.
+        [Test]
+        public void StringToEnum_RejectsANumberThatNamesNoMember() =>
+            Assert.AreEqual(Weather.Clear, new StringToEnumConverter<Weather>(Weather.Clear).Convert("99"));
+
+        [Test]
+        public void StringToEnum_RoundTrips()
+        {
+            var converter = new StringToEnumConverter<Weather>(Weather.Clear);
+
+            Assert.AreEqual(Weather.Snow, converter.Convert(converter.ConvertBack(Weather.Snow)));
+        }
+
+        [Test]
+        public void StringToDateTime_ReadsAnExactFormat() =>
+            Assert.AreEqual(
+                new DateTime(2024, 12, 25),
+                new StringToDateTimeConverter("dd.MM.yyyy").Convert("25.12.2024"));
+
+        [Test]
+        public void StringToDateTime_WrongFormatGivesTheFallback()
+        {
+            var fallback = new DateTime(2000, 1, 1);
+
+            Assert.AreEqual(
+                fallback,
+                new StringToDateTimeConverter("dd.MM.yyyy", fallback).Convert("2024-12-25"));
+        }
+
+        [Test]
+        public void StringToDateTime_BlankGivesTheFallback() =>
+            Assert.AreEqual(default(DateTime), new StringToDateTimeConverter().Convert(null));
+    }
+}

--- a/Aspid.MVVM/Packages/tech.aspid.mvvm/Tests/Editor/Converters/Strings/ParseConverterTests.cs.meta
+++ b/Aspid.MVVM/Packages/tech.aspid.mvvm/Tests/Editor/Converters/Strings/ParseConverterTests.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 57b52ffc204e74e2a97cd6b500e72c3c


### PR DESCRIPTION
✨ Phase 3 wave 3.7 — the last catalogue wave. Parsing lived hard-coded inside `InputFieldBinder`: no culture, no fallback, and a failed `long.TryParse` returned out of the whole method, swallowing float and double events.

## Summary

- ✨ `StringToIntConverter`, `StringToLongConverter`, `StringToFloatConverter`, `StringToBoolParseConverter`, `StringToEnumConverter<TEnum>`, `StringToDateTimeConverter`.
- ✨ Behind the localization version define: `LocalizedStringConverter`, `LocalizedNumberConverter`, `LocalizedEnumConverter<TEnum>`, `LocaleToStringConverter`.
- 📝 `LocalizedNumberConverter` covers what `CultureInfoMode` cannot — the game's *selected* locale rather than the device's.
- ✅ Local run: 609 total, 607 passed, 0 failed, 2 skipped.

## Notes for review

- ⚠️ **These have nowhere to go on a binder yet**, and the summaries say so: the binder's converter field is same-type, so a cross-type two-way converter does not fit — adding that slot is a binder change and belongs with one.
- 📝 `StringToEnumConverter` rejects a bare number, because `Enum.TryParse` accepts `"99"` and hands back an undeclared member — a stale numeric code would silently become a state that does not exist.
- 📝 **Wave 3.8 is deliberately not done**: it generates marker interfaces that Phase 5 step 5.3 then deletes, so the underlying need is better met after the markers are gone.

<details>
<summary>🇷🇺 Описание на русском</summary>

✨ Волна 3.7 Фазы 3 — последняя волна каталога. Парсинг был зашит внутри `InputFieldBinder`: без культуры, без отката, а провалившийся `long.TryParse` выходил из всего метода, проглатывая float- и double-события.

## Итог

- ✨ `StringToIntConverter`, `StringToLongConverter`, `StringToFloatConverter`, `StringToBoolParseConverter`, `StringToEnumConverter<TEnum>`, `StringToDateTimeConverter`.
- ✨ За version-define локализации: `LocalizedStringConverter`, `LocalizedNumberConverter`, `LocalizedEnumConverter<TEnum>`, `LocaleToStringConverter`.
- 📝 `LocalizedNumberConverter` покрывает то, что `CultureInfoMode` выразить не может, — *выбранную в игре* локаль, а не локаль устройства.
- ✅ Локальный прогон: 609 всего, 607 прошло, 0 упало, 2 пропущено.

## Заметки для ревью

- ⚠️ **Им пока некуда встать на биндере**, и в summary это сказано: конвертерное поле биндера однотипное, поэтому кросс-типовой двусторонний конвертер туда не помещается — добавление такого слота это правка биндеров.
- 📝 `StringToEnumConverter` отвергает голое число: `Enum.TryParse` принимает `"99"` и возвращает необъявленный член — устаревший числовой код молча стал бы несуществующим состоянием.
- 📝 **Волна 3.8 намеренно не сделана**: она генерирует маркерные интерфейсы, которые шаг 5.3 Фазы 5 затем удаляет, поэтому настоящую потребность лучше закрывать после удаления маркеров.

</details>

