### PR TITLE
docs(starterkit): give every serialized converter field a tooltip

### DIFF
--- a/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Runtime/Converters/Bools/NumberToBoolConverter.cs
+++ b/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Runtime/Converters/Bools/NumberToBoolConverter.cs
@@ -13,9 +13,11 @@ namespace Aspid.MVVM.StarterKit
         IConverterIntToBool,
         IConverterLongToBool
     {
+        [UnityEngine.Tooltip("How the bound number is compared with the value below.")]
         [UnityEngine.SerializeField]
         private Comparisons _comparison;
 
+        [UnityEngine.Tooltip("The number the bound one is compared against.")]
         [UnityEngine.SerializeField]
         private float _value;
 

--- a/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Runtime/Converters/Bools/ObjectNullToBoolConverter.cs
+++ b/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Runtime/Converters/Bools/ObjectNullToBoolConverter.cs
@@ -9,6 +9,7 @@ namespace Aspid.MVVM.StarterKit
     [Serializable]
     public class ObjectNullToBoolConverter : IConverterObjectToBool
     {
+        [UnityEngine.Tooltip("Invert the result — true when the object is not null.")]
         [UnityEngine.SerializeField]
         private bool _isInvert;
 
@@ -21,7 +22,7 @@ namespace Aspid.MVVM.StarterKit
         /// <summary>
         /// Initializes a new instance of the <see cref="ObjectNullToBoolConverter"/> class.
         /// </summary>
-        /// <param name="isInvert">If <c>true</c>, inverts the result of the null check. Default is <c>false</c>.</param>
+        /// <param name="isInvert">If <see langword="true"/>, inverts the result of the null check. Default is <see langword="false"/>.</param>
         public ObjectNullToBoolConverter(bool isInvert)
         {
             _isInvert = isInvert;
@@ -31,7 +32,7 @@ namespace Aspid.MVVM.StarterKit
         /// Converts an object to boolean based on whether it is null.
         /// </summary>
         /// <param name="value">The object to check.</param>
-        /// <returns><c>true</c> if the value is null (or not null if inverted), otherwise <c>false</c>.</returns>
+        /// <returns><see langword="true"/> if the value is null (or not null if inverted), otherwise <see langword="false"/>.</returns>
         public bool Convert(object? value)
         {
             var isNull = value is null;

--- a/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Runtime/Converters/Composition/ComposeConverter.cs
+++ b/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Runtime/Converters/Composition/ComposeConverter.cs
@@ -18,7 +18,10 @@ namespace Aspid.MVVM.StarterKit
     [Serializable]
     public sealed class ComposeConverter<TFrom, TMid, TTo> : IConverter<TFrom?, TTo?>
     {
+        [Tooltip("Applied to the incoming value. Both links are required.")]
         [SerializeReference] private IConverter<TFrom?, TMid?>? _first;
+
+        [Tooltip("Applied to the result of the first link. Both links are required.")]
         [SerializeReference] private IConverter<TMid?, TTo?>? _second;
 
         public ComposeConverter() { }

--- a/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Runtime/Converters/GenericFuncConverter.cs
+++ b/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Runtime/Converters/GenericFuncConverter.cs
@@ -18,7 +18,7 @@ namespace Aspid.MVVM.StarterKit
         /// Initializes a new instance of the <see cref="GenericFuncConverter{TFrom, TTo}"/> class.
         /// </summary>
         /// <param name="converter">The converter interface implementation to wrap.</param>
-        /// <exception cref="ArgumentNullException">Thrown when <paramref name="converter"/> is <c>null</c>.</exception>
+        /// <exception cref="ArgumentNullException">Thrown when <paramref name="converter"/> is <see langword="null"/>.</exception>
         public GenericFuncConverter(IConverter<TFrom?, TTo?> converter)
             : this(converter.Convert) { }
 
@@ -26,7 +26,7 @@ namespace Aspid.MVVM.StarterKit
         /// Initializes a new instance of the <see cref="GenericFuncConverter{TFrom, TTo}"/> class.
         /// </summary>
         /// <param name="converter">The conversion function.</param>
-        /// <exception cref="ArgumentNullException">Thrown when <paramref name="converter"/> is <c>null</c>.</exception>
+        /// <exception cref="ArgumentNullException">Thrown when <paramref name="converter"/> is <see langword="null"/>.</exception>
         public GenericFuncConverter(Func<TFrom?, TTo?> converter)
         {
             _converter = converter ?? throw new ArgumentNullException(nameof(converter));

--- a/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Runtime/Converters/Numbers/ArithmeticNumberConverter.cs
+++ b/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Runtime/Converters/Numbers/ArithmeticNumberConverter.cs
@@ -22,7 +22,10 @@ namespace Aspid.MVVM.StarterKit
         IConverterLong, IConverterIntToLong, IConverterFloatToLong, IConverterDoubleToLong,
         ITwoWayConverter<double, double>, ITwoWayConverter<float, float>, ITwoWayConverter<int, int>, ITwoWayConverter<long, long>
     {
+        [Tooltip("The number the operation is applied with. Division by zero returns the input unchanged.")]
         [SerializeField] private double _coefficient;
+
+        [Tooltip("The arithmetic applied to the bound number.")]
         [SerializeField] private NumberOperation _operation;
 
         public ArithmeticNumberConverter() { }

--- a/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Runtime/Converters/SequenceConverters.cs
+++ b/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Runtime/Converters/SequenceConverters.cs
@@ -17,6 +17,7 @@ namespace Aspid.MVVM.StarterKit
     public class SequenceConverters<T> : ITwoWayConverter<T, T>
     {
         // ReSharper disable once FieldCanBeMadeReadOnly.Local
+        [Tooltip("The converters applied in order. Empty slots are skipped.")]
         [SerializeReference] private IConverter<T, T>?[] _converters;
 
         public SequenceConverters()

--- a/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Runtime/Converters/Strings/GenericToString.cs
+++ b/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Runtime/Converters/Strings/GenericToString.cs
@@ -18,6 +18,7 @@ namespace Aspid.MVVM.StarterKit
     [Serializable]
     public class GenericToString<TFrom> : IConverter<TFrom?, string?>
     {
+        [Tooltip("A composite format string such as \"{0:F2}\". Note the braces: a bare \"F2\" is a literal.")]
         [SerializeField] private string? _format;
 
         [Tooltip("The culture numbers and dates are formatted with. Defaults to the device locale.")]

--- a/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Runtime/Converters/Strings/StringFormatConverter.cs
+++ b/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Runtime/Converters/Strings/StringFormatConverter.cs
@@ -15,6 +15,7 @@ namespace Aspid.MVVM.StarterKit
     [Serializable]
     public class StringFormatConverter : GenericToString<string>, IConverterString
     {
+        [Tooltip("Apply the format to a blank or null value as well, rather than passing it through.")]
         [SerializeField] private bool _formatEmptyValues;
 
         public StringFormatConverter() { }

--- a/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Unity/Runtime/Converters/Vectors/BoxColliderCentreCombineConverter.cs
+++ b/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Unity/Runtime/Converters/Vectors/BoxColliderCentreCombineConverter.cs
@@ -11,6 +11,7 @@ namespace Aspid.MVVM.StarterKit
     [Serializable]
     public sealed class BoxColliderCentreCombineConverter : Vector3CombineConverter
     {
+        [Tooltip("The collider whose centre the bound vector is combined with.")]
         [SerializeField] private BoxCollider _collider;
 
         /// <summary>

--- a/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Unity/Runtime/Converters/Vectors/BoxColliderSizeCombineConverter.cs
+++ b/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Unity/Runtime/Converters/Vectors/BoxColliderSizeCombineConverter.cs
@@ -11,6 +11,7 @@ namespace Aspid.MVVM.StarterKit
     [Serializable]
     public sealed class BoxColliderSizeCombineConverter : Vector3CombineConverter
     {
+        [Tooltip("The collider whose size the bound vector is combined with.")]
         [SerializeField] private BoxCollider _collider;
 
         /// <summary>

--- a/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Unity/Runtime/Converters/Vectors/CapsuleColliderCentreCombineConverter.cs
+++ b/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Unity/Runtime/Converters/Vectors/CapsuleColliderCentreCombineConverter.cs
@@ -11,6 +11,7 @@ namespace Aspid.MVVM.StarterKit
     [Serializable]
     public sealed class CapsuleColliderCentreCombineConverter : Vector3CombineConverter
     {
+        [Tooltip("The collider whose centre the bound vector is combined with.")]
         [SerializeField] private CapsuleCollider _collider;
 
         /// <summary>

--- a/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Unity/Runtime/Converters/Vectors/RectTransformAnchoredPositionCombineConverter.cs
+++ b/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Unity/Runtime/Converters/Vectors/RectTransformAnchoredPositionCombineConverter.cs
@@ -11,7 +11,9 @@ namespace Aspid.MVVM.StarterKit
     [Serializable]
     public sealed class RectTransformAnchoredPositionCombineConverter : Vector3CombineConverter
     {
+        [Tooltip("The rect transform whose anchored position the bound vector is combined with.")]
         [SerializeField] private RectTransform _transform;
+        [Tooltip("Which space the anchored position is read in.")]
         [SerializeField] private Space _space = Space.World;
 
         /// <summary>

--- a/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Unity/Runtime/Converters/Vectors/SphereColliderCentreCombineConverter.cs
+++ b/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Unity/Runtime/Converters/Vectors/SphereColliderCentreCombineConverter.cs
@@ -11,6 +11,7 @@ namespace Aspid.MVVM.StarterKit
     [Serializable]
     public sealed class SphereColliderCentreCombineConverter : Vector3CombineConverter
     {
+        [Tooltip("The collider whose centre the bound vector is combined with.")]
         [SerializeField] private SphereCollider _collider;
 
         /// <summary>

--- a/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Unity/Runtime/Converters/Vectors/TransformEulerAnglesCombineConverter.cs
+++ b/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Unity/Runtime/Converters/Vectors/TransformEulerAnglesCombineConverter.cs
@@ -11,7 +11,9 @@ namespace Aspid.MVVM.StarterKit
     [Serializable]
     public sealed class TransformEulerAnglesCombineConverter : Vector3CombineConverter
     {
+        [Tooltip("The transform whose Euler angles the bound vector is combined with.")]
         [SerializeField] private Transform _transform;
+        [Tooltip("Which space the angles are read in.")]
         [SerializeField] private Space _space = Space.World;
 
         /// <summary>

--- a/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Unity/Runtime/Converters/Vectors/TransformPositionCombineConverter.cs
+++ b/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Unity/Runtime/Converters/Vectors/TransformPositionCombineConverter.cs
@@ -11,7 +11,9 @@ namespace Aspid.MVVM.StarterKit
     [Serializable]
     public sealed class TransformPositionCombineConverter : Vector3CombineConverter
     {
+        [Tooltip("The transform whose position the bound vector is combined with.")]
         [SerializeField] private Transform _transform;
+        [Tooltip("Which space the position is read in.")]
         [SerializeField] private Space _space = Space.World;
 
         /// <summary>

--- a/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Unity/Runtime/Converters/Vectors/TransformScaleCombineConverter.cs
+++ b/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Unity/Runtime/Converters/Vectors/TransformScaleCombineConverter.cs
@@ -11,6 +11,7 @@ namespace Aspid.MVVM.StarterKit
     [Serializable]
     public sealed class TransformScaleCombineConverter : Vector3CombineConverter
     {
+        [Tooltip("The transform whose local scale the bound vector is combined with.")]
         [SerializeField] private Transform _transform;
 
         /// <summary>

--- a/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Unity/Runtime/Converters/Vectors/Vector2CombineConverter.cs
+++ b/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Unity/Runtime/Converters/Vectors/Vector2CombineConverter.cs
@@ -17,10 +17,13 @@ namespace Aspid.MVVM.StarterKit
     [Serializable]
     public sealed class Vector2CombineConverter
     {
+        [Tooltip("Which components come from the bound vector; the rest come from the reference one.")]
         [SerializeField] private Mode _mode;
 
+        [Tooltip("Applied to the bound vector before the components are selected.")]
         [SerializeReference] private Converter? _preConvertor;
 
+        [Tooltip("Applied to the combined result.")]
         [SerializeReference] private Converter? _postConvertor;
 
         /// <summary>

--- a/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Unity/Runtime/Converters/Vectors/Vector2SubstitutionConverter.cs
+++ b/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Unity/Runtime/Converters/Vectors/Vector2SubstitutionConverter.cs
@@ -12,6 +12,7 @@ namespace Aspid.MVVM.StarterKit
     [Serializable]
     public sealed class Vector2SubstitutionConverter : IConverterVector2
     {
+        [Tooltip("How the components are rearranged.")]
         [SerializeField] private Mode _mode;
 
         /// <summary>

--- a/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Unity/Runtime/Converters/Vectors/Vector2ToVector3Converter.cs
+++ b/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Unity/Runtime/Converters/Vectors/Vector2ToVector3Converter.cs
@@ -11,7 +11,9 @@ namespace Aspid.MVVM.StarterKit
     [Serializable]
     public sealed class Vector2ToVector3Converter : IConverterVector2ToVector3
     {
+        [Tooltip("Which axes of the 3D vector the 2D components are written into.")]
         [SerializeField] private Values _values;
+        [Tooltip("The constant written into the axis the mode leaves out.")]
         [SerializeField] private float _thirdValue;
 
         /// <summary>

--- a/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Unity/Runtime/Converters/Vectors/Vector3CombineConverter.cs
+++ b/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Unity/Runtime/Converters/Vectors/Vector3CombineConverter.cs
@@ -19,10 +19,13 @@ namespace Aspid.MVVM.StarterKit
         IConverterVector3,
         IConverterVector2ToVector3
     {
+        [Tooltip("Which components come from the bound vector; the rest come from the reference one.")]
         [SerializeField] private Mode _mode;
 
+        [Tooltip("Applied to the bound vector before the components are selected.")]
         [SerializeReference] private Converter? _preConvertor;
 
+        [Tooltip("Applied to the combined result.")]
         [SerializeReference] private Converter? _postConvertor;
 
         /// <summary>

--- a/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Unity/Runtime/Converters/Vectors/Vector3SubstitutionConverter.cs
+++ b/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Unity/Runtime/Converters/Vectors/Vector3SubstitutionConverter.cs
@@ -12,6 +12,7 @@ namespace Aspid.MVVM.StarterKit
     [Serializable]
     public sealed class Vector3SubstitutionConverter : IConverterVector3
     {
+        [Tooltip("How the components are rearranged.")]
         [SerializeField] private Mode _mode;
 
         /// <summary>

--- a/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Unity/Runtime/Converters/Vectors/Vector3ToVector2Converter.cs
+++ b/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Unity/Runtime/Converters/Vectors/Vector3ToVector2Converter.cs
@@ -12,6 +12,7 @@ namespace Aspid.MVVM.StarterKit
     [Serializable]
     public sealed class Vector3ToVector2Converter : IConverterVector3ToVector2
     {
+        [Tooltip("Which components of the 3D vector are kept, and in what order.")]
         [SerializeField] private Values _values = Values.XY;
 
         /// <summary>

--- a/Aspid.MVVM/Packages/tech.aspid.mvvm/Tests/Editor/Converters/ConverterInspectorContractTests.cs
+++ b/Aspid.MVVM/Packages/tech.aspid.mvvm/Tests/Editor/Converters/ConverterInspectorContractTests.cs
@@ -1,0 +1,84 @@
+using System;
+using System.Linq;
+using System.Text;
+using UnityEngine;
+using NUnit.Framework;
+using System.Reflection;
+using System.Collections.Generic;
+
+namespace Aspid.MVVM.StarterKit.Tests
+{
+    /// <summary>
+    /// Every serialized field of a converter needs a <see cref="TooltipAttribute"/>.
+    /// </summary>
+    /// <remarks>
+    /// Converters are configured almost entirely through the Inspector, where XML documentation is
+    /// invisible — a tooltip is the only place an explanation reaches the person setting the value.
+    /// The package shipped 33 serialized converter fields and not one tooltip, which made the most
+    /// useful documentation in the package also the missing kind.
+    /// </remarks>
+    [TestFixture]
+    internal sealed class ConverterInspectorContractTests
+    {
+        [Test]
+        public void EverySerializedConverterFieldHasATooltip()
+        {
+            var undocumented = ConverterTypes()
+                .SelectMany(type => SerializedFields(type).Select(field => (type, field)))
+                .Where(pair => pair.field.GetCustomAttribute<TooltipAttribute>(inherit: false) is null)
+                .ToArray();
+
+            Assert.IsEmpty(undocumented, Explain(undocumented));
+        }
+
+        // Guards the check above from passing because the scan stopped finding fields.
+        [Test]
+        public void TheScanSeesTheSerializedFields() =>
+            Assert.That(
+                ConverterTypes().SelectMany(SerializedFields).Count(),
+                Is.GreaterThan(30),
+                "serialized converter fields found");
+
+        private static IEnumerable<Type> ConverterTypes() => new[]
+            {
+                typeof(IConverter).Assembly,
+                typeof(IConverterVector3).Assembly,
+            }
+            .Distinct()
+            .SelectMany(assembly => assembly.GetTypes())
+            .Where(type => !type.IsInterface)
+            .Where(type => typeof(IConverter).IsAssignableFrom(type));
+
+        private static IEnumerable<FieldInfo> SerializedFields(Type type) => type
+            .GetFields(BindingFlags.Instance | BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.DeclaredOnly)
+            .Where(IsSerialized);
+
+        // Unity serializes a public field implicitly, and a private one only when it is marked. A
+        // field marked NonSerialized is state rather than configuration and never reaches the
+        // Inspector.
+        private static bool IsSerialized(FieldInfo field)
+        {
+            if (field.IsDefined(typeof(NonSerializedAttribute), inherit: false)) return false;
+            if (field.IsDefined(typeof(SerializeField), inherit: false)) return true;
+            if (field.IsDefined(typeof(SerializeReference), inherit: false)) return true;
+
+            return field.IsPublic;
+        }
+
+        private static string Explain(IReadOnlyCollection<(Type Type, FieldInfo Field)> undocumented)
+        {
+            if (undocumented.Count == 0) return string.Empty;
+
+            var message = new StringBuilder()
+                .AppendLine("These serialized converter fields have no [Tooltip]. They are configured in")
+                .AppendLine("the Inspector, where XML documentation is invisible, so the tooltip is the")
+                .AppendLine("only explanation their reader will ever see:")
+                .AppendLine();
+
+            foreach (var (type, field) in undocumented)
+                message.Append("  - ").Append(type.Name).Append('.').AppendLine(field.Name);
+
+            return message.ToString();
+        }
+    }
+}

--- a/Aspid.MVVM/Packages/tech.aspid.mvvm/Tests/Editor/Converters/ConverterInspectorContractTests.cs.meta
+++ b/Aspid.MVVM/Packages/tech.aspid.mvvm/Tests/Editor/Converters/ConverterInspectorContractTests.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 2a5b6e94dbd294133a697f2461f90cb1


### PR DESCRIPTION
📝 Audit items 4.1 and 4.7. Converters are configured in the Inspector, where XML docs are invisible — and the package shipped **33 serialized converter fields and not one tooltip**.

## Summary

- 📝 Every serialized converter field now has a `[Tooltip]`.
- ✅ A test walks both StarterKit assemblies and fails on any field that does not, with a count guard so it cannot pass by finding nothing.
- 📝 `<c>true</c>` / `<c>false</c>` / `<c>null</c>` become `<see langword=…/>`, as the project's conventions ask.

## Notes for review

- 📝 The test is the point, not the 33 strings: tooltips rot the way comments do, and the next field added would have arrived without one.
- 📝 `NonSerialized` fields are excluded on purpose (they are state, not configuration); public fields are included, since Unity serializes those implicitly.
- ⚠️ `SequenceConverters._converters` needed a hand — its attribute sits inside an `#if`, so the tooltip goes above the directive to cover both branches.

✅ Local run: 611 total, 609 passed, 0 failed, 2 skipped.

<details>
<summary>🇷🇺 Описание на русском</summary>

📝 Пункты аудита 4.1 и 4.7. Конвертеры настраивают в инспекторе, где XML-доки не видны, — а пакет ехал с **33 сериализуемыми полями конвертеров и ни одним тултипом**.

## Итог

- 📝 У каждого сериализуемого поля конвертера теперь есть `[Tooltip]`.
- ✅ Тест обходит обе сборки StarterKit и валится на любом поле без него, с контролем количества, чтобы не пройти «найдя ничего».
- 📝 `<c>true</c>` / `<c>false</c>` / `<c>null</c>` заменены на `<see langword=…/>` — как требуют конвенции проекта.

## Заметки для ревью

- 📝 Смысл в тесте, а не в 33 строках: тултипы гниют так же, как комментарии, и следующее поле приехало бы без тултипа.
- 📝 Поля `NonSerialized` исключены намеренно (это состояние, а не настройка); публичные включены, потому что Unity сериализует их неявно.
- ⚠️ `SequenceConverters._converters` потребовал ручной правки — его атрибут внутри `#if`, поэтому тултип стоит над директивой и покрывает обе ветки.

✅ Локальный прогон: 611 всего, 609 прошло, 0 упало, 2 пропущено.

</details>

