### PR TITLE
docs(starterkit): group the converters in the type picker

### DIFF
--- a/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Runtime/Converters/Bools/BoolInvertConverter.cs
+++ b/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Runtime/Converters/Bools/BoolInvertConverter.cs
@@ -1,3 +1,4 @@
+using Aspid.FastTools.Types;
 using System;
 
 // ReSharper disable once CheckNamespace
@@ -13,6 +14,7 @@ namespace Aspid.MVVM.StarterKit
     /// <c>_isInvert</c> flag for the same reason; this is the same thing, available to all of them.
     /// </remarks>
     [Serializable]
+    [TypeSelectorDisplay(Group = "Aspid/Bool", Name = "Bool Invert", Tooltip = "Negates a boolean")]
     public sealed class BoolInvertConverter : ITwoWayConverter<bool, bool>
     {
         /// <summary>

--- a/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Runtime/Converters/Bools/BoolLogicConverter.cs
+++ b/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Runtime/Converters/Bools/BoolLogicConverter.cs
@@ -1,3 +1,4 @@
+using Aspid.FastTools.Types;
 using System;
 using UnityEngine;
 
@@ -12,6 +13,7 @@ namespace Aspid.MVVM.StarterKit
     /// but held off in a shipping scene — without the ViewModel knowing the scene exists.
     /// </remarks>
     [Serializable]
+    [TypeSelectorDisplay(Group = "Aspid/Bool", Name = "Bool Logic", Tooltip = "Combines a bound boolean with an authored one")]
     public sealed class BoolLogicConverter : IConverter<bool, bool>
     {
         [Tooltip("How the bound value combines with the operand.")]

--- a/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Runtime/Converters/Bools/BoolToValueConverter.cs
+++ b/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Runtime/Converters/Bools/BoolToValueConverter.cs
@@ -1,3 +1,4 @@
+using Aspid.FastTools.Types;
 using System;
 using UnityEngine;
 
@@ -15,6 +16,7 @@ namespace Aspid.MVVM.StarterKit
     /// string covers what a dozen switcher binders each do for one property.
     /// </remarks>
     [Serializable]
+    [TypeSelectorDisplay(Group = "Aspid/Bool", Name = "Bool To Value", Tooltip = "Picks one of two authored values based on a boolean")]
     public sealed class BoolToValueConverter<T> : IConverter<bool, T>
     {
         [Tooltip("Returned when the bound value is true.")]

--- a/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Runtime/Converters/Bools/NumberToBoolConverter.cs
+++ b/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Runtime/Converters/Bools/NumberToBoolConverter.cs
@@ -1,3 +1,4 @@
+using Aspid.FastTools.Types;
 using System;
 
 // ReSharper disable once CheckNamespace
@@ -7,6 +8,7 @@ namespace Aspid.MVVM.StarterKit
     /// Converts numeric values to boolean based on comparison operations.
     /// </summary>
     [Serializable]
+    [TypeSelectorDisplay(Group = "Aspid/Bool", Name = "Number To Bool", Tooltip = "Converts numeric values to boolean based on comparison operations")]
     public class NumberToBoolConverter :
         IConverterFloatToBool,
         IConverterDoubleToBool,

--- a/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Runtime/Converters/Bools/ObjectNullToBoolConverter.cs
+++ b/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Runtime/Converters/Bools/ObjectNullToBoolConverter.cs
@@ -1,3 +1,4 @@
+using Aspid.FastTools.Types;
 using System;
 
 // ReSharper disable once CheckNamespace
@@ -7,6 +8,7 @@ namespace Aspid.MVVM.StarterKit
     /// Converts object references to boolean based on null check, with optional inversion.
     /// </summary>
     [Serializable]
+    [TypeSelectorDisplay(Group = "Aspid/Bool", Name = "Object Null To Bool", Tooltip = "Converts object references to boolean based on null check, with optional inversion")]
     public class ObjectNullToBoolConverter : IConverterObjectToBool
     {
         [UnityEngine.Tooltip("Invert the result — true when the object is not null.")]

--- a/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Runtime/Converters/Bools/StringEmptyToBoolConverter.cs
+++ b/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Runtime/Converters/Bools/StringEmptyToBoolConverter.cs
@@ -1,3 +1,4 @@
+using Aspid.FastTools.Types;
 using System;
 using UnityEngine;
 
@@ -12,6 +13,7 @@ namespace Aspid.MVVM.StarterKit
     /// means, since a string of spaces is not empty but reads as one.
     /// </remarks>
     [Serializable]
+    [TypeSelectorDisplay(Group = "Aspid/Bool", Name = "String Empty To Bool", Tooltip = "Converts string values to boolean based on empty check, with optional inversion")]
     public class StringEmptyToBoolConverter : IConverterStringToBool
     {
         [Tooltip("What counts as an absent string.")]

--- a/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Runtime/Converters/Bools/StringMatchToBoolConverter.cs
+++ b/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Runtime/Converters/Bools/StringMatchToBoolConverter.cs
@@ -1,3 +1,4 @@
+using Aspid.FastTools.Types;
 using System;
 using UnityEngine;
 
@@ -13,6 +14,7 @@ namespace Aspid.MVVM.StarterKit
     /// benefit.
     /// </remarks>
     [Serializable]
+    [TypeSelectorDisplay(Group = "Aspid/Bool", Name = "String Match To Bool", Tooltip = "Tests a bound string against an authored one")]
     public sealed class StringMatchToBoolConverter : IConverterStringToBool
     {
         [Tooltip("How the bound string is compared with the text below.")]

--- a/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Runtime/Converters/Collections/CollectionAggregateConverter.cs
+++ b/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Runtime/Converters/Collections/CollectionAggregateConverter.cs
@@ -1,3 +1,4 @@
+using Aspid.FastTools.Types;
 using System;
 using UnityEngine;
 using System.Collections.Generic;
@@ -13,6 +14,7 @@ namespace Aspid.MVVM.StarterKit
     /// invalidated whenever the list changes.
     /// </remarks>
     [Serializable]
+    [TypeSelectorDisplay(Group = "Aspid/Collection", Name = "Collection Aggregate", Tooltip = "Reduces a collection of numbers to one")]
     public sealed class CollectionAggregateConverter : IConverter<IEnumerable<float>?, float>
     {
         [Tooltip("What to compute.")]

--- a/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Runtime/Converters/Collections/CollectionContainsToBoolConverter.cs
+++ b/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Runtime/Converters/Collections/CollectionContainsToBoolConverter.cs
@@ -1,3 +1,4 @@
+using Aspid.FastTools.Types;
 using System;
 using UnityEngine;
 using System.Collections.Generic;
@@ -11,6 +12,7 @@ namespace Aspid.MVVM.StarterKit
     /// <typeparam name="T">The type of the items.</typeparam>
     /// <remarks>"Has this achievement", "owns this item".</remarks>
     [Serializable]
+    [TypeSelectorDisplay(Group = "Aspid/Collection", Name = "Collection Contains To Bool", Tooltip = "Reports whether a collection holds a particular item")]
     public sealed class CollectionContainsToBoolConverter<T> : IConverter<IEnumerable<T>?, bool>
     {
         [Tooltip("The item looked for.")]

--- a/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Runtime/Converters/Collections/CollectionCountConverter.cs
+++ b/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Runtime/Converters/Collections/CollectionCountConverter.cs
@@ -1,4 +1,6 @@
+using Aspid.FastTools.Types;
 using System;
+using UnityEngine;
 using System.Collections.Generic;
 
 // ReSharper disable once CheckNamespace
@@ -13,6 +15,7 @@ namespace Aspid.MVVM.StarterKit
     /// step with the list by hand.
     /// </remarks>
     [Serializable]
+    [TypeSelectorDisplay(Group = "Aspid/Collection", Name = "Collection Count", Tooltip = "Counts the items in a collection")]
     public sealed class CollectionCountConverter<T> : IConverter<IReadOnlyCollection<T>?, int>
     {
         /// <summary>

--- a/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Runtime/Converters/Collections/CollectionElementAtConverter.cs
+++ b/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Runtime/Converters/Collections/CollectionElementAtConverter.cs
@@ -1,3 +1,4 @@
+using Aspid.FastTools.Types;
 using System;
 using UnityEngine;
 using System.Collections.Generic;
@@ -11,6 +12,7 @@ namespace Aspid.MVVM.StarterKit
     /// <typeparam name="T">The type of the items.</typeparam>
     /// <remarks>"The leaderboard leader", "next in queue" — one item out of a bound list.</remarks>
     [Serializable]
+    [TypeSelectorDisplay(Group = "Aspid/Collection", Name = "Collection Element At", Tooltip = "Takes one item out of a list by index")]
     public sealed class CollectionElementAtConverter<T> : IConverter<IReadOnlyList<T>?, T?>
     {
         [Tooltip("Which item to take.")]

--- a/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Runtime/Converters/Collections/CollectionEmptyToBoolConverter.cs
+++ b/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Runtime/Converters/Collections/CollectionEmptyToBoolConverter.cs
@@ -1,3 +1,4 @@
+using Aspid.FastTools.Types;
 using System;
 using UnityEngine;
 using System.Collections.Generic;
@@ -11,6 +12,7 @@ namespace Aspid.MVVM.StarterKit
     /// <typeparam name="T">The type of the items.</typeparam>
     /// <remarks>Empty-state placeholders, which previously needed their own boolean property.</remarks>
     [Serializable]
+    [TypeSelectorDisplay(Group = "Aspid/Collection", Name = "Collection Empty To Bool", Tooltip = "Reports whether a collection has anything in it")]
     public sealed class CollectionEmptyToBoolConverter<T> : IConverter<IReadOnlyCollection<T>?, bool>
     {
         [Tooltip("Invert the result — true when the collection has items.")]

--- a/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Runtime/Converters/Collections/ListToStringConverter.cs
+++ b/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Runtime/Converters/Collections/ListToStringConverter.cs
@@ -1,3 +1,4 @@
+using Aspid.FastTools.Types;
 using System;
 using System.Text;
 using UnityEngine;
@@ -15,6 +16,7 @@ namespace Aspid.MVVM.StarterKit
     /// binder pushes on every notification and <c>string.Join</c> would allocate on each one.
     /// </remarks>
     [Serializable]
+    [TypeSelectorDisplay(Group = "Aspid/Collection", Name = "List To String", Tooltip = "Joins a collection into one string")]
     public sealed class ListToStringConverter<T> : IConverter<IEnumerable<T>?, string>
     {
         [Tooltip("Placed between items.")]

--- a/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Runtime/Converters/Composition/CachedConverter.cs
+++ b/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Runtime/Converters/Composition/CachedConverter.cs
@@ -1,3 +1,4 @@
+using Aspid.FastTools.Types;
 using System;
 using UnityEngine;
 using System.Collections.Generic;
@@ -19,6 +20,7 @@ namespace Aspid.MVVM.StarterKit
     /// </para>
     /// </remarks>
     [Serializable]
+    [TypeSelectorDisplay(Group = "Aspid/Composition", Name = "Cached", Tooltip = "Remembers the last conversion and reuses it while the input is unchanged")]
     public sealed class CachedConverter<TFrom, TTo> : IConverter<TFrom?, TTo?>
     {
         [Tooltip("The converter to memoize. When empty, the default value is returned.")]

--- a/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Runtime/Converters/Composition/ComposeConverter.cs
+++ b/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Runtime/Converters/Composition/ComposeConverter.cs
@@ -1,3 +1,4 @@
+using Aspid.FastTools.Types;
 using System;
 using UnityEngine;
 
@@ -16,6 +17,7 @@ namespace Aspid.MVVM.StarterKit
     /// leaves nothing meaningful to return.
     /// </remarks>
     [Serializable]
+    [TypeSelectorDisplay(Group = "Aspid/Composition", Name = "Compose", Tooltip = "Applies two converters in sequence, converting through an intermediate type")]
     public sealed class ComposeConverter<TFrom, TMid, TTo> : IConverter<TFrom?, TTo?>
     {
         [Tooltip("Applied to the incoming value. Both links are required.")]

--- a/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Runtime/Converters/Composition/ConditionalConverter.cs
+++ b/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Runtime/Converters/Composition/ConditionalConverter.cs
@@ -1,3 +1,4 @@
+using Aspid.FastTools.Types;
 using System;
 using UnityEngine;
 
@@ -13,6 +14,7 @@ namespace Aspid.MVVM.StarterKit
     /// configured instance degrades to the identity rather than to an error.
     /// </remarks>
     [Serializable]
+    [TypeSelectorDisplay(Group = "Aspid/Composition", Name = "Conditional", Tooltip = "Routes a value to one of two converters based on a predicate")]
     public sealed class ConditionalConverter<T> : IConverter<T, T>
     {
         [Tooltip("Decides which branch a value takes. When empty, the value passes through unchanged.")]

--- a/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Runtime/Converters/Composition/NullGuardConverter.cs
+++ b/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Runtime/Converters/Composition/NullGuardConverter.cs
@@ -1,3 +1,4 @@
+using Aspid.FastTools.Types;
 using System;
 using UnityEngine;
 
@@ -15,6 +16,7 @@ namespace Aspid.MVVM.StarterKit
     /// Inspector. Wrapping one settles the question at the point of use.
     /// </remarks>
     [Serializable]
+    [TypeSelectorDisplay(Group = "Aspid/Composition", Name = "Null Guard", Tooltip = "Substitutes a fixed result for a  input instead of passing it on")]
     public sealed class NullGuardConverter<TFrom, TTo> : IConverter<TFrom?, TTo?>
     {
         [Tooltip("The converter to run for a non-null value. When empty, the null result is used for every value.")]

--- a/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Runtime/Converters/Composition/PassthroughConverter.cs
+++ b/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Runtime/Converters/Composition/PassthroughConverter.cs
@@ -1,3 +1,4 @@
+using Aspid.FastTools.Types;
 using System;
 
 // ReSharper disable once CheckNamespace
@@ -12,6 +13,7 @@ namespace Aspid.MVVM.StarterKit
     /// deliberate no-op rather than an unfilled slot — and as a neutral element in code.
     /// </remarks>
     [Serializable]
+    [TypeSelectorDisplay(Group = "Aspid/Composition", Name = "Passthrough", Tooltip = "Returns its input unchanged")]
     public sealed class PassthroughConverter<T> : ITwoWayConverter<T, T>
     {
         /// <summary>

--- a/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Runtime/Converters/Composition/SafeConverter.cs
+++ b/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Runtime/Converters/Composition/SafeConverter.cs
@@ -1,3 +1,4 @@
+using Aspid.FastTools.Types;
 using System;
 using UnityEngine;
 
@@ -19,6 +20,7 @@ namespace Aspid.MVVM.StarterKit
     /// </para>
     /// </remarks>
     [Serializable]
+    [TypeSelectorDisplay(Group = "Aspid/Composition", Name = "Safe", Tooltip = "Runs another converter and substitutes a fallback value if it throws")]
     public sealed class SafeConverter<TFrom, TTo> : IConverter<TFrom?, TTo?>
     {
         [Tooltip("The converter to run. When empty, the fallback value is returned.")]

--- a/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Runtime/Converters/Enums/EnumToBoolConverter.cs
+++ b/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Runtime/Converters/Enums/EnumToBoolConverter.cs
@@ -1,3 +1,4 @@
+using Aspid.FastTools.Types;
 using System;
 using UnityEngine;
 
@@ -13,6 +14,7 @@ namespace Aspid.MVVM.StarterKit
     /// ViewModel, one for every state any View cared about.
     /// </remarks>
     [Serializable]
+    [TypeSelectorDisplay(Group = "Aspid/Enum", Name = "Enum To Bool", Tooltip = "Tests an enum value against an authored one")]
     public sealed class EnumToBoolConverter<TEnum> : IConverter<TEnum, bool>
         where TEnum : struct, Enum
     {

--- a/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Runtime/Converters/Enums/EnumToIntConverter.cs
+++ b/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Runtime/Converters/Enums/EnumToIntConverter.cs
@@ -1,3 +1,4 @@
+using Aspid.FastTools.Types;
 using System;
 
 // ReSharper disable once CheckNamespace
@@ -12,6 +13,7 @@ namespace Aspid.MVVM.StarterKit
     /// a conversion the ViewModel had to expose itself.
     /// </remarks>
     [Serializable]
+    [TypeSelectorDisplay(Group = "Aspid/Enum", Name = "Enum To Int", Tooltip = "Converts an enum value to its underlying integer")]
     public sealed class EnumToIntConverter<TEnum> : ITwoWayConverter<TEnum, int>
         where TEnum : struct, Enum
     {

--- a/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Runtime/Converters/Enums/EnumToStringConverter.cs
+++ b/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Runtime/Converters/Enums/EnumToStringConverter.cs
@@ -1,3 +1,4 @@
+using Aspid.FastTools.Types;
 using System;
 using UnityEngine;
 
@@ -14,6 +15,7 @@ namespace Aspid.MVVM.StarterKit
     /// for the same purpose in the Inspector.
     /// </remarks>
     [Serializable]
+    [TypeSelectorDisplay(Group = "Aspid/Enum", Name = "Enum To String", Tooltip = "Converts an enum value to text")]
     public sealed class EnumToStringConverter<TEnum> : IConverter<TEnum, string>
         where TEnum : struct, Enum
     {

--- a/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Runtime/Converters/Enums/EnumToValueConverter.cs
+++ b/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Runtime/Converters/Enums/EnumToValueConverter.cs
@@ -1,3 +1,4 @@
+using Aspid.FastTools.Types;
 using System;
 using System.Collections.Generic;
 using UnityEngine;
@@ -17,6 +18,7 @@ namespace Aspid.MVVM.StarterKit
     /// shared across scenes.
     /// </remarks>
     [Serializable]
+    [TypeSelectorDisplay(Group = "Aspid/Enum", Name = "Enum To Value", Tooltip = "Maps an enum value to an authored value")]
     public sealed class EnumToValueConverter<TEnum, T> : IConverter<TEnum, T>
         where TEnum : struct, Enum
     {

--- a/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Runtime/Converters/Numbers/ArithmeticNumberConverter.cs
+++ b/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Runtime/Converters/Numbers/ArithmeticNumberConverter.cs
@@ -1,3 +1,4 @@
+using Aspid.FastTools.Types;
 using System;
 using UnityEngine;
 
@@ -15,6 +16,7 @@ namespace Aspid.MVVM.StarterKit
     /// input unchanged instead of producing an infinity.
     /// </remarks>
     [Serializable]
+    [TypeSelectorDisplay(Group = "Aspid/Number", Name = "Arithmetic Number", Tooltip = "Converts numeric values by applying arithmetic operations with a coefficient")]
     public class ArithmeticNumberConverter :
         IConverterDouble, IConverterIntToDouble, IConverterLongToDouble, IConverterFloatToDouble,
         IConverterFloat, IConverterIntToFloat, IConverterLongToFloat, IConverterDoubleToFloat,

--- a/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Runtime/Converters/Numbers/ClampNumberConverter.cs
+++ b/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Runtime/Converters/Numbers/ClampNumberConverter.cs
@@ -1,3 +1,4 @@
+using Aspid.FastTools.Types;
 using System;
 using UnityEngine;
 
@@ -13,6 +14,7 @@ namespace Aspid.MVVM.StarterKit
     /// boundary keeps a bad number from becoming a bad frame.
     /// </remarks>
     [Serializable]
+    [TypeSelectorDisplay(Group = "Aspid/Number", Name = "Clamp Number", Tooltip = "Keeps a number inside a range")]
     public sealed class ClampNumberConverter : IConverterFloat
     {
         [Tooltip("The lowest value allowed through.")]

--- a/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Runtime/Converters/Numbers/CountdownProgressConverter.cs
+++ b/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Runtime/Converters/Numbers/CountdownProgressConverter.cs
@@ -1,3 +1,4 @@
+using Aspid.FastTools.Types;
 using System;
 using UnityEngine;
 
@@ -12,6 +13,7 @@ namespace Aspid.MVVM.StarterKit
     /// has to be kept in step with it.
     /// </remarks>
     [Serializable]
+    [TypeSelectorDisplay(Group = "Aspid/Number", Name = "Countdown Progress", Tooltip = "Converts seconds remaining to a 0..1 progress value")]
     public sealed class CountdownProgressConverter : IConverterFloat
     {
         [Tooltip("The full duration, in seconds.")]

--- a/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Runtime/Converters/Numbers/InverseLerpConverter.cs
+++ b/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Runtime/Converters/Numbers/InverseLerpConverter.cs
@@ -1,3 +1,4 @@
+using Aspid.FastTools.Types;
 using System;
 using UnityEngine;
 
@@ -12,6 +13,7 @@ namespace Aspid.MVVM.StarterKit
     /// it actually has instead of a fraction computed for one particular bar.
     /// </remarks>
     [Serializable]
+    [TypeSelectorDisplay(Group = "Aspid/Number", Name = "Inverse Lerp", Tooltip = "Converts a value in a range to its 0..1 position within it")]
     public sealed class InverseLerpConverter : ITwoWayConverter<float, float>
     {
         [Tooltip("The value that maps to 0.")]

--- a/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Runtime/Converters/Numbers/LerpNumberConverter.cs
+++ b/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Runtime/Converters/Numbers/LerpNumberConverter.cs
@@ -1,3 +1,4 @@
+using Aspid.FastTools.Types;
 using System;
 using UnityEngine;
 
@@ -9,6 +10,7 @@ namespace Aspid.MVVM.StarterKit
     /// </summary>
     /// <remarks>The other direction of <see cref="InverseLerpConverter"/>.</remarks>
     [Serializable]
+    [TypeSelectorDisplay(Group = "Aspid/Number", Name = "Lerp Number", Tooltip = "Converts a 0..1 position to a value in a range")]
     public sealed class LerpNumberConverter : ITwoWayConverter<float, float>
     {
         [Tooltip("The value 0 maps to.")]

--- a/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Runtime/Converters/Numbers/NormalizedToPercentConverter.cs
+++ b/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Runtime/Converters/Numbers/NormalizedToPercentConverter.cs
@@ -1,3 +1,4 @@
+using Aspid.FastTools.Types;
 using System;
 using UnityEngine;
 
@@ -8,6 +9,7 @@ namespace Aspid.MVVM.StarterKit
     /// Converts a 0..1 fraction to a percentage.
     /// </summary>
     [Serializable]
+    [TypeSelectorDisplay(Group = "Aspid/Number", Name = "Normalized To Percent", Tooltip = "Converts a 0..1 fraction to a percentage")]
     public sealed class NormalizedToPercentConverter : ITwoWayConverter<float, float>
     {
         [Tooltip("Round the percentage to a whole number.")]

--- a/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Runtime/Converters/Numbers/RemapNumberConverter.cs
+++ b/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Runtime/Converters/Numbers/RemapNumberConverter.cs
@@ -1,3 +1,4 @@
+using Aspid.FastTools.Types;
 using System;
 using UnityEngine;
 
@@ -13,6 +14,7 @@ namespace Aspid.MVVM.StarterKit
     /// a two-link chain, where nobody can see what range it came from.
     /// </remarks>
     [Serializable]
+    [TypeSelectorDisplay(Group = "Aspid/Number", Name = "Remap Number", Tooltip = "Maps a number from one range onto another")]
     public sealed class RemapNumberConverter : ITwoWayConverter<float, float>
     {
         [Tooltip("The low end of the incoming range.")]

--- a/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Runtime/Converters/Numbers/RoundNumberConverter.cs
+++ b/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Runtime/Converters/Numbers/RoundNumberConverter.cs
@@ -1,3 +1,4 @@
+using Aspid.FastTools.Types;
 using System;
 using UnityEngine;
 
@@ -13,6 +14,7 @@ namespace Aspid.MVVM.StarterKit
     /// fires, and a score truncated loses the point the player just earned.
     /// </remarks>
     [Serializable]
+    [TypeSelectorDisplay(Group = "Aspid/Number", Name = "Round Number", Tooltip = "Rounds a number, in a way the caller chooses")]
     public sealed class RoundNumberConverter : IConverterFloat, IConverterFloatToInt
     {
         [Tooltip("Which way to drop the fraction.")]

--- a/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Runtime/Converters/Numbers/SmoothStepConverter.cs
+++ b/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Runtime/Converters/Numbers/SmoothStepConverter.cs
@@ -1,3 +1,4 @@
+using Aspid.FastTools.Types;
 using System;
 using UnityEngine;
 
@@ -8,6 +9,7 @@ namespace Aspid.MVVM.StarterKit
     /// Eases a value between two bounds with <see cref="Mathf.SmoothStep"/>.
     /// </summary>
     [Serializable]
+    [TypeSelectorDisplay(Group = "Aspid/Number", Name = "Smooth Step", Tooltip = "Eases a value between two bounds with ")]
     public sealed class SmoothStepConverter : IConverterFloat
     {
         [Tooltip("The value that maps to 0.")]

--- a/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Runtime/Converters/Numbers/SnapToStepConverter.cs
+++ b/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Runtime/Converters/Numbers/SnapToStepConverter.cs
@@ -1,3 +1,4 @@
+using Aspid.FastTools.Types;
 using System;
 using UnityEngine;
 
@@ -12,6 +13,7 @@ namespace Aspid.MVVM.StarterKit
     /// ViewModel means the ViewModel knows how the control is drawn.
     /// </remarks>
     [Serializable]
+    [TypeSelectorDisplay(Group = "Aspid/Number", Name = "Snap To Step", Tooltip = "Snaps a number to the nearest multiple of a step")]
     public sealed class SnapToStepConverter : IConverterFloat
     {
         [Tooltip("The size of one step. A step of zero passes the value through.")]

--- a/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Runtime/Converters/Numbers/UnaryMathConverter.cs
+++ b/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Runtime/Converters/Numbers/UnaryMathConverter.cs
@@ -1,3 +1,4 @@
+using Aspid.FastTools.Types;
 using System;
 using UnityEngine;
 
@@ -14,6 +15,7 @@ namespace Aspid.MVVM.StarterKit
     /// is merely wrong.
     /// </remarks>
     [Serializable]
+    [TypeSelectorDisplay(Group = "Aspid/Number", Name = "Unary Math", Tooltip = "Applies a single-argument mathematical function")]
     public sealed class UnaryMathConverter : IConverterFloat
     {
         [Tooltip("The function to apply.")]

--- a/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Runtime/Converters/Numbers/WrapNumberConverter.cs
+++ b/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Runtime/Converters/Numbers/WrapNumberConverter.cs
@@ -1,3 +1,4 @@
+using Aspid.FastTools.Types;
 using System;
 using UnityEngine;
 
@@ -12,6 +13,7 @@ namespace Aspid.MVVM.StarterKit
     /// page, a progress bar that fills repeatedly.
     /// </remarks>
     [Serializable]
+    [TypeSelectorDisplay(Group = "Aspid/Number", Name = "Wrap Number", Tooltip = "Folds a number back into a range instead of clamping it")]
     public sealed class WrapNumberConverter : IConverterFloat
     {
         [Tooltip("How to fold a value that leaves the range.")]

--- a/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Runtime/Converters/Objects/EqualityToBoolConverter.cs
+++ b/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Runtime/Converters/Objects/EqualityToBoolConverter.cs
@@ -1,3 +1,4 @@
+using Aspid.FastTools.Types;
 using System;
 using UnityEngine;
 using System.Collections.Generic;
@@ -14,6 +15,7 @@ namespace Aspid.MVVM.StarterKit
     /// selected item?", "is this the equipped weapon?". Comparison uses the type's own equality.
     /// </remarks>
     [Serializable]
+    [TypeSelectorDisplay(Group = "Aspid/Object", Name = "Equality To Bool", Tooltip = "Tests a bound value against an authored one")]
     public sealed class EqualityToBoolConverter<T> : IConverter<T, bool>
     {
         [Tooltip("The value the bound one is compared against.")]

--- a/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Runtime/Converters/Objects/IndexToValueConverter.cs
+++ b/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Runtime/Converters/Objects/IndexToValueConverter.cs
@@ -1,3 +1,4 @@
+using Aspid.FastTools.Types;
 using System;
 using UnityEngine;
 
@@ -13,6 +14,7 @@ namespace Aspid.MVVM.StarterKit
     /// set of authored assets. Doing it in the ViewModel means the ViewModel holds sprites.
     /// </remarks>
     [Serializable]
+    [TypeSelectorDisplay(Group = "Aspid/Object", Name = "Index To Value", Tooltip = "Picks a value out of an authored array by index")]
     public sealed class IndexToValueConverter<T> : IConverter<int, T>
     {
         [Tooltip("The values to pick from, in order.")]

--- a/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Runtime/Converters/Objects/NullCoalesceConverter.cs
+++ b/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Runtime/Converters/Objects/NullCoalesceConverter.cs
@@ -1,3 +1,4 @@
+using Aspid.FastTools.Types;
 using System;
 using UnityEngine;
 
@@ -14,6 +15,7 @@ namespace Aspid.MVVM.StarterKit
     /// second property on the ViewModel.
     /// </remarks>
     [Serializable]
+    [TypeSelectorDisplay(Group = "Aspid/Object", Name = "Null Coalesce", Tooltip = "Substitutes an authored value for a null one")]
     public sealed class NullCoalesceConverter<T> : IConverter<T?, T>
         where T : class
     {

--- a/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Runtime/Converters/SequenceConverters.cs
+++ b/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Runtime/Converters/SequenceConverters.cs
@@ -1,3 +1,4 @@
+using Aspid.FastTools.Types;
 using System;
 using UnityEngine;
 
@@ -14,6 +15,7 @@ namespace Aspid.MVVM.StarterKit
     /// skipped rather than treated as an error.
     /// </remarks>
     [Serializable]
+    [TypeSelectorDisplay(Group = "Aspid", Name = "Sequence", Tooltip = "Chains multiple converters together, applying them sequentially to a value")]
     public class SequenceConverters<T> : ITwoWayConverter<T, T>
     {
         // ReSharper disable once FieldCanBeMadeReadOnly.Local

--- a/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Runtime/Converters/Strings/AbbreviatedNumberConverter.cs
+++ b/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Runtime/Converters/Strings/AbbreviatedNumberConverter.cs
@@ -1,3 +1,4 @@
+using Aspid.FastTools.Types;
 using System;
 using UnityEngine;
 using System.Globalization;
@@ -14,6 +15,7 @@ namespace Aspid.MVVM.StarterKit
     /// the next one.
     /// </remarks>
     [Serializable]
+    [TypeSelectorDisplay(Group = "Aspid/String", Name = "Abbreviated Number", Tooltip = "Shortens a large number to a suffixed form: 1 234 567 becomes 1.23M")]
     public sealed class AbbreviatedNumberConverter : IConverter<double, string>
     {
         [Tooltip("The suffix for each power of a thousand, starting with none.")]

--- a/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Runtime/Converters/Strings/ByteSizeConverter.cs
+++ b/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Runtime/Converters/Strings/ByteSizeConverter.cs
@@ -1,3 +1,4 @@
+using Aspid.FastTools.Types;
 using System;
 using UnityEngine;
 
@@ -8,6 +9,7 @@ namespace Aspid.MVVM.StarterKit
     /// Formats a byte count as a readable size.
     /// </summary>
     [Serializable]
+    [TypeSelectorDisplay(Group = "Aspid/String", Name = "Byte Size", Tooltip = "Formats a byte count as a readable size")]
     public sealed class ByteSizeConverter : IConverter<long, string>
     {
         [Tooltip("Use 1024 as the step and KiB-style units rather than 1000 and KB.")]

--- a/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Runtime/Converters/Strings/ConcatStringConverter.cs
+++ b/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Runtime/Converters/Strings/ConcatStringConverter.cs
@@ -1,3 +1,4 @@
+using Aspid.FastTools.Types;
 using System;
 using UnityEngine;
 
@@ -12,6 +13,7 @@ namespace Aspid.MVVM.StarterKit
     /// than decorating nothing.
     /// </remarks>
     [Serializable]
+    [TypeSelectorDisplay(Group = "Aspid/String", Name = "Concat String", Tooltip = "Wraps a string in authored text")]
     public sealed class ConcatStringConverter : IConverterString
     {
         [Tooltip("Placed before the value.")]

--- a/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Runtime/Converters/Strings/CurrencyConverter.cs
+++ b/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Runtime/Converters/Strings/CurrencyConverter.cs
@@ -1,3 +1,4 @@
+using Aspid.FastTools.Types;
 using System;
 using UnityEngine;
 
@@ -12,6 +13,7 @@ namespace Aspid.MVVM.StarterKit
     /// only knows the player's locale.
     /// </remarks>
     [Serializable]
+    [TypeSelectorDisplay(Group = "Aspid/String", Name = "Currency", Tooltip = "Formats a number as an amount of currency")]
     public sealed class CurrencyConverter : IConverter<double, string>
     {
         [Tooltip("The symbol placed beside the amount.")]

--- a/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Runtime/Converters/Strings/DefaultStringConverter.cs
+++ b/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Runtime/Converters/Strings/DefaultStringConverter.cs
@@ -1,3 +1,4 @@
+using Aspid.FastTools.Types;
 using System;
 using UnityEngine;
 
@@ -12,6 +13,7 @@ namespace Aspid.MVVM.StarterKit
     /// know what the empty state looks like.
     /// </remarks>
     [Serializable]
+    [TypeSelectorDisplay(Group = "Aspid/String", Name = "Default String", Tooltip = "Substitutes a placeholder for a blank string")]
     public sealed class DefaultStringConverter : IConverterString
     {
         [Tooltip("Shown when the bound string is blank.")]

--- a/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Runtime/Converters/Strings/GenericToString.cs
+++ b/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Runtime/Converters/Strings/GenericToString.cs
@@ -1,3 +1,4 @@
+using Aspid.FastTools.Types;
 using System;
 using UnityEngine;
 using System.Globalization;
@@ -16,6 +17,7 @@ namespace Aspid.MVVM.StarterKit
     /// <see cref="object.ToString"/> instead of throwing into the binder.
     /// </remarks>
     [Serializable]
+    [TypeSelectorDisplay(Group = "Aspid/String", Name = "Generic To String", Tooltip = "Generic converter that transforms values to strings with optional formatting")]
     public class GenericToString<TFrom> : IConverter<TFrom?, string?>
     {
         [Tooltip("A composite format string such as \"{0:F2}\". Note the braces: a bare \"F2\" is a literal.")]

--- a/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Runtime/Converters/Strings/MaskStringConverter.cs
+++ b/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Runtime/Converters/Strings/MaskStringConverter.cs
@@ -1,3 +1,4 @@
+using Aspid.FastTools.Types;
 using System;
 using UnityEngine;
 
@@ -9,6 +10,7 @@ namespace Aspid.MVVM.StarterKit
     /// </summary>
     /// <remarks>Account identifiers, e-mail addresses and promo codes shown in a settings screen.</remarks>
     [Serializable]
+    [TypeSelectorDisplay(Group = "Aspid/String", Name = "Mask String", Tooltip = "Hides the middle of a string, keeping a few characters at each end")]
     public sealed class MaskStringConverter : IConverterString
     {
         [Tooltip("How many characters to leave visible at the start.")]

--- a/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Runtime/Converters/Strings/NumberFormatConverter.cs
+++ b/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Runtime/Converters/Strings/NumberFormatConverter.cs
@@ -1,3 +1,4 @@
+using Aspid.FastTools.Types;
 using System;
 using UnityEngine;
 
@@ -13,6 +14,7 @@ namespace Aspid.MVVM.StarterKit
     /// the specifier everyone expects — the one on <see cref="int.ToString(string)"/>.
     /// </remarks>
     [Serializable]
+    [TypeSelectorDisplay(Group = "Aspid/String", Name = "Number Format", Tooltip = "Formats a number with a standard .NET format string")]
     public sealed class NumberFormatConverter :
         IConverter<float, string>,
         IConverter<double, string>,

--- a/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Runtime/Converters/Strings/ObjectToStringConverter.cs
+++ b/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Runtime/Converters/Strings/ObjectToStringConverter.cs
@@ -1,3 +1,4 @@
+using Aspid.FastTools.Types;
 using System;
 
 // ReSharper disable once CheckNamespace
@@ -7,6 +8,7 @@ namespace Aspid.MVVM.StarterKit
     /// <see cref="GenericToString{TFrom}"/> for any object, with optional formatting.
     /// </summary>
     [Serializable]
+    [TypeSelectorDisplay(Group = "Aspid/String", Name = "Object To String", Tooltip = "for any object, with optional formatting")]
     public sealed class ObjectToStringConverter : GenericToString<object?>, IConverterObjectToString
     {
         public ObjectToStringConverter() { }

--- a/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Runtime/Converters/Strings/OrdinalConverter.cs
+++ b/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Runtime/Converters/Strings/OrdinalConverter.cs
@@ -1,3 +1,4 @@
+using Aspid.FastTools.Types;
 using System;
 using System.Globalization;
 
@@ -8,6 +9,7 @@ namespace Aspid.MVVM.StarterKit
     /// Formats a number as an English ordinal: 1 becomes "1st".
     /// </summary>
     [Serializable]
+    [TypeSelectorDisplay(Group = "Aspid/String", Name = "Ordinal", Tooltip = "Formats a number as an English ordinal: 1 becomes '1st'")]
     public sealed class OrdinalConverter : IConverter<int, string>
     {
         /// <summary>

--- a/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Runtime/Converters/Strings/PadStringConverter.cs
+++ b/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Runtime/Converters/Strings/PadStringConverter.cs
@@ -1,3 +1,4 @@
+using Aspid.FastTools.Types;
 using System;
 using UnityEngine;
 
@@ -8,6 +9,7 @@ namespace Aspid.MVVM.StarterKit
     /// Pads a string to a fixed width.
     /// </summary>
     [Serializable]
+    [TypeSelectorDisplay(Group = "Aspid/String", Name = "Pad String", Tooltip = "Pads a string to a fixed width")]
     public sealed class PadStringConverter : IConverterString
     {
         [Tooltip("The width to pad to.")]

--- a/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Runtime/Converters/Strings/PaddedNumberConverter.cs
+++ b/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Runtime/Converters/Strings/PaddedNumberConverter.cs
@@ -1,3 +1,4 @@
+using Aspid.FastTools.Types;
 using System;
 using UnityEngine;
 using System.Globalization;
@@ -9,6 +10,7 @@ namespace Aspid.MVVM.StarterKit
     /// Pads a number to a fixed width: 7 becomes "007".
     /// </summary>
     [Serializable]
+    [TypeSelectorDisplay(Group = "Aspid/String", Name = "Padded Number", Tooltip = "Pads a number to a fixed width: 7 becomes '007'")]
     public sealed class PaddedNumberConverter : IConverter<int, string>
     {
         [Tooltip("The minimum number of digits.")]

--- a/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Runtime/Converters/Strings/PercentStringConverter.cs
+++ b/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Runtime/Converters/Strings/PercentStringConverter.cs
@@ -1,3 +1,4 @@
+using Aspid.FastTools.Types;
 using System;
 using UnityEngine;
 
@@ -8,6 +9,7 @@ namespace Aspid.MVVM.StarterKit
     /// Formats a number as a percentage.
     /// </summary>
     [Serializable]
+    [TypeSelectorDisplay(Group = "Aspid/String", Name = "Percent String", Tooltip = "Formats a number as a percentage")]
     public sealed class PercentStringConverter : IConverter<float, string>
     {
         [Tooltip("The incoming value is a 0..1 fraction rather than an already-scaled percentage.")]

--- a/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Runtime/Converters/Strings/PluralizeConverter.cs
+++ b/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Runtime/Converters/Strings/PluralizeConverter.cs
@@ -1,3 +1,4 @@
+using Aspid.FastTools.Types;
 using System;
 using UnityEngine;
 
@@ -12,6 +13,7 @@ namespace Aspid.MVVM.StarterKit
     /// framework documented in Russian cannot treat the Slavic rule as an extra.
     /// </remarks>
     [Serializable]
+    [TypeSelectorDisplay(Group = "Aspid/String", Name = "Pluralize", Tooltip = "Picks the right word form for a count")]
     public sealed class PluralizeConverter : IConverter<int, string>
     {
         [Tooltip("Which grammar to follow.")]

--- a/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Runtime/Converters/Strings/RatioToStringConverter.cs
+++ b/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Runtime/Converters/Strings/RatioToStringConverter.cs
@@ -1,3 +1,4 @@
+using Aspid.FastTools.Types;
 using System;
 using UnityEngine;
 
@@ -12,6 +13,7 @@ namespace Aspid.MVVM.StarterKit
     /// number that changes.
     /// </remarks>
     [Serializable]
+    [TypeSelectorDisplay(Group = "Aspid/String", Name = "Ratio To String", Tooltip = "Formats a number against a maximum: '35 / 100'")]
     public sealed class RatioToStringConverter : IConverter<float, string>
     {
         [Tooltip("The value the number is shown against.")]

--- a/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Runtime/Converters/Strings/RepeatStringConverter.cs
+++ b/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Runtime/Converters/Strings/RepeatStringConverter.cs
@@ -1,3 +1,4 @@
+using Aspid.FastTools.Types;
 using System;
 using UnityEngine;
 
@@ -9,6 +10,7 @@ namespace Aspid.MVVM.StarterKit
     /// </summary>
     /// <remarks>Star ratings and pip counters without an array of sprites.</remarks>
     [Serializable]
+    [TypeSelectorDisplay(Group = "Aspid/String", Name = "Repeat String", Tooltip = "Repeats a piece of text once per count")]
     public sealed class RepeatStringConverter : IConverter<int, string>
     {
         [Tooltip("The text repeated once per count.")]

--- a/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Runtime/Converters/Strings/ReplaceStringConverter.cs
+++ b/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Runtime/Converters/Strings/ReplaceStringConverter.cs
@@ -1,3 +1,4 @@
+using Aspid.FastTools.Types;
 using System;
 using UnityEngine;
 
@@ -8,6 +9,7 @@ namespace Aspid.MVVM.StarterKit
     /// Replaces occurrences of one piece of text with another.
     /// </summary>
     [Serializable]
+    [TypeSelectorDisplay(Group = "Aspid/String", Name = "Replace String", Tooltip = "Replaces occurrences of one piece of text with another")]
     public sealed class ReplaceStringConverter : IConverterString
     {
         [Tooltip("The text to look for. When empty, the string passes through.")]

--- a/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Runtime/Converters/Strings/RomanNumeralConverter.cs
+++ b/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Runtime/Converters/Strings/RomanNumeralConverter.cs
@@ -1,3 +1,4 @@
+using Aspid.FastTools.Types;
 using System;
 using UnityEngine;
 using System.Globalization;
@@ -13,6 +14,7 @@ namespace Aspid.MVVM.StarterKit
     /// digits.
     /// </remarks>
     [Serializable]
+    [TypeSelectorDisplay(Group = "Aspid/String", Name = "Roman Numeral", Tooltip = "Formats a number as a Roman numeral")]
     public sealed class RomanNumeralConverter : IConverter<int, string>
     {
         [Tooltip("Write the numeral in lower case.")]

--- a/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Runtime/Converters/Strings/SignedNumberStringConverter.cs
+++ b/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Runtime/Converters/Strings/SignedNumberStringConverter.cs
@@ -1,3 +1,4 @@
+using Aspid.FastTools.Types;
 using System;
 using UnityEngine;
 
@@ -9,6 +10,7 @@ namespace Aspid.MVVM.StarterKit
     /// </summary>
     /// <remarks>Floating combat text, stat deltas — where the sign is the point.</remarks>
     [Serializable]
+    [TypeSelectorDisplay(Group = "Aspid/String", Name = "Signed Number String", Tooltip = "Formats a number with an explicit sign: '+15', '-3'")]
     public sealed class SignedNumberStringConverter : IConverter<float, string>
     {
         [Tooltip("A standard numeric format string applied to the magnitude.")]

--- a/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Runtime/Converters/Strings/StringFormatConverter.cs
+++ b/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Runtime/Converters/Strings/StringFormatConverter.cs
@@ -1,3 +1,4 @@
+using Aspid.FastTools.Types;
 using System;
 using UnityEngine;
 
@@ -13,6 +14,7 @@ namespace Aspid.MVVM.StarterKit
     /// <c>_formatEmptyValues</c> to format blank and <see langword="null"/> input as well.
     /// </remarks>
     [Serializable]
+    [TypeSelectorDisplay(Group = "Aspid/String", Name = "String Format", Tooltip = "for strings, with optional handling of empty values")]
     public class StringFormatConverter : GenericToString<string>, IConverterString
     {
         [Tooltip("Apply the format to a blank or null value as well, rather than passing it through.")]

--- a/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Runtime/Converters/Strings/StringToBoolParseConverter.cs
+++ b/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Runtime/Converters/Strings/StringToBoolParseConverter.cs
@@ -1,3 +1,4 @@
+using Aspid.FastTools.Types;
 using System;
 using UnityEngine;
 
@@ -12,6 +13,7 @@ namespace Aspid.MVVM.StarterKit
     /// accepted spellings are authored rather than fixed.
     /// </remarks>
     [Serializable]
+    [TypeSelectorDisplay(Group = "Aspid/String", Name = "String To Bool Parse", Tooltip = "Reads a boolean out of text")]
     public sealed class StringToBoolParseConverter : IConverterStringToBool
     {
         [Tooltip("The spellings read as true. Matched without regard to case.")]

--- a/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Runtime/Converters/Strings/StringToDateTimeConverter.cs
+++ b/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Runtime/Converters/Strings/StringToDateTimeConverter.cs
@@ -1,3 +1,4 @@
+using Aspid.FastTools.Types;
 using System;
 using UnityEngine;
 using System.Globalization;
@@ -9,6 +10,7 @@ namespace Aspid.MVVM.StarterKit
     /// Reads a date out of text.
     /// </summary>
     [Serializable]
+    [TypeSelectorDisplay(Group = "Aspid/String", Name = "String To Date Time", Tooltip = "Reads a date out of text")]
     public sealed class StringToDateTimeConverter : IConverter<string?, DateTime>
     {
         [Tooltip("The exact format expected. When empty, any format the culture understands is accepted.")]

--- a/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Runtime/Converters/Strings/StringToEnumConverter.cs
+++ b/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Runtime/Converters/Strings/StringToEnumConverter.cs
@@ -1,3 +1,4 @@
+using Aspid.FastTools.Types;
 using System;
 using UnityEngine;
 
@@ -10,6 +11,7 @@ namespace Aspid.MVVM.StarterKit
     /// <typeparam name="TEnum">The enum type being read.</typeparam>
     /// <remarks>State names arriving from a backend or a configuration file.</remarks>
     [Serializable]
+    [TypeSelectorDisplay(Group = "Aspid/String", Name = "String To Enum", Tooltip = "Reads an enum member out of text")]
     public sealed class StringToEnumConverter<TEnum> : ITwoWayConverter<string?, TEnum>
         where TEnum : struct, Enum
     {

--- a/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Runtime/Converters/Strings/StringToFloatConverter.cs
+++ b/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Runtime/Converters/Strings/StringToFloatConverter.cs
@@ -1,3 +1,4 @@
+using Aspid.FastTools.Types;
 using System;
 using UnityEngine;
 using System.Globalization;
@@ -13,6 +14,7 @@ namespace Aspid.MVVM.StarterKit
     /// and a half, and reading it as invariant gives fifteen or nothing at all.
     /// </remarks>
     [Serializable]
+    [TypeSelectorDisplay(Group = "Aspid/String", Name = "String To Float", Tooltip = "Reads a decimal number out of text")]
     public sealed class StringToFloatConverter : ITwoWayConverter<string?, float>
     {
         [Tooltip("Returned when the text is not a number.")]

--- a/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Runtime/Converters/Strings/StringToIntConverter.cs
+++ b/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Runtime/Converters/Strings/StringToIntConverter.cs
@@ -1,3 +1,4 @@
+using Aspid.FastTools.Types;
 using System;
 using UnityEngine;
 using System.Globalization;
@@ -14,6 +15,7 @@ namespace Aspid.MVVM.StarterKit
     /// <see cref="ComposeConverter{TFrom, TMid, TTo}"/>.
     /// </remarks>
     [Serializable]
+    [TypeSelectorDisplay(Group = "Aspid/String", Name = "String To Int", Tooltip = "Reads a number out of text")]
     public sealed class StringToIntConverter : ITwoWayConverter<string?, int>
     {
         [Tooltip("Returned when the text is not a number.")]

--- a/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Runtime/Converters/Strings/StringToLongConverter.cs
+++ b/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Runtime/Converters/Strings/StringToLongConverter.cs
@@ -1,3 +1,4 @@
+using Aspid.FastTools.Types;
 using System;
 using UnityEngine;
 using System.Globalization;
@@ -10,6 +11,7 @@ namespace Aspid.MVVM.StarterKit
     /// </summary>
     /// <inheritdoc cref="StringToIntConverter" path="/remarks"/>
     [Serializable]
+    [TypeSelectorDisplay(Group = "Aspid/String", Name = "String To Long", Tooltip = "Reads a whole number out of text")]
     public sealed class StringToLongConverter : ITwoWayConverter<string?, long>
     {
         [Tooltip("Returned when the text is not a number.")]

--- a/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Runtime/Converters/Strings/SubstringConverter.cs
+++ b/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Runtime/Converters/Strings/SubstringConverter.cs
@@ -1,3 +1,4 @@
+using Aspid.FastTools.Types;
 using System;
 using UnityEngine;
 
@@ -9,6 +10,7 @@ namespace Aspid.MVVM.StarterKit
     /// </summary>
     /// <remarks>An avatar initial, a prefix, a fixed-position field of a code.</remarks>
     [Serializable]
+    [TypeSelectorDisplay(Group = "Aspid/String", Name = "Substring", Tooltip = "Takes a slice out of a string")]
     public sealed class SubstringConverter : IConverterString
     {
         [Tooltip("Where the slice starts.")]

--- a/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Runtime/Converters/Strings/TextCaseConverter.cs
+++ b/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Runtime/Converters/Strings/TextCaseConverter.cs
@@ -1,3 +1,4 @@
+using Aspid.FastTools.Types;
 using System;
 using UnityEngine;
 using System.Globalization;
@@ -14,6 +15,7 @@ namespace Aspid.MVVM.StarterKit
     /// there — which is why the culture is a setting rather than an assumption.
     /// </remarks>
     [Serializable]
+    [TypeSelectorDisplay(Group = "Aspid/String", Name = "Text Case", Tooltip = "Changes the casing of a string")]
     public sealed class TextCaseConverter : IConverterString
     {
         [Tooltip("Which casing to apply.")]

--- a/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Runtime/Converters/Strings/TimeSpanToStringConverter.cs
+++ b/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Runtime/Converters/Strings/TimeSpanToStringConverter.cs
@@ -1,3 +1,4 @@
+using Aspid.FastTools.Types;
 using System;
 
 // ReSharper disable once CheckNamespace
@@ -12,6 +13,7 @@ namespace Aspid.MVVM.StarterKit
     /// <c>"mm\\:ss"</c> that <see cref="TimeSpan.ToString(string)"/> would take comes back as itself.
     /// </remarks>
     [Serializable]
+    [TypeSelectorDisplay(Group = "Aspid/String", Name = "Time Span To String", Tooltip = "for  values, with optional formatting")]
     public sealed class TimeSpanToStringConverter : GenericToString<TimeSpan>, IConverterTimeSpanToString
     {
         public TimeSpanToStringConverter() { }

--- a/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Runtime/Converters/Strings/TrimStringConverter.cs
+++ b/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Runtime/Converters/Strings/TrimStringConverter.cs
@@ -1,3 +1,4 @@
+using Aspid.FastTools.Types;
 using System;
 using UnityEngine;
 
@@ -9,6 +10,7 @@ namespace Aspid.MVVM.StarterKit
     /// </summary>
     /// <remarks>Sanitising what came back from an input field before it is shown again.</remarks>
     [Serializable]
+    [TypeSelectorDisplay(Group = "Aspid/String", Name = "Trim String", Tooltip = "Removes surrounding characters from a string")]
     public sealed class TrimStringConverter : IConverterString
     {
         [Tooltip("Which ends to trim.")]

--- a/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Runtime/Converters/Strings/TruncateStringConverter.cs
+++ b/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Runtime/Converters/Strings/TruncateStringConverter.cs
@@ -1,3 +1,4 @@
+using Aspid.FastTools.Types;
 using System;
 using UnityEngine;
 
@@ -13,6 +14,7 @@ namespace Aspid.MVVM.StarterKit
     /// place.
     /// </remarks>
     [Serializable]
+    [TypeSelectorDisplay(Group = "Aspid/String", Name = "Truncate String", Tooltip = "Shortens a string that is too long to fit")]
     public sealed class TruncateStringConverter : IConverterString
     {
         [Tooltip("The longest string allowed through, ellipsis included.")]

--- a/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Runtime/Converters/Times/DateTimeFormatConverter.cs
+++ b/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Runtime/Converters/Times/DateTimeFormatConverter.cs
@@ -1,3 +1,4 @@
+using Aspid.FastTools.Types;
 using System;
 using UnityEngine;
 
@@ -8,6 +9,7 @@ namespace Aspid.MVVM.StarterKit
     /// Formats a <see cref="DateTime"/>.
     /// </summary>
     [Serializable]
+    [TypeSelectorDisplay(Group = "Aspid/Time", Name = "Date Time Format", Tooltip = "Formats a ")]
     public sealed class DateTimeFormatConverter : IConverter<DateTime, string>
     {
         [Tooltip("A DateTime format string, for example dd.MM.yyyy or HH:mm.")]

--- a/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Runtime/Converters/Times/DateTimeToBoolConverter.cs
+++ b/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Runtime/Converters/Times/DateTimeToBoolConverter.cs
@@ -1,3 +1,4 @@
+using Aspid.FastTools.Types;
 using System;
 using UnityEngine;
 
@@ -9,6 +10,7 @@ namespace Aspid.MVVM.StarterKit
     /// </summary>
     /// <remarks>Gating on "the event has started" or "the cooldown has expired".</remarks>
     [Serializable]
+    [TypeSelectorDisplay(Group = "Aspid/Time", Name = "Date Time To Bool", Tooltip = "Compares a  with a reference moment")]
     public sealed class DateTimeToBoolConverter : IConverter<DateTime, bool>
     {
         [Tooltip("How the bound moment is compared with the reference.")]

--- a/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Runtime/Converters/Times/RelativeTimeConverter.cs
+++ b/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Runtime/Converters/Times/RelativeTimeConverter.cs
@@ -1,3 +1,4 @@
+using Aspid.FastTools.Types;
 using System;
 using UnityEngine;
 using System.Globalization;
@@ -13,6 +14,7 @@ namespace Aspid.MVVM.StarterKit
     /// touching code; the default set is English.
     /// </remarks>
     [Serializable]
+    [TypeSelectorDisplay(Group = "Aspid/Time", Name = "Relative Time", Tooltip = "Writes how long ago — or how far ahead — a moment is")]
     public sealed class RelativeTimeConverter : IConverter<DateTime, string>
     {
         [Tooltip("Names for second, minute, hour, day. Longer spans use days.")]

--- a/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Runtime/Converters/Times/SecondsToTimeSpanConverter.cs
+++ b/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Runtime/Converters/Times/SecondsToTimeSpanConverter.cs
@@ -1,3 +1,4 @@
+using Aspid.FastTools.Types;
 using System;
 
 // ReSharper disable once CheckNamespace
@@ -7,6 +8,7 @@ namespace Aspid.MVVM.StarterKit
     /// Converts a number of seconds to a <see cref="TimeSpan"/>.
     /// </summary>
     [Serializable]
+    [TypeSelectorDisplay(Group = "Aspid/Time", Name = "Seconds To Time Span", Tooltip = "Converts a number of seconds to a ")]
     public sealed class SecondsToTimeSpanConverter : ITwoWayConverter<float, TimeSpan>
     {
         /// <summary>

--- a/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Runtime/Converters/Times/SecondsToTimeStringConverter.cs
+++ b/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Runtime/Converters/Times/SecondsToTimeStringConverter.cs
@@ -1,3 +1,4 @@
+using Aspid.FastTools.Types;
 using System;
 using UnityEngine;
 using System.Globalization;
@@ -14,6 +15,7 @@ namespace Aspid.MVVM.StarterKit
     /// stopwatch wants <see cref="RoundMode.Floor"/>.
     /// </remarks>
     [Serializable]
+    [TypeSelectorDisplay(Group = "Aspid/Time", Name = "Seconds To Time String", Tooltip = "Writes a number of seconds as a clock reading")]
     public sealed class SecondsToTimeStringConverter :
         IConverter<float, string>,
         IConverter<double, string>,

--- a/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Runtime/Converters/Times/TimeSpanFormatConverter.cs
+++ b/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Runtime/Converters/Times/TimeSpanFormatConverter.cs
@@ -1,3 +1,4 @@
+using Aspid.FastTools.Types;
 using System;
 using UnityEngine;
 
@@ -13,6 +14,7 @@ namespace Aspid.MVVM.StarterKit
     /// This takes the pattern directly, the way <see cref="TimeSpan.ToString(string)"/> does.
     /// </remarks>
     [Serializable]
+    [TypeSelectorDisplay(Group = "Aspid/Time", Name = "Time Span Format", Tooltip = "Formats a  with a real  format string")]
     public sealed class TimeSpanFormatConverter : IConverterTimeSpanToString
     {
         [Tooltip(@"A TimeSpan format string, for example mm\:ss or hh\:mm\:ss.")]

--- a/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Runtime/Converters/Times/TimeSpanToNumberConverter.cs
+++ b/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Runtime/Converters/Times/TimeSpanToNumberConverter.cs
@@ -1,3 +1,4 @@
+using Aspid.FastTools.Types;
 using System;
 using UnityEngine;
 
@@ -9,6 +10,7 @@ namespace Aspid.MVVM.StarterKit
     /// </summary>
     /// <remarks>For feeding a duration into a slider or a fill amount.</remarks>
     [Serializable]
+    [TypeSelectorDisplay(Group = "Aspid/Time", Name = "Time Span To Number", Tooltip = "Measures a  as a number")]
     public sealed class TimeSpanToNumberConverter : IConverter<TimeSpan, float>
     {
         [Tooltip("Which unit to measure in.")]

--- a/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Runtime/Converters/Times/UnixTimestampToDateTimeConverter.cs
+++ b/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Runtime/Converters/Times/UnixTimestampToDateTimeConverter.cs
@@ -1,3 +1,4 @@
+using Aspid.FastTools.Types;
 using System;
 using UnityEngine;
 
@@ -9,6 +10,7 @@ namespace Aspid.MVVM.StarterKit
     /// </summary>
     /// <remarks>A backend that speaks epoch seconds, which most do.</remarks>
     [Serializable]
+    [TypeSelectorDisplay(Group = "Aspid/Time", Name = "Unix Timestamp To Date Time", Tooltip = "Converts a Unix timestamp to a ")]
     public sealed class UnixTimestampToDateTimeConverter : ITwoWayConverter<long, DateTime>
     {
         [Tooltip("The timestamp is in milliseconds rather than seconds.")]

--- a/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Unity/Runtime/Converters/Assets/ConverterAssetReference.cs
+++ b/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Unity/Runtime/Converters/Assets/ConverterAssetReference.cs
@@ -1,4 +1,5 @@
 #nullable enable
+using Aspid.FastTools.Types;
 using System;
 using UnityEngine;
 
@@ -17,6 +18,7 @@ namespace Aspid.MVVM.StarterKit
     /// shared converters without changing.
     /// </remarks>
     [Serializable]
+    [TypeSelectorDisplay(Group = "Aspid/Asset", Name = "Converter Asset Reference", Tooltip = "Forwards conversion to a shared ")]
     public sealed class ConverterAssetReference<TFrom, TTo> : IConverter<TFrom?, TTo?>
     {
         [Tooltip("The shared converter asset. When empty, the default value is returned.")]

--- a/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Unity/Runtime/Converters/Assets/MaterialInstanceConverter.cs
+++ b/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Unity/Runtime/Converters/Assets/MaterialInstanceConverter.cs
@@ -1,4 +1,5 @@
 #nullable enable
+using Aspid.FastTools.Types;
 using System;
 using UnityEngine;
 
@@ -18,6 +19,7 @@ namespace Aspid.MVVM.StarterKit
     /// </para>
     /// </remarks>
     [Serializable]
+    [TypeSelectorDisplay(Group = "Aspid/Asset", Name = "Material Instance", Tooltip = "Hands a renderer its own copy of a material instead of the shared asset")]
     public sealed class MaterialInstanceConverter : IConverterMaterial
     {
         [Tooltip("Return a copy rather than the shared asset.")]

--- a/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Unity/Runtime/Converters/Bools/UnityObjectNullToBoolConverter.cs
+++ b/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Unity/Runtime/Converters/Bools/UnityObjectNullToBoolConverter.cs
@@ -1,4 +1,5 @@
 #nullable enable
+using Aspid.FastTools.Types;
 using System;
 using UnityEngine;
 using Object = UnityEngine.Object;
@@ -16,6 +17,7 @@ namespace Aspid.MVVM.StarterKit
     /// overloaded <c>==</c>, which is the only check that catches both cases.
     /// </remarks>
     [Serializable]
+    [TypeSelectorDisplay(Group = "Aspid/Bool", Name = "Unity Object Null To Bool", Tooltip = "Converts a  reference to a boolean based on whether it is alive")]
     public sealed class UnityObjectNullToBoolConverter : IConverter<Object?, bool>
     {
         [Tooltip("Invert the result — true when the object is alive.")]

--- a/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Unity/Runtime/Converters/Colors/ColorAlphaConverter.cs
+++ b/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Unity/Runtime/Converters/Colors/ColorAlphaConverter.cs
@@ -1,4 +1,5 @@
 #nullable enable
+using Aspid.FastTools.Types;
 using System;
 using UnityEngine;
 
@@ -14,6 +15,7 @@ namespace Aspid.MVVM.StarterKit
     /// on every binder was empty.
     /// </remarks>
     [Serializable]
+    [TypeSelectorDisplay(Group = "Aspid/Colour", Name = "Color Alpha", Tooltip = "Changes the alpha of a colour, leaving its hue alone")]
     public sealed class ColorAlphaConverter : IConverterColor
     {
         [Tooltip("The alpha applied to the colour.")]

--- a/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Unity/Runtime/Converters/Colors/ColorBlockAlphaConverter.cs
+++ b/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Unity/Runtime/Converters/Colors/ColorBlockAlphaConverter.cs
@@ -1,4 +1,5 @@
 #nullable enable
+using Aspid.FastTools.Types;
 using System;
 using UnityEngine;
 using UnityEngine.UI;
@@ -11,6 +12,7 @@ namespace Aspid.MVVM.StarterKit
     /// </summary>
     /// <remarks>Dimming a whole interactive element without touching its hues.</remarks>
     [Serializable]
+    [TypeSelectorDisplay(Group = "Aspid/Colour", Name = "Color Block Alpha", Tooltip = "Changes the alpha of every colour in a ")]
     public sealed class ColorBlockAlphaConverter : IConverterColorBlock
     {
         [Tooltip("The alpha applied to every state.")]

--- a/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Unity/Runtime/Converters/Colors/ColorBlockFadeDurationConverter.cs
+++ b/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Unity/Runtime/Converters/Colors/ColorBlockFadeDurationConverter.cs
@@ -1,4 +1,5 @@
 #nullable enable
+using Aspid.FastTools.Types;
 using System;
 using UnityEngine;
 using UnityEngine.UI;
@@ -14,6 +15,7 @@ namespace Aspid.MVVM.StarterKit
     /// reaches without rebuilding the whole block.
     /// </remarks>
     [Serializable]
+    [TypeSelectorDisplay(Group = "Aspid/Colour", Name = "Color Block Fade Duration", Tooltip = "Sets how long a  takes to change state")]
     public sealed class ColorBlockFadeDurationConverter : IConverterColorBlock
     {
         [Tooltip("How long a state change takes.")]

--- a/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Unity/Runtime/Converters/Colors/ColorBlockTintConverter.cs
+++ b/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Unity/Runtime/Converters/Colors/ColorBlockTintConverter.cs
@@ -1,4 +1,5 @@
 #nullable enable
+using Aspid.FastTools.Types;
 using System;
 using UnityEngine;
 using UnityEngine.UI;
@@ -11,6 +12,7 @@ namespace Aspid.MVVM.StarterKit
     /// </summary>
     /// <remarks>Theming a whole button at once — faction colours, a disabled palette.</remarks>
     [Serializable]
+    [TypeSelectorDisplay(Group = "Aspid/Colour", Name = "Color Block Tint", Tooltip = "Tints every colour of a ")]
     public sealed class ColorBlockTintConverter : IConverterColorBlock
     {
         [Tooltip("The colour every state is combined with.")]

--- a/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Unity/Runtime/Converters/Colors/ColorGrayscaleConverter.cs
+++ b/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Unity/Runtime/Converters/Colors/ColorGrayscaleConverter.cs
@@ -1,4 +1,5 @@
 #nullable enable
+using Aspid.FastTools.Types;
 using System;
 using UnityEngine;
 
@@ -14,6 +15,7 @@ namespace Aspid.MVVM.StarterKit
     /// channel average.
     /// </remarks>
     [Serializable]
+    [TypeSelectorDisplay(Group = "Aspid/Colour", Name = "Color Grayscale", Tooltip = "Desaturates a colour")]
     public sealed class ColorGrayscaleConverter : IConverterColor
     {
         [Tooltip("How much colour to keep. Zero is fully grey, one leaves the colour untouched.")]

--- a/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Unity/Runtime/Converters/Colors/ColorHsvConverter.cs
+++ b/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Unity/Runtime/Converters/Colors/ColorHsvConverter.cs
@@ -1,4 +1,5 @@
 #nullable enable
+using Aspid.FastTools.Types;
 using System;
 using UnityEngine;
 
@@ -10,6 +11,7 @@ namespace Aspid.MVVM.StarterKit
     /// </summary>
     /// <remarks>A palette of variations from one authored base colour.</remarks>
     [Serializable]
+    [TypeSelectorDisplay(Group = "Aspid/Colour", Name = "Color Hsv", Tooltip = "Shifts a colour in HSV space")]
     public sealed class ColorHsvConverter : IConverterColor
     {
         [Tooltip("How far to rotate the hue, in turns. 0.5 is the opposite colour.")]

--- a/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Unity/Runtime/Converters/Colors/ColorLerpConverter.cs
+++ b/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Unity/Runtime/Converters/Colors/ColorLerpConverter.cs
@@ -1,4 +1,5 @@
 #nullable enable
+using Aspid.FastTools.Types;
 using System;
 using UnityEngine;
 
@@ -10,6 +11,7 @@ namespace Aspid.MVVM.StarterKit
     /// </summary>
     /// <remarks>A two-stop gradient without a <see cref="Gradient"/> to author.</remarks>
     [Serializable]
+    [TypeSelectorDisplay(Group = "Aspid/Colour", Name = "Color Lerp", Tooltip = "Moves between two colours by a 0..1 amount")]
     public sealed class ColorLerpConverter : IConverter<float, Color>
     {
         [Tooltip("The colour at 0.")]

--- a/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Unity/Runtime/Converters/Colors/ColorTintConverter.cs
+++ b/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Unity/Runtime/Converters/Colors/ColorTintConverter.cs
@@ -1,4 +1,5 @@
 #nullable enable
+using Aspid.FastTools.Types;
 using System;
 using UnityEngine;
 
@@ -10,6 +11,7 @@ namespace Aspid.MVVM.StarterKit
     /// </summary>
     /// <remarks>Team colours, rarity tints, disabled states.</remarks>
     [Serializable]
+    [TypeSelectorDisplay(Group = "Aspid/Colour", Name = "Color Tint", Tooltip = "Combines a bound colour with an authored one")]
     public sealed class ColorTintConverter : IConverterColor
     {
         [Tooltip("The colour the bound one is combined with.")]

--- a/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Unity/Runtime/Converters/Colors/ColorToColorBlockConverter.cs
+++ b/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Unity/Runtime/Converters/Colors/ColorToColorBlockConverter.cs
@@ -1,4 +1,5 @@
 #nullable enable
+using Aspid.FastTools.Types;
 using System;
 using UnityEngine;
 using UnityEngine.UI;
@@ -14,6 +15,7 @@ namespace Aspid.MVVM.StarterKit
     /// the one colour that varies, so the ViewModel does not have to model UGUI interaction states.
     /// </remarks>
     [Serializable]
+    [TypeSelectorDisplay(Group = "Aspid/Colour", Name = "Color To Color Block", Tooltip = "Builds a full  out of one colour")]
     public sealed class ColorToColorBlockConverter : IConverter<Color, ColorBlock>
     {
         [Tooltip("Scales the colour for the highlighted state.")]

--- a/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Unity/Runtime/Converters/Colors/ColorToHtmlStringConverter.cs
+++ b/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Unity/Runtime/Converters/Colors/ColorToHtmlStringConverter.cs
@@ -1,4 +1,5 @@
 #nullable enable
+using Aspid.FastTools.Types;
 using System;
 using UnityEngine;
 
@@ -13,6 +14,7 @@ namespace Aspid.MVVM.StarterKit
     /// colour tag is built from.
     /// </remarks>
     [Serializable]
+    [TypeSelectorDisplay(Group = "Aspid/Colour", Name = "Color To Html String", Tooltip = "Writes a colour as an HTML string")]
     public sealed class ColorToHtmlStringConverter : IConverter<Color, string>
     {
         [Tooltip("Include the alpha channel.")]

--- a/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Unity/Runtime/Converters/Colors/GradientEvaluateConverter.cs
+++ b/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Unity/Runtime/Converters/Colors/GradientEvaluateConverter.cs
@@ -1,4 +1,5 @@
 #nullable enable
+using Aspid.FastTools.Types;
 using System;
 using UnityEngine;
 
@@ -14,6 +15,7 @@ namespace Aspid.MVVM.StarterKit
     /// number it already has.
     /// </remarks>
     [Serializable]
+    [TypeSelectorDisplay(Group = "Aspid/Colour", Name = "Gradient Evaluate", Tooltip = "Reads a colour off a ")]
     public sealed class GradientEvaluateConverter : IConverter<float, Color>
     {
         [Tooltip("The gradient the value is read from.")]

--- a/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Unity/Runtime/Converters/Colors/HashToColorConverter.cs
+++ b/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Unity/Runtime/Converters/Colors/HashToColorConverter.cs
@@ -1,4 +1,5 @@
 #nullable enable
+using Aspid.FastTools.Types;
 using System;
 using UnityEngine;
 
@@ -13,6 +14,7 @@ namespace Aspid.MVVM.StarterKit
     /// produces the same colour.
     /// </remarks>
     [Serializable]
+    [TypeSelectorDisplay(Group = "Aspid/Colour", Name = "Hash To Color", Tooltip = "Derives a stable colour from a string")]
     public sealed class HashToColorConverter : IConverter<string?, Color>
     {
         [Tooltip("The saturation of the produced colour.")]

--- a/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Unity/Runtime/Converters/Colors/ParseHtmlStringConverter.cs
+++ b/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Unity/Runtime/Converters/Colors/ParseHtmlStringConverter.cs
@@ -1,4 +1,5 @@
 #nullable enable
+using Aspid.FastTools.Types;
 using System;
 using UnityEngine;
 
@@ -14,6 +15,7 @@ namespace Aspid.MVVM.StarterKit
     /// every time, whichever mode is chosen.
     /// </remarks>
     [Serializable]
+    [TypeSelectorDisplay(Group = "Aspid/Colour", Name = "Parse Html String", Tooltip = "Converts HTML color strings (e.g., '#FF0000') to  values")]
     public sealed class ParseHtmlStringConverter : IConverterStringToColor
     {
         [Tooltip("What to do with a string that does not parse. ReturnInput is not available here — the input is a string and the output a colour — and behaves as ReturnFallback.")]

--- a/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Unity/Runtime/Converters/Colors/ThresholdColorConverter.cs
+++ b/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Unity/Runtime/Converters/Colors/ThresholdColorConverter.cs
@@ -1,4 +1,5 @@
 #nullable enable
+using Aspid.FastTools.Types;
 using System;
 using UnityEngine;
 
@@ -10,6 +11,7 @@ namespace Aspid.MVVM.StarterKit
     /// </summary>
     /// <remarks>Stepped states — green, amber, red — rather than a continuous ramp.</remarks>
     [Serializable]
+    [TypeSelectorDisplay(Group = "Aspid/Colour", Name = "Threshold Color", Tooltip = "Picks a colour by which threshold a number has passed")]
     public sealed class ThresholdColorConverter : IConverter<float, Color>
     {
         [Tooltip("Colours by threshold. The highest threshold at or below the value wins.")]

--- a/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Unity/Runtime/Converters/Enums/EnumToDropdownOptionDataConverter.cs
+++ b/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Unity/Runtime/Converters/Enums/EnumToDropdownOptionDataConverter.cs
@@ -1,5 +1,6 @@
 #if UNITY_2023_1_OR_NEWER || ASPID_MVVM_TEXT_MESH_PRO_INTEGRATION
 #nullable enable
+using Aspid.FastTools.Types;
 using TMPro;
 using System;
 using UnityEngine;
@@ -17,6 +18,7 @@ namespace Aspid.MVVM.StarterKit
     /// member on every notification.
     /// </remarks>
     [Serializable]
+    [TypeSelectorDisplay(Group = "Aspid/Enum", Name = "Enum To Dropdown Option Data", Tooltip = "Builds the option list of a dropdown out of an enum's members")]
     public sealed class EnumToDropdownOptionDataConverter : IConverterEnumToDropdownOptionData
     {
         /// <summary>

--- a/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Unity/Runtime/Converters/Layouts/IntToRectOffsetConverter.cs
+++ b/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Unity/Runtime/Converters/Layouts/IntToRectOffsetConverter.cs
@@ -1,4 +1,5 @@
 #nullable enable
+using Aspid.FastTools.Types;
 using System;
 using UnityEngine;
 
@@ -14,6 +15,7 @@ namespace Aspid.MVVM.StarterKit
     /// values immediately, but the result must not be held onto.
     /// </remarks>
     [Serializable]
+    [TypeSelectorDisplay(Group = "Aspid/Layout", Name = "Int To Rect Offset", Tooltip = "Writes one number into the chosen sides of a padding")]
     public sealed class IntToRectOffsetConverter : IConverter<int, RectOffset>
     {
         [Tooltip("Which sides the number is written into.")]

--- a/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Unity/Runtime/Converters/Layouts/RectOffsetScaleConverter.cs
+++ b/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Unity/Runtime/Converters/Layouts/RectOffsetScaleConverter.cs
@@ -1,4 +1,5 @@
 #nullable enable
+using Aspid.FastTools.Types;
 using System;
 using UnityEngine;
 
@@ -10,6 +11,7 @@ namespace Aspid.MVVM.StarterKit
     /// </summary>
     /// <remarks>DPI or safe-area scaling applied to an authored padding.</remarks>
     [Serializable]
+    [TypeSelectorDisplay(Group = "Aspid/Layout", Name = "Rect Offset Scale", Tooltip = "Scales a padding")]
     public sealed class RectOffsetScaleConverter : IConverterRectOffset
     {
         [Tooltip("What the padding is multiplied by.")]

--- a/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Unity/Runtime/Converters/Layouts/Vector4ToRectOffsetConverter.cs
+++ b/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Unity/Runtime/Converters/Layouts/Vector4ToRectOffsetConverter.cs
@@ -1,4 +1,5 @@
 #nullable enable
+using Aspid.FastTools.Types;
 using System;
 using UnityEngine;
 
@@ -13,6 +14,7 @@ namespace Aspid.MVVM.StarterKit
     /// would have to be allocated on its side.
     /// </remarks>
     [Serializable]
+    [TypeSelectorDisplay(Group = "Aspid/Layout", Name = "Vector4 To Rect Offset", Tooltip = "Turns the four numbers of a  into a padding")]
     public sealed class Vector4ToRectOffsetConverter : IConverter<Vector4, RectOffset>
     {
         [Tooltip("Which way to drop the fraction.")]

--- a/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Unity/Runtime/Converters/Localizations/LocaleToStringConverter.cs
+++ b/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Unity/Runtime/Converters/Localizations/LocaleToStringConverter.cs
@@ -1,5 +1,6 @@
 #if ASPID_MVVM_UNITY_LOCALIZATION_INTEGRATION
 #nullable enable
+using Aspid.FastTools.Types;
 using System;
 using UnityEngine;
 using UnityEngine.Localization;
@@ -12,6 +13,7 @@ namespace Aspid.MVVM.StarterKit
     /// </summary>
     /// <remarks>Labelling the entries of a language dropdown.</remarks>
     [Serializable]
+    [TypeSelectorDisplay(Group = "Aspid/Localization", Name = "Locale To String", Tooltip = "Writes the name of a locale")]
     public sealed class LocaleToStringConverter : IConverter<Locale?, string>
     {
         [Tooltip("Use the locale's own name for itself rather than its English name.")]

--- a/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Unity/Runtime/Converters/Localizations/LocalizedEnumConverter.cs
+++ b/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Unity/Runtime/Converters/Localizations/LocalizedEnumConverter.cs
@@ -1,5 +1,6 @@
 #if ASPID_MVVM_UNITY_LOCALIZATION_INTEGRATION
 #nullable enable
+using Aspid.FastTools.Types;
 using System;
 using UnityEngine;
 using UnityEngine.Localization;
@@ -16,6 +17,7 @@ namespace Aspid.MVVM.StarterKit
     /// member adds a key rather than a switch branch.
     /// </remarks>
     [Serializable]
+    [TypeSelectorDisplay(Group = "Aspid/Localization", Name = "Localized Enum", Tooltip = "Looks an enum member's name up in a localization table")]
     public sealed class LocalizedEnumConverter<TEnum> : IConverter<TEnum, string>
         where TEnum : struct, Enum
     {

--- a/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Unity/Runtime/Converters/Localizations/LocalizedNumberConverter.cs
+++ b/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Unity/Runtime/Converters/Localizations/LocalizedNumberConverter.cs
@@ -1,5 +1,6 @@
 #if ASPID_MVVM_UNITY_LOCALIZATION_INTEGRATION
 #nullable enable
+using Aspid.FastTools.Types;
 using System;
 using UnityEngine;
 using UnityEngine.Localization.Settings;
@@ -16,6 +17,7 @@ namespace Aspid.MVVM.StarterKit
     /// the option that mode cannot express.
     /// </remarks>
     [Serializable]
+    [TypeSelectorDisplay(Group = "Aspid/Localization", Name = "Localized Number", Tooltip = "Formats a number with the culture of the selected locale")]
     public sealed class LocalizedNumberConverter : IConverter<double, string>
     {
         [Tooltip("A standard numeric format string.")]

--- a/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Unity/Runtime/Converters/Localizations/LocalizedStringConverter.cs
+++ b/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Unity/Runtime/Converters/Localizations/LocalizedStringConverter.cs
@@ -1,5 +1,6 @@
 #if ASPID_MVVM_UNITY_LOCALIZATION_INTEGRATION
 #nullable enable
+using Aspid.FastTools.Types;
 using System;
 using UnityEngine;
 using UnityEngine.Localization;
@@ -15,6 +16,7 @@ namespace Aspid.MVVM.StarterKit
     /// localization here joins the same converter chain as truncation, casing and rich text.
     /// </remarks>
     [Serializable]
+    [TypeSelectorDisplay(Group = "Aspid/Localization", Name = "Localized String", Tooltip = "Looks a key up in a localization table")]
     public sealed class LocalizedStringConverter : IConverterString
     {
         [Tooltip("The string table the key is looked up in.")]

--- a/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Unity/Runtime/Converters/Numbers/AnimationCurveConverter.cs
+++ b/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Unity/Runtime/Converters/Numbers/AnimationCurveConverter.cs
@@ -1,4 +1,5 @@
 #nullable enable
+using Aspid.FastTools.Types;
 using System;
 using UnityEngine;
 
@@ -14,6 +15,7 @@ namespace Aspid.MVVM.StarterKit
     /// asking for one.
     /// </remarks>
     [Serializable]
+    [TypeSelectorDisplay(Group = "Aspid/Number", Name = "Animation Curve", Tooltip = "Passes a number through an ")]
     public sealed class AnimationCurveConverter : IConverterFloat
     {
         [Tooltip("The curve the value is passed through.")]

--- a/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Unity/Runtime/Converters/Numbers/AudioDecibelToLinearConverter.cs
+++ b/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Unity/Runtime/Converters/Numbers/AudioDecibelToLinearConverter.cs
@@ -1,4 +1,5 @@
 #nullable enable
+using Aspid.FastTools.Types;
 using System;
 using UnityEngine;
 
@@ -13,6 +14,7 @@ namespace Aspid.MVVM.StarterKit
     /// mixer value onto a slider.
     /// </remarks>
     [Serializable]
+    [TypeSelectorDisplay(Group = "Aspid/Number", Name = "Audio Decibel To Linear", Tooltip = "Converts a decibel value to a 0..1 slider position")]
     public sealed class AudioDecibelToLinearConverter : ITwoWayConverter<float, float>
     {
         [Tooltip("The decibel value that maps to silence.")]

--- a/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Unity/Runtime/Converters/Numbers/AudioLinearToDecibelConverter.cs
+++ b/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Unity/Runtime/Converters/Numbers/AudioLinearToDecibelConverter.cs
@@ -1,4 +1,5 @@
 #nullable enable
+using Aspid.FastTools.Types;
 using System;
 using UnityEngine;
 
@@ -14,6 +15,7 @@ namespace Aspid.MVVM.StarterKit
     /// nothing. This is the conversion that makes a linear slider sound linear.
     /// </remarks>
     [Serializable]
+    [TypeSelectorDisplay(Group = "Aspid/Number", Name = "Audio Linear To Decibel", Tooltip = "Converts a 0..1 slider position to the decibels an  expects")]
     public sealed class AudioLinearToDecibelConverter : ITwoWayConverter<float, float>
     {
         [Tooltip("The decibel value silence maps to.")]

--- a/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Unity/Runtime/Converters/Rotations/AngleToDirectionConverter.cs
+++ b/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Unity/Runtime/Converters/Rotations/AngleToDirectionConverter.cs
@@ -1,4 +1,5 @@
 #nullable enable
+using Aspid.FastTools.Types;
 using System;
 using UnityEngine;
 
@@ -10,6 +11,7 @@ namespace Aspid.MVVM.StarterKit
     /// </summary>
     /// <remarks>Placing a marker on a radial HUD.</remarks>
     [Serializable]
+    [TypeSelectorDisplay(Group = "Aspid/Rotation", Name = "Angle To Direction", Tooltip = "Turns an angle into a direction")]
     public sealed class AngleToDirectionConverter : IConverter<float, Vector2>
     {
         [Tooltip("The angle is in degrees rather than radians.")]

--- a/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Unity/Runtime/Converters/Rotations/AngleToQuaternionConverter.cs
+++ b/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Unity/Runtime/Converters/Rotations/AngleToQuaternionConverter.cs
@@ -1,4 +1,5 @@
 #nullable enable
+using Aspid.FastTools.Types;
 using System;
 using UnityEngine;
 
@@ -13,6 +14,7 @@ namespace Aspid.MVVM.StarterKit
     /// on the View. Until now <c>IConverterQuaternion</c> had no implementation at all.
     /// </remarks>
     [Serializable]
+    [TypeSelectorDisplay(Group = "Aspid/Rotation", Name = "Angle To Quaternion", Tooltip = "Turns a single angle into a rotation")]
     public sealed class AngleToQuaternionConverter : ITwoWayConverter<float, Quaternion>
     {
         [Tooltip("The axis the angle turns around. Z is the one a 2D UI element spins on.")]

--- a/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Unity/Runtime/Converters/Rotations/AngleWrapConverter.cs
+++ b/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Unity/Runtime/Converters/Rotations/AngleWrapConverter.cs
@@ -1,4 +1,5 @@
 #nullable enable
+using Aspid.FastTools.Types;
 using System;
 using UnityEngine;
 
@@ -13,6 +14,7 @@ namespace Aspid.MVVM.StarterKit
     /// round when it moved two degrees.
     /// </remarks>
     [Serializable]
+    [TypeSelectorDisplay(Group = "Aspid/Rotation", Name = "Angle Wrap", Tooltip = "Folds an angle into a standard range")]
     public sealed class AngleWrapConverter : IConverterFloat
     {
         [Tooltip("Which range to report in.")]

--- a/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Unity/Runtime/Converters/Rotations/DegreesToRadiansConverter.cs
+++ b/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Unity/Runtime/Converters/Rotations/DegreesToRadiansConverter.cs
@@ -1,4 +1,5 @@
 #nullable enable
+using Aspid.FastTools.Types;
 using System;
 using UnityEngine;
 
@@ -10,6 +11,7 @@ namespace Aspid.MVVM.StarterKit
     /// </summary>
     /// <remarks>Physics and backend data usually speak radians; Unity's Inspector speaks degrees.</remarks>
     [Serializable]
+    [TypeSelectorDisplay(Group = "Aspid/Rotation", Name = "Degrees To Radians", Tooltip = "Converts between degrees and radians")]
     public sealed class DegreesToRadiansConverter : ITwoWayConverter<float, float>
     {
         /// <summary>

--- a/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Unity/Runtime/Converters/Rotations/DirectionToAngleConverter.cs
+++ b/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Unity/Runtime/Converters/Rotations/DirectionToAngleConverter.cs
@@ -1,4 +1,5 @@
 #nullable enable
+using Aspid.FastTools.Types;
 using System;
 using UnityEngine;
 
@@ -13,6 +14,7 @@ namespace Aspid.MVVM.StarterKit
     /// direction and needs a rotation.
     /// </remarks>
     [Serializable]
+    [TypeSelectorDisplay(Group = "Aspid/Rotation", Name = "Direction To Angle", Tooltip = "Reads the angle a direction points in")]
     public sealed class DirectionToAngleConverter : IConverter<Vector2, float>
     {
         [Tooltip("Report the angle in degrees rather than radians.")]

--- a/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Unity/Runtime/Converters/Rotations/EulerToQuaternionConverter.cs
+++ b/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Unity/Runtime/Converters/Rotations/EulerToQuaternionConverter.cs
@@ -1,4 +1,5 @@
 #nullable enable
+using Aspid.FastTools.Types;
 using System;
 using UnityEngine;
 
@@ -13,6 +14,7 @@ namespace Aspid.MVVM.StarterKit
     /// directions are here because the pair round-trips within the ±180 convention.
     /// </remarks>
     [Serializable]
+    [TypeSelectorDisplay(Group = "Aspid/Rotation", Name = "Euler To Quaternion", Tooltip = "Turns Euler angles into a rotation")]
     public sealed class EulerToQuaternionConverter : ITwoWayConverter<Vector3, Quaternion>
     {
         /// <summary>

--- a/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Unity/Runtime/Converters/Rotations/LookRotationConverter.cs
+++ b/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Unity/Runtime/Converters/Rotations/LookRotationConverter.cs
@@ -1,4 +1,5 @@
 #nullable enable
+using Aspid.FastTools.Types;
 using System;
 using UnityEngine;
 
@@ -9,6 +10,7 @@ namespace Aspid.MVVM.StarterKit
     /// Builds a rotation that looks along a direction.
     /// </summary>
     [Serializable]
+    [TypeSelectorDisplay(Group = "Aspid/Rotation", Name = "Look Rotation", Tooltip = "Builds a rotation that looks along a direction")]
     public sealed class LookRotationConverter : IConverter<Vector3, Quaternion>
     {
         [Tooltip("Which way is up for the produced rotation.")]

--- a/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Unity/Runtime/Converters/Rotations/QuaternionOffsetConverter.cs
+++ b/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Unity/Runtime/Converters/Rotations/QuaternionOffsetConverter.cs
@@ -1,4 +1,5 @@
 #nullable enable
+using Aspid.FastTools.Types;
 using System;
 using UnityEngine;
 
@@ -13,6 +14,7 @@ namespace Aspid.MVVM.StarterKit
     /// which way the art faces.
     /// </remarks>
     [Serializable]
+    [TypeSelectorDisplay(Group = "Aspid/Rotation", Name = "Quaternion Offset", Tooltip = "Applies a fixed rotation on top of a bound one")]
     public sealed class QuaternionOffsetConverter : ITwoWayConverter<Quaternion, Quaternion>
     {
         [Tooltip("The rotation applied on top of the bound one, in Euler degrees.")]

--- a/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Unity/Runtime/Converters/Rotations/QuaternionToEulerConverter.cs
+++ b/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Unity/Runtime/Converters/Rotations/QuaternionToEulerConverter.cs
@@ -1,4 +1,5 @@
 #nullable enable
+using Aspid.FastTools.Types;
 using System;
 using UnityEngine;
 
@@ -14,6 +15,7 @@ namespace Aspid.MVVM.StarterKit
     /// ±180 is the option that removes the trap.
     /// </remarks>
     [Serializable]
+    [TypeSelectorDisplay(Group = "Aspid/Rotation", Name = "Quaternion To Euler", Tooltip = "Reads Euler angles off a rotation")]
     public sealed class QuaternionToEulerConverter : IConverter<Quaternion, Vector3>
     {
         [Tooltip("Report angles as -180..180 rather than Unity's 0..360.")]

--- a/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Unity/Runtime/Converters/Strings/RichTextColorConverter.cs
+++ b/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Unity/Runtime/Converters/Strings/RichTextColorConverter.cs
@@ -1,4 +1,5 @@
 #nullable enable
+using Aspid.FastTools.Types;
 using System;
 using UnityEngine;
 
@@ -13,6 +14,7 @@ namespace Aspid.MVVM.StarterKit
     /// nobody has to.
     /// </remarks>
     [Serializable]
+    [TypeSelectorDisplay(Group = "Aspid/String", Name = "Rich Text Color", Tooltip = "Wraps a string in a rich-text colour tag")]
     public sealed class RichTextColorConverter : IConverterString
     {
         [Tooltip("The colour the text is tagged with.")]

--- a/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Unity/Runtime/Converters/Strings/RichTextNoParseConverter.cs
+++ b/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Unity/Runtime/Converters/Strings/RichTextNoParseConverter.cs
@@ -1,5 +1,7 @@
 #nullable enable
+using Aspid.FastTools.Types;
 using System;
+using UnityEngine;
 
 // ReSharper disable once CheckNamespace
 namespace Aspid.MVVM.StarterKit
@@ -14,6 +16,7 @@ namespace Aspid.MVVM.StarterKit
     /// type — the rest of the converters here add markup and are for text the game itself authors.
     /// </remarks>
     [Serializable]
+    [TypeSelectorDisplay(Group = "Aspid/String", Name = "Rich Text No Parse", Tooltip = "Stops rich-text markup in a string from being interpreted")]
     public sealed class RichTextNoParseConverter : IConverterString
     {
         /// <summary>

--- a/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Unity/Runtime/Converters/Strings/RichTextSizeConverter.cs
+++ b/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Unity/Runtime/Converters/Strings/RichTextSizeConverter.cs
@@ -1,4 +1,5 @@
 #nullable enable
+using Aspid.FastTools.Types;
 using System;
 using UnityEngine;
 
@@ -9,6 +10,7 @@ namespace Aspid.MVVM.StarterKit
     /// Wraps a string in a rich-text size tag.
     /// </summary>
     [Serializable]
+    [TypeSelectorDisplay(Group = "Aspid/String", Name = "Rich Text Size", Tooltip = "Wraps a string in a rich-text size tag")]
     public sealed class RichTextSizeConverter : IConverterString
     {
         [Tooltip("The size applied to the text.")]

--- a/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Unity/Runtime/Converters/Strings/RichTextStyleConverter.cs
+++ b/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Unity/Runtime/Converters/Strings/RichTextStyleConverter.cs
@@ -1,4 +1,5 @@
 #nullable enable
+using Aspid.FastTools.Types;
 using System;
 using UnityEngine;
 
@@ -9,6 +10,7 @@ namespace Aspid.MVVM.StarterKit
     /// Wraps a string in rich-text style tags.
     /// </summary>
     [Serializable]
+    [TypeSelectorDisplay(Group = "Aspid/String", Name = "Rich Text Style", Tooltip = "Wraps a string in rich-text style tags")]
     public sealed class RichTextStyleConverter : IConverterString
     {
         [Tooltip("Wrap in <b>.")]

--- a/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Unity/Runtime/Converters/Strings/ThresholdRichTextColorConverter.cs
+++ b/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Unity/Runtime/Converters/Strings/ThresholdRichTextColorConverter.cs
@@ -1,4 +1,5 @@
 #nullable enable
+using Aspid.FastTools.Types;
 using System;
 using UnityEngine;
 
@@ -14,6 +15,7 @@ namespace Aspid.MVVM.StarterKit
     /// kept in step.
     /// </remarks>
     [Serializable]
+    [TypeSelectorDisplay(Group = "Aspid/String", Name = "Threshold Rich Text Color", Tooltip = "Writes a number as coloured text, the colour chosen by how large it is")]
     public sealed class ThresholdRichTextColorConverter : IConverter<float, string>
     {
         [Tooltip("Colours by threshold. The highest threshold at or below the value wins.")]

--- a/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Unity/Runtime/Converters/Textures/NormalizedToSpriteConverter.cs
+++ b/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Unity/Runtime/Converters/Textures/NormalizedToSpriteConverter.cs
@@ -1,4 +1,5 @@
 #nullable enable
+using Aspid.FastTools.Types;
 using System;
 using UnityEngine;
 
@@ -13,6 +14,7 @@ namespace Aspid.MVVM.StarterKit
     /// fixed set of frames.
     /// </remarks>
     [Serializable]
+    [TypeSelectorDisplay(Group = "Aspid/Texture", Name = "Normalized To Sprite", Tooltip = "Picks one of a list of sprites by a 0..1 amount")]
     public sealed class NormalizedToSpriteConverter : IConverter<float, Sprite?>
     {
         [Tooltip("The frames, from empty to full.")]

--- a/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Unity/Runtime/Converters/Textures/ObjectNameConverter.cs
+++ b/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Unity/Runtime/Converters/Textures/ObjectNameConverter.cs
@@ -1,4 +1,5 @@
 #nullable enable
+using Aspid.FastTools.Types;
 using System;
 using UnityEngine;
 
@@ -10,6 +11,7 @@ namespace Aspid.MVVM.StarterKit
     /// </summary>
     /// <remarks>Debug overlays and tooltips that label whatever they are pointed at.</remarks>
     [Serializable]
+    [TypeSelectorDisplay(Group = "Aspid/Texture", Name = "Object Name", Tooltip = "Reads the name of a Unity object")]
     public sealed class ObjectNameConverter : IConverter<UnityEngine.Object?, string>
     {
         [Tooltip("Shown when the object is missing.")]

--- a/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Unity/Runtime/Converters/Textures/SpriteToTextureConverter.cs
+++ b/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Unity/Runtime/Converters/Textures/SpriteToTextureConverter.cs
@@ -1,4 +1,5 @@
 #nullable enable
+using Aspid.FastTools.Types;
 using System;
 using UnityEngine;
 
@@ -13,6 +14,7 @@ namespace Aspid.MVVM.StarterKit
     /// <see cref="Texture"/> — two properties for one picture.
     /// </remarks>
     [Serializable]
+    [TypeSelectorDisplay(Group = "Aspid/Texture", Name = "Sprite To Texture", Tooltip = "Takes the texture a  is drawn from")]
     public sealed class SpriteToTextureConverter : IConverter<Sprite?, Texture?>
     {
         /// <summary>

--- a/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Unity/Runtime/Converters/Textures/Texture2DToSpriteConverter.cs
+++ b/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Unity/Runtime/Converters/Textures/Texture2DToSpriteConverter.cs
@@ -1,4 +1,5 @@
 #nullable enable
+using Aspid.FastTools.Types;
 using System;
 using UnityEngine;
 
@@ -14,6 +15,7 @@ namespace Aspid.MVVM.StarterKit
     /// against the texture it came from. Without that, a bound avatar leaks a sprite per frame.
     /// </remarks>
     [Serializable]
+    [TypeSelectorDisplay(Group = "Aspid/Texture", Name = "Texture2 D To Sprite", Tooltip = "Wraps a  in a ")]
     public sealed class Texture2DToSpriteConverter : IConverter<Texture2D?, Sprite?>
     {
         [Tooltip("Where the sprite's pivot sits, in normalised coordinates.")]

--- a/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Unity/Runtime/Converters/Vectors/BoxColliderCentreCombineConverter.cs
+++ b/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Unity/Runtime/Converters/Vectors/BoxColliderCentreCombineConverter.cs
@@ -1,4 +1,5 @@
 #nullable enable
+using Aspid.FastTools.Types;
 using System;
 using UnityEngine;
 
@@ -9,6 +10,7 @@ namespace Aspid.MVVM.StarterKit
     /// Combines a vector with a <see cref="BoxCollider"/>'s center point.
     /// </summary>
     [Serializable]
+    [TypeSelectorDisplay(Group = "Aspid/Vector", Name = "Box Collider Centre Combine", Tooltip = "Combines a vector with a 's center point")]
     public sealed class BoxColliderCentreCombineConverter : Vector3CombineConverter
     {
         [Tooltip("The collider whose centre the bound vector is combined with.")]

--- a/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Unity/Runtime/Converters/Vectors/BoxColliderSizeCombineConverter.cs
+++ b/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Unity/Runtime/Converters/Vectors/BoxColliderSizeCombineConverter.cs
@@ -1,4 +1,5 @@
 #nullable enable
+using Aspid.FastTools.Types;
 using System;
 using UnityEngine;
 
@@ -9,6 +10,7 @@ namespace Aspid.MVVM.StarterKit
     /// Combines a vector with a <see cref="BoxCollider"/>'s size.
     /// </summary>
     [Serializable]
+    [TypeSelectorDisplay(Group = "Aspid/Vector", Name = "Box Collider Size Combine", Tooltip = "Combines a vector with a 's size")]
     public sealed class BoxColliderSizeCombineConverter : Vector3CombineConverter
     {
         [Tooltip("The collider whose size the bound vector is combined with.")]

--- a/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Unity/Runtime/Converters/Vectors/CapsuleColliderCentreCombineConverter.cs
+++ b/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Unity/Runtime/Converters/Vectors/CapsuleColliderCentreCombineConverter.cs
@@ -1,4 +1,5 @@
 #nullable enable
+using Aspid.FastTools.Types;
 using System;
 using UnityEngine;
 
@@ -9,6 +10,7 @@ namespace Aspid.MVVM.StarterKit
     /// Combines a vector with a <see cref="CapsuleCollider"/>'s center point.
     /// </summary>
     [Serializable]
+    [TypeSelectorDisplay(Group = "Aspid/Vector", Name = "Capsule Collider Centre Combine", Tooltip = "Combines a vector with a 's center point")]
     public sealed class CapsuleColliderCentreCombineConverter : Vector3CombineConverter
     {
         [Tooltip("The collider whose centre the bound vector is combined with.")]

--- a/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Unity/Runtime/Converters/Vectors/FloatToVector2Converter.cs
+++ b/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Unity/Runtime/Converters/Vectors/FloatToVector2Converter.cs
@@ -1,4 +1,5 @@
 #nullable enable
+using Aspid.FastTools.Types;
 using System;
 using UnityEngine;
 
@@ -9,6 +10,7 @@ namespace Aspid.MVVM.StarterKit
     /// Writes one number into the chosen axes of a 2D vector.
     /// </summary>
     [Serializable]
+    [TypeSelectorDisplay(Group = "Aspid/Vector", Name = "Float To Vector2", Tooltip = "Writes one number into the chosen axes of a 2D vector")]
     public sealed class FloatToVector2Converter : IConverter<float, Vector2>
     {
         [Tooltip("Which axes the number is written into.")]

--- a/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Unity/Runtime/Converters/Vectors/FloatToVector3Converter.cs
+++ b/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Unity/Runtime/Converters/Vectors/FloatToVector3Converter.cs
@@ -1,4 +1,5 @@
 #nullable enable
+using Aspid.FastTools.Types;
 using System;
 using UnityEngine;
 
@@ -13,6 +14,7 @@ namespace Aspid.MVVM.StarterKit
     /// currently hard-code this fan-out, so the choice of axes is theirs rather than the author's.
     /// </remarks>
     [Serializable]
+    [TypeSelectorDisplay(Group = "Aspid/Vector", Name = "Float To Vector3", Tooltip = "Writes one number into the chosen axes of a vector")]
     public sealed class FloatToVector3Converter : IConverter<float, Vector3>
     {
         [Tooltip("Which axes the number is written into.")]

--- a/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Unity/Runtime/Converters/Vectors/RectTransformAnchoredPositionCombineConverter.cs
+++ b/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Unity/Runtime/Converters/Vectors/RectTransformAnchoredPositionCombineConverter.cs
@@ -1,4 +1,5 @@
 #nullable enable
+using Aspid.FastTools.Types;
 using System;
 using UnityEngine;
 
@@ -9,6 +10,7 @@ namespace Aspid.MVVM.StarterKit
     /// Combines a vector with a <see cref="RectTransform"/>'s anchored position.
     /// </summary>
     [Serializable]
+    [TypeSelectorDisplay(Group = "Aspid/Vector", Name = "Rect Transform Anchored Position Combine", Tooltip = "Combines a vector with a 's anchored position")]
     public sealed class RectTransformAnchoredPositionCombineConverter : Vector3CombineConverter
     {
         [Tooltip("The rect transform whose anchored position the bound vector is combined with.")]

--- a/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Unity/Runtime/Converters/Vectors/SphereColliderCentreCombineConverter.cs
+++ b/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Unity/Runtime/Converters/Vectors/SphereColliderCentreCombineConverter.cs
@@ -1,4 +1,5 @@
 #nullable enable
+using Aspid.FastTools.Types;
 using System;
 using UnityEngine;
 
@@ -9,6 +10,7 @@ namespace Aspid.MVVM.StarterKit
     /// Combines a vector with a <see cref="SphereCollider"/>'s center point.
     /// </summary>
     [Serializable]
+    [TypeSelectorDisplay(Group = "Aspid/Vector", Name = "Sphere Collider Centre Combine", Tooltip = "Combines a vector with a 's center point")]
     public sealed class SphereColliderCentreCombineConverter : Vector3CombineConverter
     {
         [Tooltip("The collider whose centre the bound vector is combined with.")]

--- a/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Unity/Runtime/Converters/Vectors/TransformEulerAnglesCombineConverter.cs
+++ b/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Unity/Runtime/Converters/Vectors/TransformEulerAnglesCombineConverter.cs
@@ -1,4 +1,5 @@
 #nullable enable
+using Aspid.FastTools.Types;
 using System;
 using UnityEngine;
 
@@ -9,6 +10,7 @@ namespace Aspid.MVVM.StarterKit
     /// Combines a vector with a <see cref="Transform"/>'s Euler angles.
     /// </summary>
     [Serializable]
+    [TypeSelectorDisplay(Group = "Aspid/Vector", Name = "Transform Euler Angles Combine", Tooltip = "Combines a vector with a 's Euler angles")]
     public sealed class TransformEulerAnglesCombineConverter : Vector3CombineConverter
     {
         [Tooltip("The transform whose Euler angles the bound vector is combined with.")]

--- a/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Unity/Runtime/Converters/Vectors/TransformPositionCombineConverter.cs
+++ b/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Unity/Runtime/Converters/Vectors/TransformPositionCombineConverter.cs
@@ -1,4 +1,5 @@
 #nullable enable
+using Aspid.FastTools.Types;
 using System;
 using UnityEngine;
 
@@ -9,6 +10,7 @@ namespace Aspid.MVVM.StarterKit
     /// Combines a vector with a <see cref="Transform"/>'s current position.
     /// </summary>
     [Serializable]
+    [TypeSelectorDisplay(Group = "Aspid/Vector", Name = "Transform Position Combine", Tooltip = "Combines a vector with a 's current position")]
     public sealed class TransformPositionCombineConverter : Vector3CombineConverter
     {
         [Tooltip("The transform whose position the bound vector is combined with.")]

--- a/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Unity/Runtime/Converters/Vectors/TransformScaleCombineConverter.cs
+++ b/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Unity/Runtime/Converters/Vectors/TransformScaleCombineConverter.cs
@@ -1,4 +1,5 @@
 #nullable enable
+using Aspid.FastTools.Types;
 using System;
 using UnityEngine;
 
@@ -9,6 +10,7 @@ namespace Aspid.MVVM.StarterKit
     /// Combines a vector with a <see cref="Transform"/>'s local scale.
     /// </summary>
     [Serializable]
+    [TypeSelectorDisplay(Group = "Aspid/Vector", Name = "Transform Scale Combine", Tooltip = "Combines a vector with a 's local scale")]
     public sealed class TransformScaleCombineConverter : Vector3CombineConverter
     {
         [Tooltip("The transform whose local scale the bound vector is combined with.")]

--- a/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Unity/Runtime/Converters/Vectors/Vector2CombineConverter.cs
+++ b/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Unity/Runtime/Converters/Vectors/Vector2CombineConverter.cs
@@ -1,4 +1,5 @@
 #nullable enable
+using Aspid.FastTools.Types;
 using System;
 using UnityEngine;
 #if UNITY_2023_1_OR_NEWER
@@ -15,6 +16,7 @@ namespace Aspid.MVVM.StarterKit
     /// Supports optional pre- and post-conversion transformations.
     /// </summary>
     [Serializable]
+    [TypeSelectorDisplay(Group = "Aspid/Vector", Name = "Vector2 Combine", Tooltip = "Combines two  values by selecting which components to use from each vector")]
     public sealed class Vector2CombineConverter
     {
         [Tooltip("Which components come from the bound vector; the rest come from the reference one.")]

--- a/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Unity/Runtime/Converters/Vectors/Vector2SubstitutionConverter.cs
+++ b/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Unity/Runtime/Converters/Vectors/Vector2SubstitutionConverter.cs
@@ -1,4 +1,5 @@
 #nullable enable
+using Aspid.FastTools.Types;
 using System;
 using UnityEngine;
 
@@ -10,6 +11,7 @@ namespace Aspid.MVVM.StarterKit
     /// Converts <see cref="Vector2"/> values by substituting and rearranging their components.
     /// </summary>
     [Serializable]
+    [TypeSelectorDisplay(Group = "Aspid/Vector", Name = "Vector2 Substitution", Tooltip = "Converts  values by substituting and rearranging their components")]
     public sealed class Vector2SubstitutionConverter : IConverterVector2
     {
         [Tooltip("How the components are rearranged.")]

--- a/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Unity/Runtime/Converters/Vectors/Vector2ToVector2IntConverter.cs
+++ b/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Unity/Runtime/Converters/Vectors/Vector2ToVector2IntConverter.cs
@@ -1,4 +1,5 @@
 #nullable enable
+using Aspid.FastTools.Types;
 using System;
 using UnityEngine;
 
@@ -9,6 +10,7 @@ namespace Aspid.MVVM.StarterKit
     /// Converts a 2D vector to its integer form.
     /// </summary>
     [Serializable]
+    [TypeSelectorDisplay(Group = "Aspid/Vector", Name = "Vector2 To Vector2 Int", Tooltip = "Converts a 2D vector to its integer form")]
     public sealed class Vector2ToVector2IntConverter : ITwoWayConverter<Vector2, Vector2Int>
     {
         [Tooltip("Which way to drop the fraction.")]

--- a/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Unity/Runtime/Converters/Vectors/Vector2ToVector3Converter.cs
+++ b/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Unity/Runtime/Converters/Vectors/Vector2ToVector3Converter.cs
@@ -1,4 +1,5 @@
 #nullable enable
+using Aspid.FastTools.Types;
 using System;
 using UnityEngine;
 
@@ -9,6 +10,7 @@ namespace Aspid.MVVM.StarterKit
     /// Converts <see cref="Vector2"/> values to <see cref="Vector3"/> by specifying which components to use and a constant value for the third component.
     /// </summary>
     [Serializable]
+    [TypeSelectorDisplay(Group = "Aspid/Vector", Name = "Vector2 To Vector3", Tooltip = "Converts  values to  by specifying which components to use and a constant value for the third component")]
     public sealed class Vector2ToVector3Converter : IConverterVector2ToVector3
     {
         [Tooltip("Which axes of the 3D vector the 2D components are written into.")]

--- a/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Unity/Runtime/Converters/Vectors/Vector3ArithmeticConverter.cs
+++ b/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Unity/Runtime/Converters/Vectors/Vector3ArithmeticConverter.cs
@@ -1,4 +1,5 @@
 #nullable enable
+using Aspid.FastTools.Types;
 using System;
 using UnityEngine;
 
@@ -13,6 +14,7 @@ namespace Aspid.MVVM.StarterKit
     /// scalars.
     /// </remarks>
     [Serializable]
+    [TypeSelectorDisplay(Group = "Aspid/Vector", Name = "Vector3 Arithmetic", Tooltip = "Combines a bound vector with an authored one")]
     public sealed class Vector3ArithmeticConverter : IConverterVector3
     {
         [Tooltip("What to do with the operand.")]

--- a/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Unity/Runtime/Converters/Vectors/Vector3SubstitutionConverter.cs
+++ b/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Unity/Runtime/Converters/Vectors/Vector3SubstitutionConverter.cs
@@ -1,4 +1,5 @@
 #nullable enable
+using Aspid.FastTools.Types;
 using System;
 using UnityEngine;
 
@@ -10,6 +11,7 @@ namespace Aspid.MVVM.StarterKit
     /// Converts <see cref="Vector3"/> values by substituting and rearranging their components.
     /// </summary>
     [Serializable]
+    [TypeSelectorDisplay(Group = "Aspid/Vector", Name = "Vector3 Substitution", Tooltip = "Converts  values by substituting and rearranging their components")]
     public sealed class Vector3SubstitutionConverter : IConverterVector3
     {
         [Tooltip("How the components are rearranged.")]

--- a/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Unity/Runtime/Converters/Vectors/Vector3ToFloatConverter.cs
+++ b/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Unity/Runtime/Converters/Vectors/Vector3ToFloatConverter.cs
@@ -1,4 +1,5 @@
 #nullable enable
+using Aspid.FastTools.Types;
 using System;
 using UnityEngine;
 
@@ -10,6 +11,7 @@ namespace Aspid.MVVM.StarterKit
     /// </summary>
     /// <remarks>Driving a bar or a label from one axis, or from how long the vector is.</remarks>
     [Serializable]
+    [TypeSelectorDisplay(Group = "Aspid/Vector", Name = "Vector3 To Float", Tooltip = "Measures one number out of a vector")]
     public sealed class Vector3ToFloatConverter : IConverter<Vector3, float>
     {
         [Tooltip("Which number to take.")]

--- a/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Unity/Runtime/Converters/Vectors/Vector3ToVector2Converter.cs
+++ b/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Unity/Runtime/Converters/Vectors/Vector3ToVector2Converter.cs
@@ -1,4 +1,5 @@
 #nullable enable
+using Aspid.FastTools.Types;
 using System;
 using UnityEngine;
 
@@ -10,6 +11,7 @@ namespace Aspid.MVVM.StarterKit
     /// Converts <see cref="Vector3"/> values to <see cref="Vector2"/> by selecting which components to use.
     /// </summary>
     [Serializable]
+    [TypeSelectorDisplay(Group = "Aspid/Vector", Name = "Vector3 To Vector2", Tooltip = "Converts  values to  by selecting which components to use")]
     public sealed class Vector3ToVector2Converter : IConverterVector3ToVector2
     {
         [Tooltip("Which components of the 3D vector are kept, and in what order.")]

--- a/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Unity/Runtime/Converters/Vectors/Vector3ToVector3IntConverter.cs
+++ b/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Unity/Runtime/Converters/Vectors/Vector3ToVector3IntConverter.cs
@@ -1,4 +1,5 @@
 #nullable enable
+using Aspid.FastTools.Types;
 using System;
 using UnityEngine;
 
@@ -13,6 +14,7 @@ namespace Aspid.MVVM.StarterKit
     /// and the package had no way to reach them.
     /// </remarks>
     [Serializable]
+    [TypeSelectorDisplay(Group = "Aspid/Vector", Name = "Vector3 To Vector3 Int", Tooltip = "Converts a vector to its integer form")]
     public sealed class Vector3ToVector3IntConverter : ITwoWayConverter<Vector3, Vector3Int>
     {
         [Tooltip("Which way to drop the fraction.")]

--- a/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Unity/Runtime/Converters/Vectors/VectorClampMagnitudeConverter.cs
+++ b/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Unity/Runtime/Converters/Vectors/VectorClampMagnitudeConverter.cs
@@ -1,4 +1,5 @@
 #nullable enable
+using Aspid.FastTools.Types;
 using System;
 using UnityEngine;
 
@@ -10,6 +11,7 @@ namespace Aspid.MVVM.StarterKit
     /// </summary>
     /// <remarks>Holding a joystick offset or a drag inside a panel's radius.</remarks>
     [Serializable]
+    [TypeSelectorDisplay(Group = "Aspid/Vector", Name = "Vector Clamp Magnitude", Tooltip = "Keeps a vector inside a length")]
     public sealed class VectorClampMagnitudeConverter : IConverterVector3
     {
         [Tooltip("The longest the vector is allowed to be.")]

--- a/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Unity/Runtime/Converters/Vectors/VectorLerpConverter.cs
+++ b/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Unity/Runtime/Converters/Vectors/VectorLerpConverter.cs
@@ -1,4 +1,5 @@
 #nullable enable
+using Aspid.FastTools.Types;
 using System;
 using UnityEngine;
 
@@ -10,6 +11,7 @@ namespace Aspid.MVVM.StarterKit
     /// </summary>
     /// <remarks>A marker travelling along a track as progress advances.</remarks>
     [Serializable]
+    [TypeSelectorDisplay(Group = "Aspid/Vector", Name = "Vector Lerp", Tooltip = "Moves between two vectors by a 0..1 amount")]
     public sealed class VectorLerpConverter : IConverter<float, Vector3>
     {
         [Tooltip("The vector at 0.")]

--- a/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Unity/Runtime/Converters/Vectors/VectorNormalizeConverter.cs
+++ b/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Unity/Runtime/Converters/Vectors/VectorNormalizeConverter.cs
@@ -1,4 +1,5 @@
 #nullable enable
+using Aspid.FastTools.Types;
 using System;
 using UnityEngine;
 
@@ -9,6 +10,7 @@ namespace Aspid.MVVM.StarterKit
     /// Reduces a vector to its direction.
     /// </summary>
     [Serializable]
+    [TypeSelectorDisplay(Group = "Aspid/Vector", Name = "Vector Normalize", Tooltip = "Reduces a vector to its direction")]
     public sealed class VectorNormalizeConverter : IConverterVector3
     {
         /// <summary>

--- a/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Unity/Runtime/Converters/Vectors/VectorRoundConverter.cs
+++ b/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Unity/Runtime/Converters/Vectors/VectorRoundConverter.cs
@@ -1,4 +1,5 @@
 #nullable enable
+using Aspid.FastTools.Types;
 using System;
 using UnityEngine;
 
@@ -10,6 +11,7 @@ namespace Aspid.MVVM.StarterKit
     /// </summary>
     /// <remarks>Snapping to a grid, for tile-based UI and level tools.</remarks>
     [Serializable]
+    [TypeSelectorDisplay(Group = "Aspid/Vector", Name = "Vector Round", Tooltip = "Rounds every axis of a vector")]
     public sealed class VectorRoundConverter : IConverterVector3
     {
         [Tooltip("Which way to drop the fraction.")]

--- a/Aspid.MVVM/Packages/tech.aspid.mvvm/Tests/Editor/Converters/ConverterInspectorContractTests.cs
+++ b/Aspid.MVVM/Packages/tech.aspid.mvvm/Tests/Editor/Converters/ConverterInspectorContractTests.cs
@@ -31,6 +31,33 @@ namespace Aspid.MVVM.StarterKit.Tests
             Assert.IsEmpty(undocumented, Explain(undocumented));
         }
 
+        /// <summary>
+        /// Every converter the picker offers should say where it belongs and what it is for.
+        /// </summary>
+        /// <remarks>
+        /// The dropdown lists them by namespace, and they share one — so without a group the whole
+        /// catalogue arrives as a single flat list of a hundred-odd entries, which is a worse way to
+        /// find a converter than knowing its name already.
+        /// </remarks>
+        [Test]
+        public void EveryPickableConverterIsGroupedAndDescribed()
+        {
+            var ungrouped = ConverterTypes()
+                .Where(type => !type.IsAbstract)
+                .Where(type => !typeof(UnityEngine.Object).IsAssignableFrom(type))
+                .Where(type => type.IsDefined(typeof(SerializableAttribute), inherit: false))
+                .Select(type => (type, display: type.GetCustomAttribute<Aspid.FastTools.Types.TypeSelectorDisplayAttribute>(inherit: false)))
+                .Where(pair => pair.display is null || string.IsNullOrEmpty(pair.display.Group))
+                .Select(pair => pair.type)
+                .ToArray();
+
+            Assert.IsEmpty(
+                ungrouped,
+                "These converters appear in the picker with no group, so they land in one flat list:"
+                + Environment.NewLine
+                + string.Join(Environment.NewLine, ungrouped.Select(type => "  - " + type.Name)));
+        }
+
         // Guards the check above from passing because the scan stopped finding fields.
         [Test]
         public void TheScanSeesTheSerializedFields() =>


### PR DESCRIPTION
📝 Audit item 4.2: the `[SerializeReference]` picker lists candidates by namespace, and all ~150 converters share one — a flat list is a worse way to find a converter than already knowing its name.

## Summary

- 📝 Every pickable converter carries a group, a spaced display name and a one-line tooltip derived from its own summary, so the two cannot drift.
- 📝 Groups: `Aspid/Bool`, `Number`, `String`, `Time`, `Enum`, `Object`, `Collection`, `Composition`, `Colour`, `Vector`, `Rotation`, `Layout`, `Texture`, `Asset`, `Localization`.
- ✅ A test fails on any `[Serializable]` converter the picker can offer that declares no group; `ScriptableObject` assets and hidden types are excluded because the picker never offers them.

## Notes for review

- 📝 Paired with the tooltip test from #173, both halves of "can somebody find this in the Inspector, and understand it once found" are enforced rather than remembered.
- ⚠️ Two files needed the `using` inserted by hand — they open with a `#if`, so the automated insertion landed above the directive and did nothing (25 compiler errors caught it).
- ✅ Local run: 612 total, 610 passed, 0 failed, 2 skipped.

<details>
<summary>🇷🇺 Описание на русском</summary>

📝 Пункт аудита 4.2: пикер `[SerializeReference]` перечисляет кандидатов по неймспейсу, а все ~150 конвертеров лежат в одном — плоский список хуже, чем просто знать имя нужного конвертера.

## Итог

- 📝 У каждого конвертера в пикере есть группа, читаемое имя с пробелами и однострочный тултип, выведенный из его же summary, — так они не разъедутся.
- 📝 Группы: `Aspid/Bool`, `Number`, `String`, `Time`, `Enum`, `Object`, `Collection`, `Composition`, `Colour`, `Vector`, `Rotation`, `Layout`, `Texture`, `Asset`, `Localization`.
- ✅ Тест валится на любом `[Serializable]`-конвертере из пикера без группы; ассеты `ScriptableObject` и скрытые типы исключены, потому что пикер их не предлагает.

## Заметки для ревью

- 📝 Вместе с тестом тултипов из #173 обе половины вопроса «найдут ли это в инспекторе и поймут ли, найдя» проверяются, а не держатся в памяти.
- ⚠️ В двух файлах `using` пришлось вставить руками — они начинаются с `#if`, и автоматическая вставка попадала выше директивы (это поймали 25 ошибок компиляции).
- ✅ Локальный прогон: 612 всего, 610 прошло, 0 упало, 2 пропущено.

</details>

