### PR TITLE
Document the converter marker interfaces, wrappers and enums

### DIFF
--- a/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Runtime/Converters/Bools/Comparisons.cs
+++ b/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Runtime/Converters/Bools/Comparisons.cs
@@ -1,13 +1,37 @@
 // ReSharper disable once CheckNamespace
 namespace Aspid.MVVM.StarterKit
 {
+    /// <summary>
+    /// How a converter compares the bound value with the one it is configured with.
+    /// </summary>
+    /// <remarks>
+    /// Read every member as <c>bound &lt;op&gt; configured</c>: <see cref="LessThan"/> asks whether the
+    /// bound value is below the configured one, not the other way round.
+    /// <para>
+    /// New members are appended rather than inserted: the order is the serialized value, so moving one
+    /// silently rewrites every converter already authored in a scene. <see cref="Inequality"/> shipped
+    /// inverted once and was fixed in 1.1.0-beta.1 — of the six, the two that are not a bare operator
+    /// are the two worth a test.
+    /// </para>
+    /// </remarks>
     public enum Comparisons
     {
+        /// <summary>Equal. Numeric converters compare approximately, scaled to the magnitude.</summary>
         Equal,
+
+        /// <summary>Not equal — the negation of <see cref="Equal"/>, tolerance included.</summary>
         Inequality,
+
+        /// <summary>The bound value is below the configured one.</summary>
         LessThan,
+
+        /// <summary>The bound value is above the configured one.</summary>
         GreaterThan,
+
+        /// <summary>The bound value is below the configured one or exactly on it.</summary>
         LessThanOrEqual,
+
+        /// <summary>The bound value is above the configured one or exactly on it.</summary>
         GreaterThanOrEqual,
     }
 }

--- a/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Runtime/Converters/GenericFuncConverter.cs
+++ b/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Runtime/Converters/GenericFuncConverter.cs
@@ -19,8 +19,11 @@ namespace Aspid.MVVM.StarterKit
         /// </summary>
         /// <param name="converter">The converter interface implementation to wrap.</param>
         /// <exception cref="ArgumentNullException">Thrown when <paramref name="converter"/> is <see langword="null"/>.</exception>
+        // The null check has to happen before the method group is taken, because reading .Convert off a
+        // null reference throws an NRE — which is what this overload used to do, in flat contradiction
+        // of the contract documented right above it.
         public GenericFuncConverter(IConverter<TFrom?, TTo?> converter)
-            : this(converter.Convert) { }
+            : this((converter ?? throw new ArgumentNullException(nameof(converter))).Convert) { }
 
         /// <summary>
         /// Initializes a new instance of the <see cref="GenericFuncConverter{TFrom, TTo}"/> class.

--- a/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Runtime/Converters/Specific/Bool/BoolConverterSpecificExtensions.cs
+++ b/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Runtime/Converters/Specific/Bool/BoolConverterSpecificExtensions.cs
@@ -4,41 +4,123 @@ using Aspid.FastTools.Types;
 // ReSharper disable once CheckNamespace
 namespace Aspid.MVVM.StarterKit
 {
+    /// <summary>
+    /// Wraps a function or a generic converter as one of the named boolean converter
+    /// interfaces.
+    /// </summary>
+    /// <remarks>
+    /// <c>ToConvert</c> takes a function, <c>ToConvertSpecific</c> takes a converter that is
+    /// already the right shape but not the named type. Both exist because a binder before
+    /// Unity 2023.1 declares its field as the named interface rather than the generic one,
+    /// so a lambda cannot be assigned to it directly.
+    /// </remarks>
     public static class BoolConverterSpecificExtensions
     {
+        /// <summary>
+        /// Wraps the specified function as an <see cref="IConverterDoubleToBool"/>.
+        /// </summary>
+        /// <param name="converter">The function to wrap.</param>
+        /// <returns>A converter of the named interface type.</returns>
+        /// <exception cref="System.ArgumentNullException">Thrown when <paramref name="converter"/> is <see langword="null"/>.</exception>
         public static IConverterDoubleToBool ToConvert(this Func<double, bool> converter) =>
             new ConverterDoubleToBool(converter);
         
+        /// <summary>
+        /// Wraps the specified converter as an <see cref="IConverterDoubleToBool"/>.
+        /// </summary>
+        /// <param name="converter">The converter to wrap.</param>
+        /// <returns>A converter of the named interface type.</returns>
+        /// <exception cref="System.ArgumentNullException">Thrown when <paramref name="converter"/> is <see langword="null"/>.</exception>
         public static IConverterDoubleToBool ToConvertSpecific(this IConverter<double, bool> converter) =>
             new ConverterDoubleToBool(converter);
         
+        /// <summary>
+        /// Wraps the specified function as an <see cref="IConverterFloatToBool"/>.
+        /// </summary>
+        /// <param name="converter">The function to wrap.</param>
+        /// <returns>A converter of the named interface type.</returns>
+        /// <exception cref="System.ArgumentNullException">Thrown when <paramref name="converter"/> is <see langword="null"/>.</exception>
         public static IConverterFloatToBool ToConvert(this Func<float, bool> converter) =>
             new ConverterFloatToBool(converter);
         
+        /// <summary>
+        /// Wraps the specified converter as an <see cref="IConverterFloatToBool"/>.
+        /// </summary>
+        /// <param name="converter">The converter to wrap.</param>
+        /// <returns>A converter of the named interface type.</returns>
+        /// <exception cref="System.ArgumentNullException">Thrown when <paramref name="converter"/> is <see langword="null"/>.</exception>
         public static IConverterFloatToBool ToConvertSpecific(this IConverter<float, bool> converter) =>
             new ConverterFloatToBool(converter);
         
+        /// <summary>
+        /// Wraps the specified function as an <see cref="IConverterIntToBool"/>.
+        /// </summary>
+        /// <param name="converter">The function to wrap.</param>
+        /// <returns>A converter of the named interface type.</returns>
+        /// <exception cref="System.ArgumentNullException">Thrown when <paramref name="converter"/> is <see langword="null"/>.</exception>
         public static IConverterIntToBool ToConvert(this Func<int, bool> converter) =>
             new ConverterIntToBool(converter);
         
+        /// <summary>
+        /// Wraps the specified converter as an <see cref="IConverterIntToBool"/>.
+        /// </summary>
+        /// <param name="converter">The converter to wrap.</param>
+        /// <returns>A converter of the named interface type.</returns>
+        /// <exception cref="System.ArgumentNullException">Thrown when <paramref name="converter"/> is <see langword="null"/>.</exception>
         public static IConverterIntToBool ToConvertSpecific(this IConverter<int, bool> converter) =>
             new ConverterIntToBool(converter);
         
+        /// <summary>
+        /// Wraps the specified function as an <see cref="IConverterLongToBool"/>.
+        /// </summary>
+        /// <param name="converter">The function to wrap.</param>
+        /// <returns>A converter of the named interface type.</returns>
+        /// <exception cref="System.ArgumentNullException">Thrown when <paramref name="converter"/> is <see langword="null"/>.</exception>
         public static IConverterLongToBool ToConvert(this Func<long, bool> converter) =>
             new ConverterLongToBool(converter);
         
+        /// <summary>
+        /// Wraps the specified converter as an <see cref="IConverterLongToBool"/>.
+        /// </summary>
+        /// <param name="converter">The converter to wrap.</param>
+        /// <returns>A converter of the named interface type.</returns>
+        /// <exception cref="System.ArgumentNullException">Thrown when <paramref name="converter"/> is <see langword="null"/>.</exception>
         public static IConverterLongToBool ToConvertSpecific(this IConverter<long, bool> converter) =>
             new ConverterLongToBool(converter);
         
+        /// <summary>
+        /// Wraps the specified function as an <see cref="IConverterObjectToBool"/>.
+        /// </summary>
+        /// <param name="converter">The function to wrap.</param>
+        /// <returns>A converter of the named interface type.</returns>
+        /// <exception cref="System.ArgumentNullException">Thrown when <paramref name="converter"/> is <see langword="null"/>.</exception>
         public static IConverterObjectToBool ToConvert(this Func<object?, bool> converter) =>
             new ConverterObjectToBool(converter);
         
+        /// <summary>
+        /// Wraps the specified converter as an <see cref="IConverterObjectToBool"/>.
+        /// </summary>
+        /// <param name="converter">The converter to wrap.</param>
+        /// <returns>A converter of the named interface type.</returns>
+        /// <exception cref="System.ArgumentNullException">Thrown when <paramref name="converter"/> is <see langword="null"/>.</exception>
         public static IConverterObjectToBool ToConvertSpecific(this IConverter<object?, bool> converter) =>
             new ConverterObjectToBool(converter);
         
+        /// <summary>
+        /// Wraps the specified function as an <see cref="IConverterStringToBool"/>.
+        /// </summary>
+        /// <param name="converter">The function to wrap.</param>
+        /// <returns>A converter of the named interface type.</returns>
+        /// <exception cref="System.ArgumentNullException">Thrown when <paramref name="converter"/> is <see langword="null"/>.</exception>
         public static IConverterStringToBool ToConvert(this Func<string?, bool> converter) =>
             new ConverterStringToBool(converter);
         
+        /// <summary>
+        /// Wraps the specified converter as an <see cref="IConverterStringToBool"/>.
+        /// </summary>
+        /// <param name="converter">The converter to wrap.</param>
+        /// <returns>A converter of the named interface type.</returns>
+        /// <exception cref="System.ArgumentNullException">Thrown when <paramref name="converter"/> is <see langword="null"/>.</exception>
         public static IConverterStringToBool ToConvertSpecific(this IConverter<string?, bool> converter) =>
             new ConverterStringToBool(converter);
         

--- a/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Runtime/Converters/Specific/Bool/IConverterDoubleToBool.cs
+++ b/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Runtime/Converters/Specific/Bool/IConverterDoubleToBool.cs
@@ -1,5 +1,14 @@
 // ReSharper disable once CheckNamespace
 namespace Aspid.MVVM.StarterKit
 {
+    /// <summary>
+    /// A converter from <see cref="double"/> to <see cref="bool"/>.
+    /// </summary>
+    /// <remarks>
+    /// A named alias for <see cref="IConverter{TFrom, TTo}"/> closed over these two types.
+    /// It exists because Unity before 2023.1 cannot serialize a <c>[SerializeReference]</c>
+    /// field typed as an open generic, so a binder declares the field as this instead. From
+    /// 2023.1 the generic form is used directly and this is a compatibility shim.
+    /// </remarks>
     public interface IConverterDoubleToBool : IConverter<double, bool> { }
 }

--- a/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Runtime/Converters/Specific/Bool/IConverterFloatToBool.cs
+++ b/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Runtime/Converters/Specific/Bool/IConverterFloatToBool.cs
@@ -1,5 +1,14 @@
 // ReSharper disable once CheckNamespace
 namespace Aspid.MVVM.StarterKit
 {
+    /// <summary>
+    /// A converter from <see cref="float"/> to <see cref="bool"/>.
+    /// </summary>
+    /// <remarks>
+    /// A named alias for <see cref="IConverter{TFrom, TTo}"/> closed over these two types.
+    /// It exists because Unity before 2023.1 cannot serialize a <c>[SerializeReference]</c>
+    /// field typed as an open generic, so a binder declares the field as this instead. From
+    /// 2023.1 the generic form is used directly and this is a compatibility shim.
+    /// </remarks>
     public interface IConverterFloatToBool : IConverter<float, bool> { }
 }

--- a/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Runtime/Converters/Specific/Bool/IConverterIntToBool.cs
+++ b/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Runtime/Converters/Specific/Bool/IConverterIntToBool.cs
@@ -1,5 +1,14 @@
 // ReSharper disable once CheckNamespace
 namespace Aspid.MVVM.StarterKit
 {
+    /// <summary>
+    /// A converter from <see cref="int"/> to <see cref="bool"/>.
+    /// </summary>
+    /// <remarks>
+    /// A named alias for <see cref="IConverter{TFrom, TTo}"/> closed over these two types.
+    /// It exists because Unity before 2023.1 cannot serialize a <c>[SerializeReference]</c>
+    /// field typed as an open generic, so a binder declares the field as this instead. From
+    /// 2023.1 the generic form is used directly and this is a compatibility shim.
+    /// </remarks>
     public interface IConverterIntToBool : IConverter<int, bool> { }
 }

--- a/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Runtime/Converters/Specific/Bool/IConverterLongToBool.cs
+++ b/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Runtime/Converters/Specific/Bool/IConverterLongToBool.cs
@@ -1,5 +1,14 @@
 // ReSharper disable once CheckNamespace
 namespace Aspid.MVVM.StarterKit
 {
+    /// <summary>
+    /// A converter from <see cref="long"/> to <see cref="bool"/>.
+    /// </summary>
+    /// <remarks>
+    /// A named alias for <see cref="IConverter{TFrom, TTo}"/> closed over these two types.
+    /// It exists because Unity before 2023.1 cannot serialize a <c>[SerializeReference]</c>
+    /// field typed as an open generic, so a binder declares the field as this instead. From
+    /// 2023.1 the generic form is used directly and this is a compatibility shim.
+    /// </remarks>
     public interface IConverterLongToBool : IConverter<long, bool> { }
 }

--- a/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Runtime/Converters/Specific/Bool/IConverterObjectToBool.cs
+++ b/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Runtime/Converters/Specific/Bool/IConverterObjectToBool.cs
@@ -1,5 +1,14 @@
 // ReSharper disable once CheckNamespace
 namespace Aspid.MVVM.StarterKit
 {
+    /// <summary>
+    /// A converter from <see cref="object"/> to <see cref="bool"/>.
+    /// </summary>
+    /// <remarks>
+    /// A named alias for <see cref="IConverter{TFrom, TTo}"/> closed over these two types.
+    /// It exists because Unity before 2023.1 cannot serialize a <c>[SerializeReference]</c>
+    /// field typed as an open generic, so a binder declares the field as this instead. From
+    /// 2023.1 the generic form is used directly and this is a compatibility shim.
+    /// </remarks>
     public interface IConverterObjectToBool : IConverter<object?, bool> { }
 }

--- a/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Runtime/Converters/Specific/Bool/IConverterStringToBool.cs
+++ b/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Runtime/Converters/Specific/Bool/IConverterStringToBool.cs
@@ -1,5 +1,14 @@
 // ReSharper disable once CheckNamespace
 namespace Aspid.MVVM.StarterKit
 {
+    /// <summary>
+    /// A converter from <see cref="string"/> to <see cref="bool"/>.
+    /// </summary>
+    /// <remarks>
+    /// A named alias for <see cref="IConverter{TFrom, TTo}"/> closed over these two types.
+    /// It exists because Unity before 2023.1 cannot serialize a <c>[SerializeReference]</c>
+    /// field typed as an open generic, so a binder declares the field as this instead. From
+    /// 2023.1 the generic form is used directly and this is a compatibility shim.
+    /// </remarks>
     public interface IConverterStringToBool : IConverter<string?, bool> { }
 }

--- a/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Runtime/Converters/Specific/Numbers/IConverterDouble.cs
+++ b/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Runtime/Converters/Specific/Numbers/IConverterDouble.cs
@@ -1,5 +1,14 @@
 // ReSharper disable once CheckNamespace
 namespace Aspid.MVVM.StarterKit
 {
+    /// <summary>
+    /// A converter from <see cref="double"/> to <see cref="double"/>.
+    /// </summary>
+    /// <remarks>
+    /// A named alias for <see cref="IConverter{TFrom, TTo}"/> closed over these two types.
+    /// It exists because Unity before 2023.1 cannot serialize a <c>[SerializeReference]</c>
+    /// field typed as an open generic, so a binder declares the field as this instead. From
+    /// 2023.1 the generic form is used directly and this is a compatibility shim.
+    /// </remarks>
     public interface IConverterDouble : IConverter<double, double> { }
 }

--- a/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Runtime/Converters/Specific/Numbers/IConverterDoubleToFloat.cs
+++ b/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Runtime/Converters/Specific/Numbers/IConverterDoubleToFloat.cs
@@ -1,5 +1,14 @@
 // ReSharper disable once CheckNamespace
 namespace Aspid.MVVM.StarterKit
 {
+    /// <summary>
+    /// A converter from <see cref="double"/> to <see cref="float"/>.
+    /// </summary>
+    /// <remarks>
+    /// A named alias for <see cref="IConverter{TFrom, TTo}"/> closed over these two types.
+    /// It exists because Unity before 2023.1 cannot serialize a <c>[SerializeReference]</c>
+    /// field typed as an open generic, so a binder declares the field as this instead. From
+    /// 2023.1 the generic form is used directly and this is a compatibility shim.
+    /// </remarks>
     public interface IConverterDoubleToFloat : IConverter<double, float> { }
 }

--- a/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Runtime/Converters/Specific/Numbers/IConverterDoubleToInt.cs
+++ b/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Runtime/Converters/Specific/Numbers/IConverterDoubleToInt.cs
@@ -1,5 +1,14 @@
 // ReSharper disable once CheckNamespace
 namespace Aspid.MVVM.StarterKit
 {
+    /// <summary>
+    /// A converter from <see cref="double"/> to <see cref="int"/>.
+    /// </summary>
+    /// <remarks>
+    /// A named alias for <see cref="IConverter{TFrom, TTo}"/> closed over these two types.
+    /// It exists because Unity before 2023.1 cannot serialize a <c>[SerializeReference]</c>
+    /// field typed as an open generic, so a binder declares the field as this instead. From
+    /// 2023.1 the generic form is used directly and this is a compatibility shim.
+    /// </remarks>
     public interface IConverterDoubleToInt : IConverter<double, int> { }
 }

--- a/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Runtime/Converters/Specific/Numbers/IConverterDoubleToLong.cs
+++ b/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Runtime/Converters/Specific/Numbers/IConverterDoubleToLong.cs
@@ -1,5 +1,14 @@
 // ReSharper disable once CheckNamespace
 namespace Aspid.MVVM.StarterKit
 {
+    /// <summary>
+    /// A converter from <see cref="double"/> to <see cref="long"/>.
+    /// </summary>
+    /// <remarks>
+    /// A named alias for <see cref="IConverter{TFrom, TTo}"/> closed over these two types.
+    /// It exists because Unity before 2023.1 cannot serialize a <c>[SerializeReference]</c>
+    /// field typed as an open generic, so a binder declares the field as this instead. From
+    /// 2023.1 the generic form is used directly and this is a compatibility shim.
+    /// </remarks>
     public interface IConverterDoubleToLong : IConverter<double, long> { }
 }

--- a/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Runtime/Converters/Specific/Numbers/IConverterFloat.cs
+++ b/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Runtime/Converters/Specific/Numbers/IConverterFloat.cs
@@ -1,5 +1,14 @@
 // ReSharper disable once CheckNamespace
 namespace Aspid.MVVM.StarterKit
 {
+    /// <summary>
+    /// A converter from <see cref="float"/> to <see cref="float"/>.
+    /// </summary>
+    /// <remarks>
+    /// A named alias for <see cref="IConverter{TFrom, TTo}"/> closed over these two types.
+    /// It exists because Unity before 2023.1 cannot serialize a <c>[SerializeReference]</c>
+    /// field typed as an open generic, so a binder declares the field as this instead. From
+    /// 2023.1 the generic form is used directly and this is a compatibility shim.
+    /// </remarks>
     public interface IConverterFloat : IConverter<float, float> { }
 }

--- a/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Runtime/Converters/Specific/Numbers/IConverterFloatToDouble.cs
+++ b/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Runtime/Converters/Specific/Numbers/IConverterFloatToDouble.cs
@@ -1,5 +1,14 @@
 // ReSharper disable once CheckNamespace
 namespace Aspid.MVVM.StarterKit
 {
+    /// <summary>
+    /// A converter from <see cref="float"/> to <see cref="double"/>.
+    /// </summary>
+    /// <remarks>
+    /// A named alias for <see cref="IConverter{TFrom, TTo}"/> closed over these two types.
+    /// It exists because Unity before 2023.1 cannot serialize a <c>[SerializeReference]</c>
+    /// field typed as an open generic, so a binder declares the field as this instead. From
+    /// 2023.1 the generic form is used directly and this is a compatibility shim.
+    /// </remarks>
     public interface IConverterFloatToDouble : IConverter<float, double> { }
 }

--- a/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Runtime/Converters/Specific/Numbers/IConverterFloatToInt.cs
+++ b/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Runtime/Converters/Specific/Numbers/IConverterFloatToInt.cs
@@ -1,5 +1,14 @@
 // ReSharper disable once CheckNamespace
 namespace Aspid.MVVM.StarterKit
 {
+    /// <summary>
+    /// A converter from <see cref="float"/> to <see cref="int"/>.
+    /// </summary>
+    /// <remarks>
+    /// A named alias for <see cref="IConverter{TFrom, TTo}"/> closed over these two types.
+    /// It exists because Unity before 2023.1 cannot serialize a <c>[SerializeReference]</c>
+    /// field typed as an open generic, so a binder declares the field as this instead. From
+    /// 2023.1 the generic form is used directly and this is a compatibility shim.
+    /// </remarks>
     public interface IConverterFloatToInt : IConverter<float, int> { }
 }

--- a/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Runtime/Converters/Specific/Numbers/IConverterFloatToLong.cs
+++ b/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Runtime/Converters/Specific/Numbers/IConverterFloatToLong.cs
@@ -1,5 +1,14 @@
 // ReSharper disable once CheckNamespace
 namespace Aspid.MVVM.StarterKit
 {
+    /// <summary>
+    /// A converter from <see cref="float"/> to <see cref="long"/>.
+    /// </summary>
+    /// <remarks>
+    /// A named alias for <see cref="IConverter{TFrom, TTo}"/> closed over these two types.
+    /// It exists because Unity before 2023.1 cannot serialize a <c>[SerializeReference]</c>
+    /// field typed as an open generic, so a binder declares the field as this instead. From
+    /// 2023.1 the generic form is used directly and this is a compatibility shim.
+    /// </remarks>
     public interface IConverterFloatToLong : IConverter<float, long> { }
 }

--- a/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Runtime/Converters/Specific/Numbers/IConverterInt.cs
+++ b/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Runtime/Converters/Specific/Numbers/IConverterInt.cs
@@ -1,5 +1,14 @@
 // ReSharper disable once CheckNamespace
 namespace Aspid.MVVM.StarterKit
 {
+    /// <summary>
+    /// A converter from <see cref="int"/> to <see cref="int"/>.
+    /// </summary>
+    /// <remarks>
+    /// A named alias for <see cref="IConverter{TFrom, TTo}"/> closed over these two types.
+    /// It exists because Unity before 2023.1 cannot serialize a <c>[SerializeReference]</c>
+    /// field typed as an open generic, so a binder declares the field as this instead. From
+    /// 2023.1 the generic form is used directly and this is a compatibility shim.
+    /// </remarks>
     public interface IConverterInt : IConverter<int, int> { }
 }

--- a/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Runtime/Converters/Specific/Numbers/IConverterIntToDouble.cs
+++ b/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Runtime/Converters/Specific/Numbers/IConverterIntToDouble.cs
@@ -1,5 +1,14 @@
 // ReSharper disable once CheckNamespace
 namespace Aspid.MVVM.StarterKit
 {
+    /// <summary>
+    /// A converter from <see cref="int"/> to <see cref="double"/>.
+    /// </summary>
+    /// <remarks>
+    /// A named alias for <see cref="IConverter{TFrom, TTo}"/> closed over these two types.
+    /// It exists because Unity before 2023.1 cannot serialize a <c>[SerializeReference]</c>
+    /// field typed as an open generic, so a binder declares the field as this instead. From
+    /// 2023.1 the generic form is used directly and this is a compatibility shim.
+    /// </remarks>
     public interface IConverterIntToDouble : IConverter<int, double> { }
 }

--- a/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Runtime/Converters/Specific/Numbers/IConverterIntToFloat.cs
+++ b/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Runtime/Converters/Specific/Numbers/IConverterIntToFloat.cs
@@ -1,5 +1,14 @@
 // ReSharper disable once CheckNamespace
 namespace Aspid.MVVM.StarterKit
 {
+    /// <summary>
+    /// A converter from <see cref="int"/> to <see cref="float"/>.
+    /// </summary>
+    /// <remarks>
+    /// A named alias for <see cref="IConverter{TFrom, TTo}"/> closed over these two types.
+    /// It exists because Unity before 2023.1 cannot serialize a <c>[SerializeReference]</c>
+    /// field typed as an open generic, so a binder declares the field as this instead. From
+    /// 2023.1 the generic form is used directly and this is a compatibility shim.
+    /// </remarks>
     public interface IConverterIntToFloat : IConverter<int, float> { }
 }

--- a/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Runtime/Converters/Specific/Numbers/IConverterIntToLong.cs
+++ b/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Runtime/Converters/Specific/Numbers/IConverterIntToLong.cs
@@ -1,5 +1,14 @@
 // ReSharper disable once CheckNamespace
 namespace Aspid.MVVM.StarterKit
 {
+    /// <summary>
+    /// A converter from <see cref="int"/> to <see cref="long"/>.
+    /// </summary>
+    /// <remarks>
+    /// A named alias for <see cref="IConverter{TFrom, TTo}"/> closed over these two types.
+    /// It exists because Unity before 2023.1 cannot serialize a <c>[SerializeReference]</c>
+    /// field typed as an open generic, so a binder declares the field as this instead. From
+    /// 2023.1 the generic form is used directly and this is a compatibility shim.
+    /// </remarks>
     public interface IConverterIntToLong : IConverter<int, long> { }
 }

--- a/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Runtime/Converters/Specific/Numbers/IConverterLong.cs
+++ b/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Runtime/Converters/Specific/Numbers/IConverterLong.cs
@@ -1,5 +1,14 @@
 // ReSharper disable once CheckNamespace
 namespace Aspid.MVVM.StarterKit
 {
+    /// <summary>
+    /// A converter from <see cref="long"/> to <see cref="long"/>.
+    /// </summary>
+    /// <remarks>
+    /// A named alias for <see cref="IConverter{TFrom, TTo}"/> closed over these two types.
+    /// It exists because Unity before 2023.1 cannot serialize a <c>[SerializeReference]</c>
+    /// field typed as an open generic, so a binder declares the field as this instead. From
+    /// 2023.1 the generic form is used directly and this is a compatibility shim.
+    /// </remarks>
     public interface IConverterLong : IConverter<long, long> { }
 }

--- a/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Runtime/Converters/Specific/Numbers/IConverterLongToDouble.cs
+++ b/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Runtime/Converters/Specific/Numbers/IConverterLongToDouble.cs
@@ -1,5 +1,14 @@
 // ReSharper disable once CheckNamespace
 namespace Aspid.MVVM.StarterKit
 {
+    /// <summary>
+    /// A converter from <see cref="long"/> to <see cref="double"/>.
+    /// </summary>
+    /// <remarks>
+    /// A named alias for <see cref="IConverter{TFrom, TTo}"/> closed over these two types.
+    /// It exists because Unity before 2023.1 cannot serialize a <c>[SerializeReference]</c>
+    /// field typed as an open generic, so a binder declares the field as this instead. From
+    /// 2023.1 the generic form is used directly and this is a compatibility shim.
+    /// </remarks>
     public interface IConverterLongToDouble : IConverter<long, double> { }
 }

--- a/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Runtime/Converters/Specific/Numbers/IConverterLongToFloat.cs
+++ b/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Runtime/Converters/Specific/Numbers/IConverterLongToFloat.cs
@@ -1,5 +1,14 @@
 // ReSharper disable once CheckNamespace
 namespace Aspid.MVVM.StarterKit
 {
+    /// <summary>
+    /// A converter from <see cref="long"/> to <see cref="float"/>.
+    /// </summary>
+    /// <remarks>
+    /// A named alias for <see cref="IConverter{TFrom, TTo}"/> closed over these two types.
+    /// It exists because Unity before 2023.1 cannot serialize a <c>[SerializeReference]</c>
+    /// field typed as an open generic, so a binder declares the field as this instead. From
+    /// 2023.1 the generic form is used directly and this is a compatibility shim.
+    /// </remarks>
     public interface IConverterLongToFloat : IConverter<long, float> { }
 }

--- a/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Runtime/Converters/Specific/Numbers/IConverterLongToInt.cs
+++ b/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Runtime/Converters/Specific/Numbers/IConverterLongToInt.cs
@@ -1,5 +1,14 @@
 // ReSharper disable once CheckNamespace
 namespace Aspid.MVVM.StarterKit
 {
+    /// <summary>
+    /// A converter from <see cref="long"/> to <see cref="int"/>.
+    /// </summary>
+    /// <remarks>
+    /// A named alias for <see cref="IConverter{TFrom, TTo}"/> closed over these two types.
+    /// It exists because Unity before 2023.1 cannot serialize a <c>[SerializeReference]</c>
+    /// field typed as an open generic, so a binder declares the field as this instead. From
+    /// 2023.1 the generic form is used directly and this is a compatibility shim.
+    /// </remarks>
     public interface IConverterLongToInt : IConverter<long, int> { }
 }

--- a/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Runtime/Converters/Specific/Numbers/NumberConverterSpecificExtensions.cs
+++ b/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Runtime/Converters/Specific/Numbers/NumberConverterSpecificExtensions.cs
@@ -4,108 +4,310 @@ using Aspid.FastTools.Types;
 // ReSharper disable once CheckNamespace
 namespace Aspid.MVVM.StarterKit
 {
+    /// <summary>
+    /// Wraps a function or a generic converter as one of the named numeric converter
+    /// interfaces.
+    /// </summary>
+    /// <remarks>
+    /// <c>ToConvert</c> takes a function, <c>ToConvertSpecific</c> takes a converter that is
+    /// already the right shape but not the named type. Both exist because a binder before
+    /// Unity 2023.1 declares its field as the named interface rather than the generic one,
+    /// so a lambda cannot be assigned to it directly.
+    /// </remarks>
     public static class NumberConverterSpecificExtensions
     {
         #region Int Methods
+        /// <summary>
+        /// Wraps the specified function as an <see cref="IConverterInt"/>.
+        /// </summary>
+        /// <param name="converter">The function to wrap.</param>
+        /// <returns>A converter of the named interface type.</returns>
+        /// <exception cref="System.ArgumentNullException">Thrown when <paramref name="converter"/> is <see langword="null"/>.</exception>
         public static IConverterInt ToConvert(this Func<int, int> converter) =>
             new ConverterInt(converter);
         
+        /// <summary>
+        /// Wraps the specified converter as an <see cref="IConverterInt"/>.
+        /// </summary>
+        /// <param name="converter">The converter to wrap.</param>
+        /// <returns>A converter of the named interface type.</returns>
+        /// <exception cref="System.ArgumentNullException">Thrown when <paramref name="converter"/> is <see langword="null"/>.</exception>
         public static IConverterInt ToConvertSpecific(this IConverter<int, int> converter) =>
             new ConverterInt(converter);
         
+        /// <summary>
+        /// Wraps the specified function as an <see cref="IConverterIntToLong"/>.
+        /// </summary>
+        /// <param name="converter">The function to wrap.</param>
+        /// <returns>A converter of the named interface type.</returns>
+        /// <exception cref="System.ArgumentNullException">Thrown when <paramref name="converter"/> is <see langword="null"/>.</exception>
         public static IConverterIntToLong ToConvert(this Func<int, long> converter) =>
             new ConverterIntToLong(converter);
         
+        /// <summary>
+        /// Wraps the specified converter as an <see cref="IConverterIntToLong"/>.
+        /// </summary>
+        /// <param name="converter">The converter to wrap.</param>
+        /// <returns>A converter of the named interface type.</returns>
+        /// <exception cref="System.ArgumentNullException">Thrown when <paramref name="converter"/> is <see langword="null"/>.</exception>
         public static IConverterIntToLong ToConvertSpecific(this IConverter<int, long> converter) =>
             new ConverterIntToLong(converter);
         
+        /// <summary>
+        /// Wraps the specified function as an <see cref="IConverterIntToFloat"/>.
+        /// </summary>
+        /// <param name="converter">The function to wrap.</param>
+        /// <returns>A converter of the named interface type.</returns>
+        /// <exception cref="System.ArgumentNullException">Thrown when <paramref name="converter"/> is <see langword="null"/>.</exception>
         public static IConverterIntToFloat ToConvert(this Func<int, float> converter) =>
             new ConverterIntToFloat(converter);
         
+        /// <summary>
+        /// Wraps the specified converter as an <see cref="IConverterIntToFloat"/>.
+        /// </summary>
+        /// <param name="converter">The converter to wrap.</param>
+        /// <returns>A converter of the named interface type.</returns>
+        /// <exception cref="System.ArgumentNullException">Thrown when <paramref name="converter"/> is <see langword="null"/>.</exception>
         public static IConverterIntToFloat ToConvertSpecific(this IConverter<int, float> converter) =>
             new ConverterIntToFloat(converter);
         
+        /// <summary>
+        /// Wraps the specified function as an <see cref="IConverterIntToDouble"/>.
+        /// </summary>
+        /// <param name="converter">The function to wrap.</param>
+        /// <returns>A converter of the named interface type.</returns>
+        /// <exception cref="System.ArgumentNullException">Thrown when <paramref name="converter"/> is <see langword="null"/>.</exception>
         public static IConverterIntToDouble ToConvert(this Func<int, double> converter) =>
             new ConverterIntToDouble(converter);
         
+        /// <summary>
+        /// Wraps the specified converter as an <see cref="IConverterIntToDouble"/>.
+        /// </summary>
+        /// <param name="converter">The converter to wrap.</param>
+        /// <returns>A converter of the named interface type.</returns>
+        /// <exception cref="System.ArgumentNullException">Thrown when <paramref name="converter"/> is <see langword="null"/>.</exception>
         public static IConverterIntToDouble ToConvertSpecific(this IConverter<int, double> converter) =>
             new ConverterIntToDouble(converter);
         #endregion
         
         #region Long Methods
+        /// <summary>
+        /// Wraps the specified function as an <see cref="IConverterLongToInt"/>.
+        /// </summary>
+        /// <param name="converter">The function to wrap.</param>
+        /// <returns>A converter of the named interface type.</returns>
+        /// <exception cref="System.ArgumentNullException">Thrown when <paramref name="converter"/> is <see langword="null"/>.</exception>
         public static IConverterLongToInt ToConvert(this Func<long, int> converter) =>
             new ConverterLongToInt(converter);
         
+        /// <summary>
+        /// Wraps the specified converter as an <see cref="IConverterLongToInt"/>.
+        /// </summary>
+        /// <param name="converter">The converter to wrap.</param>
+        /// <returns>A converter of the named interface type.</returns>
+        /// <exception cref="System.ArgumentNullException">Thrown when <paramref name="converter"/> is <see langword="null"/>.</exception>
         public static IConverterLongToInt ToConvertSpecific(this IConverter<long, int> converter) =>
             new ConverterLongToInt(converter);
         
+        /// <summary>
+        /// Wraps the specified function as an <see cref="IConverterLong"/>.
+        /// </summary>
+        /// <param name="converter">The function to wrap.</param>
+        /// <returns>A converter of the named interface type.</returns>
+        /// <exception cref="System.ArgumentNullException">Thrown when <paramref name="converter"/> is <see langword="null"/>.</exception>
         public static IConverterLong ToConvert(this Func<long, long> converter) =>
             new ConverterLong(converter);
         
+        /// <summary>
+        /// Wraps the specified converter as an <see cref="IConverterLong"/>.
+        /// </summary>
+        /// <param name="converter">The converter to wrap.</param>
+        /// <returns>A converter of the named interface type.</returns>
+        /// <exception cref="System.ArgumentNullException">Thrown when <paramref name="converter"/> is <see langword="null"/>.</exception>
         public static IConverterLong ToConvertSpecific(this IConverter<long, long> converter) =>
             new ConverterLong(converter);
         
+        /// <summary>
+        /// Wraps the specified function as an <see cref="IConverterLongToFloat"/>.
+        /// </summary>
+        /// <param name="converter">The function to wrap.</param>
+        /// <returns>A converter of the named interface type.</returns>
+        /// <exception cref="System.ArgumentNullException">Thrown when <paramref name="converter"/> is <see langword="null"/>.</exception>
         public static IConverterLongToFloat ToConvert(this Func<long, float> converter) =>
             new ConverterLongToFloat(converter);
         
+        /// <summary>
+        /// Wraps the specified converter as an <see cref="IConverterLongToFloat"/>.
+        /// </summary>
+        /// <param name="converter">The converter to wrap.</param>
+        /// <returns>A converter of the named interface type.</returns>
+        /// <exception cref="System.ArgumentNullException">Thrown when <paramref name="converter"/> is <see langword="null"/>.</exception>
         public static IConverterLongToFloat ToConvertSpecific(this IConverter<long, float> converter) =>
             new ConverterLongToFloat(converter);
         
+        /// <summary>
+        /// Wraps the specified function as an <see cref="IConverterLongToDouble"/>.
+        /// </summary>
+        /// <param name="converter">The function to wrap.</param>
+        /// <returns>A converter of the named interface type.</returns>
+        /// <exception cref="System.ArgumentNullException">Thrown when <paramref name="converter"/> is <see langword="null"/>.</exception>
         public static IConverterLongToDouble ToConvert(this Func<long, double> converter) =>
             new ConverterLongToDouble(converter);
         
+        /// <summary>
+        /// Wraps the specified converter as an <see cref="IConverterLongToDouble"/>.
+        /// </summary>
+        /// <param name="converter">The converter to wrap.</param>
+        /// <returns>A converter of the named interface type.</returns>
+        /// <exception cref="System.ArgumentNullException">Thrown when <paramref name="converter"/> is <see langword="null"/>.</exception>
         public static IConverterLongToDouble ToConvertSpecific(this IConverter<long, double> converter) =>
             new ConverterLongToDouble(converter);
         #endregion
         
         #region Float Methods
+        /// <summary>
+        /// Wraps the specified function as an <see cref="IConverterFloatToInt"/>.
+        /// </summary>
+        /// <param name="converter">The function to wrap.</param>
+        /// <returns>A converter of the named interface type.</returns>
+        /// <exception cref="System.ArgumentNullException">Thrown when <paramref name="converter"/> is <see langword="null"/>.</exception>
         public static IConverterFloatToInt ToConvert(this Func<float, int> converter) =>
             new ConverterFloatToInt(converter);
         
+        /// <summary>
+        /// Wraps the specified converter as an <see cref="IConverterFloatToInt"/>.
+        /// </summary>
+        /// <param name="converter">The converter to wrap.</param>
+        /// <returns>A converter of the named interface type.</returns>
+        /// <exception cref="System.ArgumentNullException">Thrown when <paramref name="converter"/> is <see langword="null"/>.</exception>
         public static IConverterFloatToInt ToConvertSpecific(this IConverter<float, int> converter) =>
             new ConverterFloatToInt(converter);
         
+        /// <summary>
+        /// Wraps the specified function as an <see cref="IConverterFloatToLong"/>.
+        /// </summary>
+        /// <param name="converter">The function to wrap.</param>
+        /// <returns>A converter of the named interface type.</returns>
+        /// <exception cref="System.ArgumentNullException">Thrown when <paramref name="converter"/> is <see langword="null"/>.</exception>
         public static IConverterFloatToLong ToConvert(this Func<float, long> converter) =>
             new ConverterFloatToLong(converter);
         
+        /// <summary>
+        /// Wraps the specified converter as an <see cref="IConverterFloatToLong"/>.
+        /// </summary>
+        /// <param name="converter">The converter to wrap.</param>
+        /// <returns>A converter of the named interface type.</returns>
+        /// <exception cref="System.ArgumentNullException">Thrown when <paramref name="converter"/> is <see langword="null"/>.</exception>
         public static IConverterFloatToLong ToConvertSpecific(this IConverter<float, long> converter) =>
             new ConverterFloatToLong(converter);
         
+        /// <summary>
+        /// Wraps the specified function as an <see cref="IConverterFloat"/>.
+        /// </summary>
+        /// <param name="converter">The function to wrap.</param>
+        /// <returns>A converter of the named interface type.</returns>
+        /// <exception cref="System.ArgumentNullException">Thrown when <paramref name="converter"/> is <see langword="null"/>.</exception>
         public static IConverterFloat ToConvert(this Func<float, float> converter) =>
             new ConverterFloat(converter);
         
+        /// <summary>
+        /// Wraps the specified converter as an <see cref="IConverterFloat"/>.
+        /// </summary>
+        /// <param name="converter">The converter to wrap.</param>
+        /// <returns>A converter of the named interface type.</returns>
+        /// <exception cref="System.ArgumentNullException">Thrown when <paramref name="converter"/> is <see langword="null"/>.</exception>
         public static IConverterFloat ToConvertSpecific(this IConverter<float, float> converter) =>
             new ConverterFloat(converter);
         
+        /// <summary>
+        /// Wraps the specified function as an <see cref="IConverterFloatToDouble"/>.
+        /// </summary>
+        /// <param name="converter">The function to wrap.</param>
+        /// <returns>A converter of the named interface type.</returns>
+        /// <exception cref="System.ArgumentNullException">Thrown when <paramref name="converter"/> is <see langword="null"/>.</exception>
         public static IConverterFloatToDouble ToConvert(this Func<float, double> converter) =>
             new ConverterFloatToDouble(converter);
         
+        /// <summary>
+        /// Wraps the specified converter as an <see cref="IConverterFloatToDouble"/>.
+        /// </summary>
+        /// <param name="converter">The converter to wrap.</param>
+        /// <returns>A converter of the named interface type.</returns>
+        /// <exception cref="System.ArgumentNullException">Thrown when <paramref name="converter"/> is <see langword="null"/>.</exception>
         public static IConverterFloatToDouble ToConvertSpecific(this IConverter<float, double> converter) =>
             new ConverterFloatToDouble(converter);
         #endregion
         
         #region Double Methods
+        /// <summary>
+        /// Wraps the specified function as an <see cref="IConverterDoubleToInt"/>.
+        /// </summary>
+        /// <param name="converter">The function to wrap.</param>
+        /// <returns>A converter of the named interface type.</returns>
+        /// <exception cref="System.ArgumentNullException">Thrown when <paramref name="converter"/> is <see langword="null"/>.</exception>
         public static IConverterDoubleToInt ToConvert(this Func<double, int> converter) =>
             new ConverterDoubleToInt(converter);
         
+        /// <summary>
+        /// Wraps the specified converter as an <see cref="IConverterDoubleToInt"/>.
+        /// </summary>
+        /// <param name="converter">The converter to wrap.</param>
+        /// <returns>A converter of the named interface type.</returns>
+        /// <exception cref="System.ArgumentNullException">Thrown when <paramref name="converter"/> is <see langword="null"/>.</exception>
         public static IConverterDoubleToInt ToConvertSpecific(this IConverter<double, int> converter) =>
             new ConverterDoubleToInt(converter);
         
+        /// <summary>
+        /// Wraps the specified function as an <see cref="IConverterDoubleToLong"/>.
+        /// </summary>
+        /// <param name="converter">The function to wrap.</param>
+        /// <returns>A converter of the named interface type.</returns>
+        /// <exception cref="System.ArgumentNullException">Thrown when <paramref name="converter"/> is <see langword="null"/>.</exception>
         public static IConverterDoubleToLong ToConvert(this Func<double, long> converter) =>
             new ConverterDoubleToLong(converter);
         
+        /// <summary>
+        /// Wraps the specified converter as an <see cref="IConverterDoubleToLong"/>.
+        /// </summary>
+        /// <param name="converter">The converter to wrap.</param>
+        /// <returns>A converter of the named interface type.</returns>
+        /// <exception cref="System.ArgumentNullException">Thrown when <paramref name="converter"/> is <see langword="null"/>.</exception>
         public static IConverterDoubleToLong ToConvertSpecific(this IConverter<double, long> converter) =>
             new ConverterDoubleToLong(converter);
         
+        /// <summary>
+        /// Wraps the specified function as an <see cref="IConverterDoubleToFloat"/>.
+        /// </summary>
+        /// <param name="converter">The function to wrap.</param>
+        /// <returns>A converter of the named interface type.</returns>
+        /// <exception cref="System.ArgumentNullException">Thrown when <paramref name="converter"/> is <see langword="null"/>.</exception>
         public static IConverterDoubleToFloat ToConvert(this Func<double, float> converter) =>
             new ConverterDoubleToFloat(converter);
         
+        /// <summary>
+        /// Wraps the specified converter as an <see cref="IConverterDoubleToFloat"/>.
+        /// </summary>
+        /// <param name="converter">The converter to wrap.</param>
+        /// <returns>A converter of the named interface type.</returns>
+        /// <exception cref="System.ArgumentNullException">Thrown when <paramref name="converter"/> is <see langword="null"/>.</exception>
         public static IConverterDoubleToFloat ToConvertSpecific(this IConverter<double, float> converter) =>
             new ConverterDoubleToFloat(converter);
         
+        /// <summary>
+        /// Wraps the specified function as an <see cref="IConverterDouble"/>.
+        /// </summary>
+        /// <param name="converter">The function to wrap.</param>
+        /// <returns>A converter of the named interface type.</returns>
+        /// <exception cref="System.ArgumentNullException">Thrown when <paramref name="converter"/> is <see langword="null"/>.</exception>
         public static IConverterDouble ToConvert(this Func<double, double> converter) =>
             new ConverterDouble(converter);
         
+        /// <summary>
+        /// Wraps the specified converter as an <see cref="IConverterDouble"/>.
+        /// </summary>
+        /// <param name="converter">The converter to wrap.</param>
+        /// <returns>A converter of the named interface type.</returns>
+        /// <exception cref="System.ArgumentNullException">Thrown when <paramref name="converter"/> is <see langword="null"/>.</exception>
         public static IConverterDouble ToConvertSpecific(this IConverter<double, double> converter) =>
             new ConverterDouble(converter);
         #endregion

--- a/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Runtime/Converters/Specific/Strings/IConverterObjectToString.cs
+++ b/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Runtime/Converters/Specific/Strings/IConverterObjectToString.cs
@@ -1,5 +1,14 @@
 // ReSharper disable once CheckNamespace
 namespace Aspid.MVVM.StarterKit
 {
+    /// <summary>
+    /// A converter from <see cref="object"/> to <see cref="string"/>.
+    /// </summary>
+    /// <remarks>
+    /// A named alias for <see cref="IConverter{TFrom, TTo}"/> closed over these two types.
+    /// It exists because Unity before 2023.1 cannot serialize a <c>[SerializeReference]</c>
+    /// field typed as an open generic, so a binder declares the field as this instead. From
+    /// 2023.1 the generic form is used directly and this is a compatibility shim.
+    /// </remarks>
     public interface IConverterObjectToString : IConverter<object?, string?> { }
 }

--- a/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Runtime/Converters/Specific/Strings/IConverterString.cs
+++ b/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Runtime/Converters/Specific/Strings/IConverterString.cs
@@ -1,5 +1,14 @@
 // ReSharper disable once CheckNamespace
 namespace Aspid.MVVM.StarterKit
 {
+    /// <summary>
+    /// A converter from <see cref="string"/> to <see cref="string"/>.
+    /// </summary>
+    /// <remarks>
+    /// A named alias for <see cref="IConverter{TFrom, TTo}"/> closed over these two types.
+    /// It exists because Unity before 2023.1 cannot serialize a <c>[SerializeReference]</c>
+    /// field typed as an open generic, so a binder declares the field as this instead. From
+    /// 2023.1 the generic form is used directly and this is a compatibility shim.
+    /// </remarks>
     public interface IConverterString : IConverter<string?, string?> { }
 }

--- a/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Runtime/Converters/Specific/Strings/IConverterTimeSpanToString.cs
+++ b/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Runtime/Converters/Specific/Strings/IConverterTimeSpanToString.cs
@@ -3,5 +3,14 @@ using System;
 // ReSharper disable once CheckNamespace
 namespace Aspid.MVVM.StarterKit
 {
+    /// <summary>
+    /// A converter from <see cref="TimeSpan"/> to <see cref="string"/>.
+    /// </summary>
+    /// <remarks>
+    /// A named alias for <see cref="IConverter{TFrom, TTo}"/> closed over these two types.
+    /// It exists because Unity before 2023.1 cannot serialize a <c>[SerializeReference]</c>
+    /// field typed as an open generic, so a binder declares the field as this instead. From
+    /// 2023.1 the generic form is used directly and this is a compatibility shim.
+    /// </remarks>
     public interface IConverterTimeSpanToString : IConverter<TimeSpan, string?> { }
 }

--- a/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Runtime/Converters/Specific/Strings/StringConverterSpecificExtensions.cs
+++ b/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Runtime/Converters/Specific/Strings/StringConverterSpecificExtensions.cs
@@ -4,23 +4,69 @@ using Aspid.FastTools.Types;
 // ReSharper disable once CheckNamespace
 namespace Aspid.MVVM.StarterKit
 {
+    /// <summary>
+    /// Wraps a function or a generic converter as one of the named string converter
+    /// interfaces.
+    /// </summary>
+    /// <remarks>
+    /// <c>ToConvert</c> takes a function, <c>ToConvertSpecific</c> takes a converter that is
+    /// already the right shape but not the named type. Both exist because a binder before
+    /// Unity 2023.1 declares its field as the named interface rather than the generic one,
+    /// so a lambda cannot be assigned to it directly.
+    /// </remarks>
     public static class StringConverterSpecificExtensions
     {
+        /// <summary>
+        /// Wraps the specified function as an <see cref="IConverterString"/>.
+        /// </summary>
+        /// <param name="converter">The function to wrap.</param>
+        /// <returns>A converter of the named interface type.</returns>
+        /// <exception cref="System.ArgumentNullException">Thrown when <paramref name="converter"/> is <see langword="null"/>.</exception>
         public static IConverterString ToConvert(this Func<string?, string?> converter) =>
             new ConverterString(converter);
         
+        /// <summary>
+        /// Wraps the specified converter as an <see cref="IConverterString"/>.
+        /// </summary>
+        /// <param name="converter">The converter to wrap.</param>
+        /// <returns>A converter of the named interface type.</returns>
+        /// <exception cref="System.ArgumentNullException">Thrown when <paramref name="converter"/> is <see langword="null"/>.</exception>
         public static IConverterString ToConvertSpecific(this IConverter<string?, string?> converter) =>
             new ConverterString(converter);
         
+        /// <summary>
+        /// Wraps the specified function as an <see cref="IConverterObjectToString"/>.
+        /// </summary>
+        /// <param name="converter">The function to wrap.</param>
+        /// <returns>A converter of the named interface type.</returns>
+        /// <exception cref="System.ArgumentNullException">Thrown when <paramref name="converter"/> is <see langword="null"/>.</exception>
         public static IConverterObjectToString ToConvert(this Func<object?, string?> converter) =>
             new ConverterObjectToString(converter);
         
+        /// <summary>
+        /// Wraps the specified converter as an <see cref="IConverterObjectToString"/>.
+        /// </summary>
+        /// <param name="converter">The converter to wrap.</param>
+        /// <returns>A converter of the named interface type.</returns>
+        /// <exception cref="System.ArgumentNullException">Thrown when <paramref name="converter"/> is <see langword="null"/>.</exception>
         public static IConverterObjectToString ToConvertSpecific(this IConverter<object?, string?> converter) =>
             new ConverterObjectToString(converter);
         
+        /// <summary>
+        /// Wraps the specified function as an <see cref="IConverterTimeSpanToString"/>.
+        /// </summary>
+        /// <param name="converter">The function to wrap.</param>
+        /// <returns>A converter of the named interface type.</returns>
+        /// <exception cref="System.ArgumentNullException">Thrown when <paramref name="converter"/> is <see langword="null"/>.</exception>
         public static IConverterTimeSpanToString ToConvert(this Func<TimeSpan, string?> converter) =>
             new ConverterTimeSpanToString(converter);
         
+        /// <summary>
+        /// Wraps the specified converter as an <see cref="IConverterTimeSpanToString"/>.
+        /// </summary>
+        /// <param name="converter">The converter to wrap.</param>
+        /// <returns>A converter of the named interface type.</returns>
+        /// <exception cref="System.ArgumentNullException">Thrown when <paramref name="converter"/> is <see langword="null"/>.</exception>
         public static IConverterTimeSpanToString ToConvertSpecific(this IConverter<TimeSpan, string?> converter) =>
             new ConverterTimeSpanToString(converter);
         

--- a/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Runtime/Converters/Strings/CultureInfoMode.cs
+++ b/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Runtime/Converters/Strings/CultureInfoMode.cs
@@ -1,13 +1,48 @@
 // ReSharper disable once CheckNamespace
 namespace Aspid.MVVM.StarterKit
 {
+    /// <summary>
+    /// Which culture a converter formats and parses with.
+    /// </summary>
+    /// <remarks>
+    /// A serializable stand-in for <see cref="System.Globalization.CultureInfo"/>, which Unity cannot
+    /// serialize — the Inspector picks the mode and <see cref="ToCultureStringExtensions.ToCultureInfo"/>
+    /// resolves it at call time, so a change of locale is picked up without re-authoring the scene.
+    /// <para>
+    /// The choice matters more than it looks: a decimal separator is a comma in half of Europe, so a
+    /// number written by one culture and parsed by another loses its fractional part rather than
+    /// failing. Text a player sees wants <see cref="CurrentCulture"/>; text that round-trips through
+    /// a save file, a network message or <c>PlayerPrefs</c> wants <see cref="InvariantCulture"/>.
+    /// </para>
+    /// <para>
+    /// New members are appended rather than inserted: the order is the serialized value, so moving one
+    /// silently rewrites every converter already authored in a scene.
+    /// </para>
+    /// </remarks>
     public enum CultureInfoMode
     {
+        /// <summary>The thread's culture — what the player's machine is set to. The default.</summary>
         CurrentCulture,
+
+        /// <summary>The thread's UI culture, used for resource lookup rather than for formatting.</summary>
         CurrentUICulture,
+
+        /// <summary>Culture-independent. The choice for anything stored, sent, or parsed back.</summary>
         InvariantCulture,
+
+        /// <summary>The culture the operating system itself was installed with.</summary>
         InstalledUICulture,
+
+        /// <summary>
+        /// The process-wide default culture. Falls back to <see cref="CurrentCulture"/> while unset,
+        /// which is its state unless the application assigns it.
+        /// </summary>
         DefaultThreadCurrentCulture,
+
+        /// <summary>
+        /// The process-wide default UI culture. Falls back to <see cref="CurrentUICulture"/> while
+        /// unset, which is its state unless the application assigns it.
+        /// </summary>
         DefaultThreadCurrentUICulture,
     }
 }

--- a/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Runtime/Converters/Strings/CultureInfoMode.cs
+++ b/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Runtime/Converters/Strings/CultureInfoMode.cs
@@ -6,17 +6,13 @@ namespace Aspid.MVVM.StarterKit
     /// </summary>
     /// <remarks>
     /// A serializable stand-in for <see cref="System.Globalization.CultureInfo"/>, which Unity cannot
-    /// serialize — the Inspector picks the mode and <see cref="ToCultureStringExtensions.ToCultureInfo"/>
-    /// resolves it at call time, so a change of locale is picked up without re-authoring the scene.
+    /// serialize; <see cref="ToCultureStringExtensions.ToCultureInfo"/> resolves it at call time.
     /// <para>
-    /// The choice matters more than it looks: a decimal separator is a comma in half of Europe, so a
-    /// number written by one culture and parsed by another loses its fractional part rather than
-    /// failing. Text a player sees wants <see cref="CurrentCulture"/>; text that round-trips through
-    /// a save file, a network message or <c>PlayerPrefs</c> wants <see cref="InvariantCulture"/>.
-    /// </para>
-    /// <para>
-    /// New members are appended rather than inserted: the order is the serialized value, so moving one
-    /// silently rewrites every converter already authored in a scene.
+    /// A decimal separator is a comma in half of Europe, so a number written by one culture and parsed
+    /// by another loses its fractional part rather than failing. Text a player sees wants
+    /// <see cref="CurrentCulture"/>; text that round-trips through a save file or a network message
+    /// wants <see cref="InvariantCulture"/>. Append new members rather than inserting one — the order
+    /// is the serialized value.
     /// </para>
     /// </remarks>
     public enum CultureInfoMode

--- a/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Runtime/Converters/Strings/Extensions/ToCultureStringExtensions.cs
+++ b/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Runtime/Converters/Strings/Extensions/ToCultureStringExtensions.cs
@@ -32,18 +32,28 @@ namespace Aspid.MVVM.StarterKit
             _ => throw new ArgumentOutOfRangeException(nameof(mode), mode, null)
         };
 
+        /// <summary>
+        /// Writes the specified number in the culture the mode names.
+        /// </summary>
+        /// <param name="number">The number to write.</param>
+        /// <param name="mode">The culture to write it in.</param>
+        /// <returns>The number as text.</returns>
         public static string ToCultureString(this int number, CultureInfoMode mode) =>
             number.ToString(mode.ToCultureInfo());
 
+        /// <inheritdoc cref="ToCultureString(int, CultureInfoMode)"/>
         public static string ToCultureString(this uint number, CultureInfoMode mode) =>
             number.ToString(mode.ToCultureInfo());
 
+        /// <inheritdoc cref="ToCultureString(int, CultureInfoMode)"/>
         public static string ToCultureString(this long number, CultureInfoMode mode) =>
             number.ToString(mode.ToCultureInfo());
 
+        /// <inheritdoc cref="ToCultureString(int, CultureInfoMode)"/>
         public static string ToCultureString(this double number, CultureInfoMode mode) =>
             number.ToString(mode.ToCultureInfo());
 
+        /// <inheritdoc cref="ToCultureString(int, CultureInfoMode)"/>
         public static string ToCultureString(this float number, CultureInfoMode mode) =>
             number.ToString(mode.ToCultureInfo());
     }

--- a/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Unity/Runtime/Converters/Specific/Colors/ConverterColorSpecificExtensions.cs
+++ b/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Unity/Runtime/Converters/Specific/Colors/ConverterColorSpecificExtensions.cs
@@ -6,17 +6,51 @@ using UnityEngine;
 // ReSharper disable once CheckNamespace
 namespace Aspid.MVVM.StarterKit
 {
+    /// <summary>
+    /// Wraps a function or a generic converter as one of the named colour converter
+    /// interfaces.
+    /// </summary>
+    /// <remarks>
+    /// <c>ToConvert</c> takes a function, <c>ToConvertSpecific</c> takes a converter that is
+    /// already the right shape but not the named type. Both exist because a binder before
+    /// Unity 2023.1 declares its field as the named interface rather than the generic one,
+    /// so a lambda cannot be assigned to it directly.
+    /// </remarks>
     public static class ConverterColorSpecificExtensions
     {
+        /// <summary>
+        /// Wraps the specified function as an <see cref="IConverterColor"/>.
+        /// </summary>
+        /// <param name="converter">The function to wrap.</param>
+        /// <returns>A converter of the named interface type.</returns>
+        /// <exception cref="System.ArgumentNullException">Thrown when <paramref name="converter"/> is <see langword="null"/>.</exception>
         public static IConverterColor ToConvert(this Func<Color, Color> converter) =>
             new ConverterColor(converter);
         
+        /// <summary>
+        /// Wraps the specified converter as an <see cref="IConverterColor"/>.
+        /// </summary>
+        /// <param name="converter">The converter to wrap.</param>
+        /// <returns>A converter of the named interface type.</returns>
+        /// <exception cref="System.ArgumentNullException">Thrown when <paramref name="converter"/> is <see langword="null"/>.</exception>
         public static IConverterColor ToConvertSpecific(this IConverter<Color, Color> converter) =>
             new ConverterColor(converter);
         
+        /// <summary>
+        /// Wraps the specified function as an <see cref="IConverterStringToColor"/>.
+        /// </summary>
+        /// <param name="converter">The function to wrap.</param>
+        /// <returns>A converter of the named interface type.</returns>
+        /// <exception cref="System.ArgumentNullException">Thrown when <paramref name="converter"/> is <see langword="null"/>.</exception>
         public static IConverterStringToColor ToConvert(this Func<string?, Color> converter) =>
             new ConverterStringToColor(converter);
         
+        /// <summary>
+        /// Wraps the specified converter as an <see cref="IConverterStringToColor"/>.
+        /// </summary>
+        /// <param name="converter">The converter to wrap.</param>
+        /// <returns>A converter of the named interface type.</returns>
+        /// <exception cref="System.ArgumentNullException">Thrown when <paramref name="converter"/> is <see langword="null"/>.</exception>
         public static IConverterStringToColor ToConvertSpecific(this IConverter<string?, Color> converter) =>
             new ConverterStringToColor(converter);
         

--- a/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Unity/Runtime/Converters/Specific/Colors/IConverterColor.cs
+++ b/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Unity/Runtime/Converters/Specific/Colors/IConverterColor.cs
@@ -4,5 +4,14 @@ using UnityEngine;
 // ReSharper disable once CheckNamespace
 namespace Aspid.MVVM.StarterKit
 {
+    /// <summary>
+    /// A converter from <see cref="Color"/> to <see cref="Color"/>.
+    /// </summary>
+    /// <remarks>
+    /// A named alias for <see cref="IConverter{TFrom, TTo}"/> closed over these two types.
+    /// It exists because Unity before 2023.1 cannot serialize a <c>[SerializeReference]</c>
+    /// field typed as an open generic, so a binder declares the field as this instead. From
+    /// 2023.1 the generic form is used directly and this is a compatibility shim.
+    /// </remarks>
     public interface IConverterColor : IConverter<Color, Color> { }
 }

--- a/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Unity/Runtime/Converters/Specific/Colors/IConverterColorBlock.cs
+++ b/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Unity/Runtime/Converters/Specific/Colors/IConverterColorBlock.cs
@@ -4,5 +4,14 @@ using UnityEngine.UI;
 // ReSharper disable once CheckNamespace
 namespace Aspid.MVVM.StarterKit
 {
+    /// <summary>
+    /// A converter from <see cref="ColorBlock"/> to <see cref="ColorBlock"/>.
+    /// </summary>
+    /// <remarks>
+    /// A named alias for <see cref="IConverter{TFrom, TTo}"/> closed over these two types.
+    /// It exists because Unity before 2023.1 cannot serialize a <c>[SerializeReference]</c>
+    /// field typed as an open generic, so a binder declares the field as this instead. From
+    /// 2023.1 the generic form is used directly and this is a compatibility shim.
+    /// </remarks>
     public interface IConverterColorBlock : IConverter<ColorBlock, ColorBlock> { }
 }

--- a/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Unity/Runtime/Converters/Specific/Colors/IConverterStringToColor.cs
+++ b/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Unity/Runtime/Converters/Specific/Colors/IConverterStringToColor.cs
@@ -4,5 +4,14 @@ using UnityEngine;
 // ReSharper disable once CheckNamespace
 namespace Aspid.MVVM.StarterKit
 {
+    /// <summary>
+    /// A converter from <see cref="string"/> to <see cref="Color"/>.
+    /// </summary>
+    /// <remarks>
+    /// A named alias for <see cref="IConverter{TFrom, TTo}"/> closed over these two types.
+    /// It exists because Unity before 2023.1 cannot serialize a <c>[SerializeReference]</c>
+    /// field typed as an open generic, so a binder declares the field as this instead. From
+    /// 2023.1 the generic form is used directly and this is a compatibility shim.
+    /// </remarks>
     public interface IConverterStringToColor : IConverter<string?, Color> { }
 }

--- a/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Unity/Runtime/Converters/Specific/ConverterSpecificExtensions.cs
+++ b/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Unity/Runtime/Converters/Specific/ConverterSpecificExtensions.cs
@@ -11,29 +11,87 @@ using PhysicsMaterial = UnityEngine.PhysicMaterial;
 // ReSharper disable once CheckNamespace
 namespace Aspid.MVVM.StarterKit
 {
+    /// <summary>
+    /// Wraps a function or a generic converter as one of the named Unity asset converter
+    /// interfaces.
+    /// </summary>
+    /// <remarks>
+    /// <c>ToConvert</c> takes a function, <c>ToConvertSpecific</c> takes a converter that is
+    /// already the right shape but not the named type. Both exist because a binder before
+    /// Unity 2023.1 declares its field as the named interface rather than the generic one,
+    /// so a lambda cannot be assigned to it directly.
+    /// </remarks>
     public static class ConverterSpecificExtensions
     {
+        /// <summary>
+        /// Wraps the specified function as an <see cref="IConverterMesh"/>.
+        /// </summary>
+        /// <param name="converter">The function to wrap.</param>
+        /// <returns>A converter of the named interface type.</returns>
+        /// <exception cref="System.ArgumentNullException">Thrown when <paramref name="converter"/> is <see langword="null"/>.</exception>
         public static IConverterMesh ToConvert(this Func<Mesh?, Mesh?> converter) =>
             new ConverterMesh(converter);
         
+        /// <summary>
+        /// Wraps the specified converter as an <see cref="IConverterMesh"/>.
+        /// </summary>
+        /// <param name="converter">The converter to wrap.</param>
+        /// <returns>A converter of the named interface type.</returns>
+        /// <exception cref="System.ArgumentNullException">Thrown when <paramref name="converter"/> is <see langword="null"/>.</exception>
         public static IConverterMesh ToConvertSpecific(this IConverter<Mesh?, Mesh?> converter) =>
             new ConverterMesh(converter);
         
+        /// <summary>
+        /// Wraps the specified function as an <see cref="IConverterMaterial"/>.
+        /// </summary>
+        /// <param name="converter">The function to wrap.</param>
+        /// <returns>A converter of the named interface type.</returns>
+        /// <exception cref="System.ArgumentNullException">Thrown when <paramref name="converter"/> is <see langword="null"/>.</exception>
         public static IConverterMaterial ToConvert(this Func<Material?, Material?> converter) =>
             new ConverterMaterial(converter);
         
+        /// <summary>
+        /// Wraps the specified converter as an <see cref="IConverterMaterial"/>.
+        /// </summary>
+        /// <param name="converter">The converter to wrap.</param>
+        /// <returns>A converter of the named interface type.</returns>
+        /// <exception cref="System.ArgumentNullException">Thrown when <paramref name="converter"/> is <see langword="null"/>.</exception>
         public static IConverterMaterial ToConvertSpecific(this IConverter<Material?, Material?> converter) =>
             new ConverterMaterial(converter);
         
+        /// <summary>
+        /// Wraps the specified function as an <see cref="IConverterQuaternion"/>.
+        /// </summary>
+        /// <param name="converter">The function to wrap.</param>
+        /// <returns>A converter of the named interface type.</returns>
+        /// <exception cref="System.ArgumentNullException">Thrown when <paramref name="converter"/> is <see langword="null"/>.</exception>
         public static IConverterQuaternion ToConvert(this Func<Quaternion, Quaternion> converter) =>
             new ConverterQuaternion(converter);
         
+        /// <summary>
+        /// Wraps the specified converter as an <see cref="IConverterQuaternion"/>.
+        /// </summary>
+        /// <param name="converter">The converter to wrap.</param>
+        /// <returns>A converter of the named interface type.</returns>
+        /// <exception cref="System.ArgumentNullException">Thrown when <paramref name="converter"/> is <see langword="null"/>.</exception>
         public static IConverterQuaternion ToConvertSpecific(this IConverter<Quaternion, Quaternion> converter) =>
             new ConverterQuaternion(converter);
         
+        /// <summary>
+        /// Wraps the specified function as an <see cref="IConverterPhysicsMaterial"/>.
+        /// </summary>
+        /// <param name="converter">The function to wrap.</param>
+        /// <returns>A converter of the named interface type.</returns>
+        /// <exception cref="System.ArgumentNullException">Thrown when <paramref name="converter"/> is <see langword="null"/>.</exception>
         public static IConverterPhysicsMaterial ToConvert(this Func<PhysicsMaterial?, PhysicsMaterial?> converter) =>
             new ConverterPhysicsMaterial(converter);
         
+        /// <summary>
+        /// Wraps the specified converter as an <see cref="IConverterPhysicsMaterial"/>.
+        /// </summary>
+        /// <param name="converter">The converter to wrap.</param>
+        /// <returns>A converter of the named interface type.</returns>
+        /// <exception cref="System.ArgumentNullException">Thrown when <paramref name="converter"/> is <see langword="null"/>.</exception>
         public static IConverterPhysicsMaterial ToConvertSpecific(this IConverter<PhysicsMaterial?, PhysicsMaterial?> converter) =>
             new ConverterPhysicsMaterial(converter);
         

--- a/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Unity/Runtime/Converters/Specific/IConverterEnumToDropdownOptionData.cs
+++ b/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Unity/Runtime/Converters/Specific/IConverterEnumToDropdownOptionData.cs
@@ -6,5 +6,14 @@ using System.Collections.Generic;
 // ReSharper disable once CheckNamespace
 namespace Aspid.MVVM.StarterKit
 {
+    /// <summary>
+    /// A converter from <see cref="Enum"/> to <see cref="OptionData>"/>.
+    /// </summary>
+    /// <remarks>
+    /// A named alias for <see cref="IConverter{TFrom, TTo}"/> closed over these two types.
+    /// It exists because Unity before 2023.1 cannot serialize a <c>[SerializeReference]</c>
+    /// field typed as an open generic, so a binder declares the field as this instead. From
+    /// 2023.1 the generic form is used directly and this is a compatibility shim.
+    /// </remarks>
     public interface IConverterEnumToDropdownOptionData : IConverter<Enum, IEnumerable<TMP_Dropdown.OptionData>> { }
 }

--- a/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Unity/Runtime/Converters/Specific/IConverterMaterial.cs
+++ b/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Unity/Runtime/Converters/Specific/IConverterMaterial.cs
@@ -4,5 +4,14 @@ using UnityEngine;
 // ReSharper disable once CheckNamespace
 namespace Aspid.MVVM.StarterKit
 {
+    /// <summary>
+    /// A converter from <see cref="Material"/> to <see cref="Material"/>.
+    /// </summary>
+    /// <remarks>
+    /// A named alias for <see cref="IConverter{TFrom, TTo}"/> closed over these two types.
+    /// It exists because Unity before 2023.1 cannot serialize a <c>[SerializeReference]</c>
+    /// field typed as an open generic, so a binder declares the field as this instead. From
+    /// 2023.1 the generic form is used directly and this is a compatibility shim.
+    /// </remarks>
     public interface IConverterMaterial : IConverter<Material?, Material?> { }
 }

--- a/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Unity/Runtime/Converters/Specific/IConverterMesh.cs
+++ b/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Unity/Runtime/Converters/Specific/IConverterMesh.cs
@@ -4,5 +4,14 @@ using UnityEngine;
 // ReSharper disable once CheckNamespace
 namespace Aspid.MVVM.StarterKit
 {
+    /// <summary>
+    /// A converter from <see cref="Mesh"/> to <see cref="Mesh"/>.
+    /// </summary>
+    /// <remarks>
+    /// A named alias for <see cref="IConverter{TFrom, TTo}"/> closed over these two types.
+    /// It exists because Unity before 2023.1 cannot serialize a <c>[SerializeReference]</c>
+    /// field typed as an open generic, so a binder declares the field as this instead. From
+    /// 2023.1 the generic form is used directly and this is a compatibility shim.
+    /// </remarks>
     public interface IConverterMesh : IConverter<Mesh?, Mesh?> { }
 }

--- a/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Unity/Runtime/Converters/Specific/IConverterPhysicsMaterial.cs
+++ b/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Unity/Runtime/Converters/Specific/IConverterPhysicsMaterial.cs
@@ -8,5 +8,14 @@ using PhysicsMaterial = UnityEngine.PhysicMaterial;
 // ReSharper disable once CheckNamespace
 namespace Aspid.MVVM.StarterKit
 {
+    /// <summary>
+    /// A converter from <see cref="PhysicsMaterial"/> to <see cref="PhysicsMaterial"/>.
+    /// </summary>
+    /// <remarks>
+    /// A named alias for <see cref="IConverter{TFrom, TTo}"/> closed over these two types.
+    /// It exists because Unity before 2023.1 cannot serialize a <c>[SerializeReference]</c>
+    /// field typed as an open generic, so a binder declares the field as this instead. From
+    /// 2023.1 the generic form is used directly and this is a compatibility shim.
+    /// </remarks>
     public interface IConverterPhysicsMaterial : IConverter<PhysicsMaterial?, PhysicsMaterial?> { }
 }

--- a/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Unity/Runtime/Converters/Specific/IConverterQuaternion.cs
+++ b/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Unity/Runtime/Converters/Specific/IConverterQuaternion.cs
@@ -4,5 +4,14 @@ using UnityEngine;
 // ReSharper disable once CheckNamespace
 namespace Aspid.MVVM.StarterKit
 {
+    /// <summary>
+    /// A converter from <see cref="Quaternion"/> to <see cref="Quaternion"/>.
+    /// </summary>
+    /// <remarks>
+    /// A named alias for <see cref="IConverter{TFrom, TTo}"/> closed over these two types.
+    /// It exists because Unity before 2023.1 cannot serialize a <c>[SerializeReference]</c>
+    /// field typed as an open generic, so a binder declares the field as this instead. From
+    /// 2023.1 the generic form is used directly and this is a compatibility shim.
+    /// </remarks>
     public interface IConverterQuaternion : IConverter<Quaternion, Quaternion> { }
 }

--- a/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Unity/Runtime/Converters/Specific/IConverterRectOffset.cs
+++ b/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Unity/Runtime/Converters/Specific/IConverterRectOffset.cs
@@ -4,5 +4,14 @@ using UnityEngine;
 // ReSharper disable once CheckNamespace
 namespace Aspid.MVVM.StarterKit
 {
+    /// <summary>
+    /// A converter from <see cref="RectOffset"/> to <see cref="RectOffset"/>.
+    /// </summary>
+    /// <remarks>
+    /// A named alias for <see cref="IConverter{TFrom, TTo}"/> closed over these two types.
+    /// It exists because Unity before 2023.1 cannot serialize a <c>[SerializeReference]</c>
+    /// field typed as an open generic, so a binder declares the field as this instead. From
+    /// 2023.1 the generic form is used directly and this is a compatibility shim.
+    /// </remarks>
     public interface IConverterRectOffset : IConverter<RectOffset, RectOffset> { }
 }

--- a/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Unity/Runtime/Converters/Specific/IConverterTexture.cs
+++ b/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Unity/Runtime/Converters/Specific/IConverterTexture.cs
@@ -4,5 +4,14 @@ using UnityEngine;
 // ReSharper disable once CheckNamespace
 namespace Aspid.MVVM.StarterKit
 {
+    /// <summary>
+    /// A converter from <see cref="Texture"/> to <see cref="Texture"/>.
+    /// </summary>
+    /// <remarks>
+    /// A named alias for <see cref="IConverter{TFrom, TTo}"/> closed over these two types.
+    /// It exists because Unity before 2023.1 cannot serialize a <c>[SerializeReference]</c>
+    /// field typed as an open generic, so a binder declares the field as this instead. From
+    /// 2023.1 the generic form is used directly and this is a compatibility shim.
+    /// </remarks>
     public interface IConverterTexture : IConverter<Texture, Texture> { }
 }

--- a/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Unity/Runtime/Converters/Specific/IConverterTexture2D.cs
+++ b/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Unity/Runtime/Converters/Specific/IConverterTexture2D.cs
@@ -4,5 +4,14 @@ using UnityEngine;
 // ReSharper disable once CheckNamespace
 namespace Aspid.MVVM.StarterKit
 {
+    /// <summary>
+    /// A converter from <see cref="Texture2D"/> to <see cref="Texture2D"/>.
+    /// </summary>
+    /// <remarks>
+    /// A named alias for <see cref="IConverter{TFrom, TTo}"/> closed over these two types.
+    /// It exists because Unity before 2023.1 cannot serialize a <c>[SerializeReference]</c>
+    /// field typed as an open generic, so a binder declares the field as this instead. From
+    /// 2023.1 the generic form is used directly and this is a compatibility shim.
+    /// </remarks>
     public interface IConverterTexture2D : IConverter<Texture2D, Texture2D> { }
 }

--- a/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Unity/Runtime/Converters/Specific/Vectors/IConverterVector2.cs
+++ b/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Unity/Runtime/Converters/Specific/Vectors/IConverterVector2.cs
@@ -4,5 +4,14 @@ using UnityEngine;
 // ReSharper disable once CheckNamespace
 namespace Aspid.MVVM.StarterKit
 {
+    /// <summary>
+    /// A converter from <see cref="Vector2"/> to <see cref="Vector2"/>.
+    /// </summary>
+    /// <remarks>
+    /// A named alias for <see cref="IConverter{TFrom, TTo}"/> closed over these two types.
+    /// It exists because Unity before 2023.1 cannot serialize a <c>[SerializeReference]</c>
+    /// field typed as an open generic, so a binder declares the field as this instead. From
+    /// 2023.1 the generic form is used directly and this is a compatibility shim.
+    /// </remarks>
     public interface IConverterVector2 : IConverter<Vector2, Vector2> { }
 }

--- a/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Unity/Runtime/Converters/Specific/Vectors/IConverterVector2ToVector3.cs
+++ b/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Unity/Runtime/Converters/Specific/Vectors/IConverterVector2ToVector3.cs
@@ -4,5 +4,14 @@ using UnityEngine;
 // ReSharper disable once CheckNamespace
 namespace Aspid.MVVM.StarterKit
 {
+    /// <summary>
+    /// A converter from <see cref="Vector2"/> to <see cref="Vector3"/>.
+    /// </summary>
+    /// <remarks>
+    /// A named alias for <see cref="IConverter{TFrom, TTo}"/> closed over these two types.
+    /// It exists because Unity before 2023.1 cannot serialize a <c>[SerializeReference]</c>
+    /// field typed as an open generic, so a binder declares the field as this instead. From
+    /// 2023.1 the generic form is used directly and this is a compatibility shim.
+    /// </remarks>
     public interface IConverterVector2ToVector3 : IConverter<Vector2, Vector3> { }
 }

--- a/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Unity/Runtime/Converters/Specific/Vectors/IConverterVector3.cs
+++ b/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Unity/Runtime/Converters/Specific/Vectors/IConverterVector3.cs
@@ -4,5 +4,14 @@ using UnityEngine;
 // ReSharper disable once CheckNamespace
 namespace Aspid.MVVM.StarterKit
 {
+    /// <summary>
+    /// A converter from <see cref="Vector3"/> to <see cref="Vector3"/>.
+    /// </summary>
+    /// <remarks>
+    /// A named alias for <see cref="IConverter{TFrom, TTo}"/> closed over these two types.
+    /// It exists because Unity before 2023.1 cannot serialize a <c>[SerializeReference]</c>
+    /// field typed as an open generic, so a binder declares the field as this instead. From
+    /// 2023.1 the generic form is used directly and this is a compatibility shim.
+    /// </remarks>
     public interface IConverterVector3 : IConverter<Vector3, Vector3> { }
 }

--- a/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Unity/Runtime/Converters/Specific/Vectors/IConverterVector3ToVector2.cs
+++ b/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Unity/Runtime/Converters/Specific/Vectors/IConverterVector3ToVector2.cs
@@ -4,5 +4,14 @@ using UnityEngine;
 // ReSharper disable once CheckNamespace
 namespace Aspid.MVVM.StarterKit
 {
+    /// <summary>
+    /// A converter from <see cref="Vector3"/> to <see cref="Vector2"/>.
+    /// </summary>
+    /// <remarks>
+    /// A named alias for <see cref="IConverter{TFrom, TTo}"/> closed over these two types.
+    /// It exists because Unity before 2023.1 cannot serialize a <c>[SerializeReference]</c>
+    /// field typed as an open generic, so a binder declares the field as this instead. From
+    /// 2023.1 the generic form is used directly and this is a compatibility shim.
+    /// </remarks>
     public interface IConverterVector3ToVector2 : IConverter<Vector3, Vector2> { }
 }

--- a/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Unity/Runtime/Converters/Specific/Vectors/VectorConverterSpecificExtensions.cs
+++ b/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Unity/Runtime/Converters/Specific/Vectors/VectorConverterSpecificExtensions.cs
@@ -6,29 +6,87 @@ using UnityEngine;
 // ReSharper disable once CheckNamespace
 namespace Aspid.MVVM.StarterKit
 {
+    /// <summary>
+    /// Wraps a function or a generic converter as one of the named vector converter
+    /// interfaces.
+    /// </summary>
+    /// <remarks>
+    /// <c>ToConvert</c> takes a function, <c>ToConvertSpecific</c> takes a converter that is
+    /// already the right shape but not the named type. Both exist because a binder before
+    /// Unity 2023.1 declares its field as the named interface rather than the generic one,
+    /// so a lambda cannot be assigned to it directly.
+    /// </remarks>
     public static class VectorConverterSpecificExtensions
     {
+        /// <summary>
+        /// Wraps the specified function as an <see cref="IConverterVector2"/>.
+        /// </summary>
+        /// <param name="converter">The function to wrap.</param>
+        /// <returns>A converter of the named interface type.</returns>
+        /// <exception cref="System.ArgumentNullException">Thrown when <paramref name="converter"/> is <see langword="null"/>.</exception>
         public static IConverterVector2 ToConvert(this Func<Vector2, Vector2> converter) =>
             new ConverterVector2(converter);
         
+        /// <summary>
+        /// Wraps the specified converter as an <see cref="IConverterVector2"/>.
+        /// </summary>
+        /// <param name="converter">The converter to wrap.</param>
+        /// <returns>A converter of the named interface type.</returns>
+        /// <exception cref="System.ArgumentNullException">Thrown when <paramref name="converter"/> is <see langword="null"/>.</exception>
         public static IConverterVector2 ToConvertSpecific(this IConverter<Vector2, Vector2> converter) =>
             new ConverterVector2(converter);
         
+        /// <summary>
+        /// Wraps the specified function as an <see cref="IConverterVector2ToVector3"/>.
+        /// </summary>
+        /// <param name="converter">The function to wrap.</param>
+        /// <returns>A converter of the named interface type.</returns>
+        /// <exception cref="System.ArgumentNullException">Thrown when <paramref name="converter"/> is <see langword="null"/>.</exception>
         public static IConverterVector2ToVector3 ToConvert(this Func<Vector2, Vector3> converter) =>
             new ConverterVector2ToVector3(converter);
         
+        /// <summary>
+        /// Wraps the specified converter as an <see cref="IConverterVector2ToVector3"/>.
+        /// </summary>
+        /// <param name="converter">The converter to wrap.</param>
+        /// <returns>A converter of the named interface type.</returns>
+        /// <exception cref="System.ArgumentNullException">Thrown when <paramref name="converter"/> is <see langword="null"/>.</exception>
         public static IConverterVector2ToVector3 ToConvertSpecific(this IConverter<Vector2, Vector3> converter) =>
             new ConverterVector2ToVector3(converter);
         
+        /// <summary>
+        /// Wraps the specified function as an <see cref="IConverterVector3"/>.
+        /// </summary>
+        /// <param name="converter">The function to wrap.</param>
+        /// <returns>A converter of the named interface type.</returns>
+        /// <exception cref="System.ArgumentNullException">Thrown when <paramref name="converter"/> is <see langword="null"/>.</exception>
         public static IConverterVector3 ToConvert(this Func<Vector3, Vector3> converter) =>
             new ConverterVector3(converter);
         
+        /// <summary>
+        /// Wraps the specified converter as an <see cref="IConverterVector3"/>.
+        /// </summary>
+        /// <param name="converter">The converter to wrap.</param>
+        /// <returns>A converter of the named interface type.</returns>
+        /// <exception cref="System.ArgumentNullException">Thrown when <paramref name="converter"/> is <see langword="null"/>.</exception>
         public static IConverterVector3 ToConvertSpecific(this IConverter<Vector3, Vector3> converter) =>
             new ConverterVector3(converter);
         
+        /// <summary>
+        /// Wraps the specified function as an <see cref="IConverterVector3ToVector2"/>.
+        /// </summary>
+        /// <param name="converter">The function to wrap.</param>
+        /// <returns>A converter of the named interface type.</returns>
+        /// <exception cref="System.ArgumentNullException">Thrown when <paramref name="converter"/> is <see langword="null"/>.</exception>
         public static IConverterVector3ToVector2 ToConvert(this Func<Vector3, Vector2> converter) =>
             new ConverterVector3ToVector2(converter);
         
+        /// <summary>
+        /// Wraps the specified converter as an <see cref="IConverterVector3ToVector2"/>.
+        /// </summary>
+        /// <param name="converter">The converter to wrap.</param>
+        /// <returns>A converter of the named interface type.</returns>
+        /// <exception cref="System.ArgumentNullException">Thrown when <paramref name="converter"/> is <see langword="null"/>.</exception>
         public static IConverterVector3ToVector2 ToConvertSpecific(this IConverter<Vector3, Vector2> converter) =>
             new ConverterVector3ToVector2(converter);
         

--- a/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Unity/Runtime/Converters/Vectors/Vector2CombineConverter.cs
+++ b/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Unity/Runtime/Converters/Vectors/Vector2CombineConverter.cs
@@ -49,8 +49,12 @@ namespace Aspid.MVVM.StarterKit
         /// Initializes a new instance of the <see cref="Vector2CombineConverter"/> class with conversion functions.
         /// </summary>
         /// <param name="mode">The combination mode specifying which components to use.</param>
-        /// <param name="preConvertor">Optional function to apply before combining vectors.</param>
-        /// <param name="postConvertor">Optional function to apply after combining vectors.</param>
+        /// <param name="preConvertor">Applied to the bound vector before the components are selected.</param>
+        /// <param name="postConvertor">Applied to the combined result.</param>
+        /// <exception cref="ArgumentNullException">
+        /// Thrown when either function is <see langword="null"/>. Use the converter overload with
+        /// <see langword="null"/> to leave a stage out.
+        /// </exception>
         public Vector2CombineConverter(
             Mode mode,
             Func<Vector2, Vector2> preConvertor,
@@ -61,8 +65,13 @@ namespace Aspid.MVVM.StarterKit
         /// Initializes a new instance of the <see cref="Vector2CombineConverter"/> class with converter interfaces.
         /// </summary>
         /// <param name="mode">The combination mode specifying which components to use.</param>
-        /// <param name="preConvertor">Optional converter to apply before combining vectors.</param>
-        /// <param name="postConvertor">Optional converter to apply after combining vectors.</param>
+        /// <param name="preConvertor">
+        /// Applied to the bound vector before the components are selected, or <see langword="null"/> to
+        /// leave that stage out.
+        /// </param>
+        /// <param name="postConvertor">
+        /// Applied to the combined result, or <see langword="null"/> to leave that stage out.
+        /// </param>
         public Vector2CombineConverter(
             Mode mode,
             Converter? preConvertor,

--- a/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Unity/Runtime/Converters/Vectors/Vector3CombineConverter.cs
+++ b/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Unity/Runtime/Converters/Vectors/Vector3CombineConverter.cs
@@ -49,8 +49,12 @@ namespace Aspid.MVVM.StarterKit
         /// Initializes a new instance of the <see cref="Vector3CombineConverter"/> class with conversion functions.
         /// </summary>
         /// <param name="mode">The combination mode specifying which components to use.</param>
-        /// <param name="preConvertor">Optional function to apply before combining vectors.</param>
-        /// <param name="postConvertor">Optional function to apply after combining vectors.</param>
+        /// <param name="preConvertor">Applied to the bound vector before the components are selected.</param>
+        /// <param name="postConvertor">Applied to the combined result.</param>
+        /// <exception cref="ArgumentNullException">
+        /// Thrown when either function is <see langword="null"/>. Use the converter overload with
+        /// <see langword="null"/> to leave a stage out.
+        /// </exception>
         public Vector3CombineConverter(
             Mode mode,
             Func<Vector3, Vector3> preConvertor,
@@ -61,8 +65,13 @@ namespace Aspid.MVVM.StarterKit
         /// Initializes a new instance of the <see cref="Vector3CombineConverter"/> class with converter interfaces.
         /// </summary>
         /// <param name="mode">The combination mode specifying which components to use.</param>
-        /// <param name="preConvertor">Optional converter to apply before combining vectors.</param>
-        /// <param name="postConvertor">Optional converter to apply after combining vectors.</param>
+        /// <param name="preConvertor">
+        /// Applied to the bound vector before the components are selected, or <see langword="null"/> to
+        /// leave that stage out.
+        /// </param>
+        /// <param name="postConvertor">
+        /// Applied to the combined result, or <see langword="null"/> to leave that stage out.
+        /// </param>
         public Vector3CombineConverter(
             Mode mode,
             Converter? preConvertor,

--- a/Aspid.MVVM/Packages/tech.aspid.mvvm/Tests/Editor/Converters/GenericFuncConverterTests.cs
+++ b/Aspid.MVVM/Packages/tech.aspid.mvvm/Tests/Editor/Converters/GenericFuncConverterTests.cs
@@ -1,0 +1,47 @@
+using System;
+using NUnit.Framework;
+
+namespace Aspid.MVVM.StarterKit.Tests
+{
+    /// <summary>
+    /// The documented null contract of <see cref="GenericFuncConverter{TFrom,TTo}"/>.
+    /// </summary>
+    /// <remarks>
+    /// Both constructors promised an <see cref="ArgumentNullException"/>, but the converter overload
+    /// delegated with <c>converter.Convert</c> — reading a method group off a null reference, which
+    /// throws a <see cref="NullReferenceException"/> instead. Every one of the seventy
+    /// <c>ToConvert</c> / <c>ToConvertSpecific</c> extension methods funnels through here, so the
+    /// contract is worth pinning rather than trusting.
+    /// </remarks>
+    [TestFixture]
+    internal sealed class GenericFuncConverterTests
+    {
+        [Test]
+        public void Constructor_NullFunction_ThrowsArgumentNull() =>
+            Assert.Throws<ArgumentNullException>(() => _ = new GenericFuncConverter<int, int>((Func<int, int>)null!));
+
+        [Test]
+        public void Constructor_NullConverter_ThrowsArgumentNull() =>
+            Assert.Throws<ArgumentNullException>(() => _ = new GenericFuncConverter<int, int>((IConverter<int, int>)null!));
+
+        [Test]
+        public void ToConvertSpecific_NullConverter_ThrowsArgumentNull() =>
+            Assert.Throws<ArgumentNullException>(() => _ = ((IConverter<int, int>)null!).ToConvertSpecific());
+
+        [Test]
+        public void ToConvert_NullFunction_ThrowsArgumentNull() =>
+            Assert.Throws<ArgumentNullException>(() => _ = ((Func<int, int>)null!).ToConvert());
+
+        [Test]
+        public void Convert_WrappedConverter_DelegatesToIt()
+        {
+            var converter = new GenericFuncConverter<int, int>(new Doubler());
+            Assert.AreEqual(42, converter.Convert(21));
+        }
+
+        private sealed class Doubler : IConverter<int, int>
+        {
+            public int Convert(int value) => value * 2;
+        }
+    }
+}

--- a/Aspid.MVVM/Packages/tech.aspid.mvvm/Tests/Editor/Converters/GenericFuncConverterTests.cs
+++ b/Aspid.MVVM/Packages/tech.aspid.mvvm/Tests/Editor/Converters/GenericFuncConverterTests.cs
@@ -7,11 +7,9 @@ namespace Aspid.MVVM.StarterKit.Tests
     /// The documented null contract of <see cref="GenericFuncConverter{TFrom,TTo}"/>.
     /// </summary>
     /// <remarks>
-    /// Both constructors promised an <see cref="ArgumentNullException"/>, but the converter overload
-    /// delegated with <c>converter.Convert</c> — reading a method group off a null reference, which
-    /// throws a <see cref="NullReferenceException"/> instead. Every one of the seventy
-    /// <c>ToConvert</c> / <c>ToConvertSpecific</c> extension methods funnels through here, so the
-    /// contract is worth pinning rather than trusting.
+    /// The converter overload delegated with <c>converter.Convert</c> — a method group read off a null
+    /// reference, which throws <see cref="NullReferenceException"/> where the constructor promised
+    /// <see cref="ArgumentNullException"/>. Every <c>ToConvert</c> extension funnels through here.
     /// </remarks>
     [TestFixture]
     internal sealed class GenericFuncConverterTests

--- a/Aspid.MVVM/Packages/tech.aspid.mvvm/Tests/Editor/Converters/GenericFuncConverterTests.cs.meta
+++ b/Aspid.MVVM/Packages/tech.aspid.mvvm/Tests/Editor/Converters/GenericFuncConverterTests.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: ace97c89670304e9aa80664e83ed5698


### PR DESCRIPTION
📝 Audit items 4.4–4.6: the converter API surface that had no documentation at all, plus the two places where the documentation that did exist was wrong.

## Summary

- 📝 **40 marker interfaces** now say what they alias and that they carry no behaviour — they are a Unity < 2023.1 serialization shim.
- 📝 **70 `ToConvert` / `ToConvertSpecific` wrappers** and their 6 host classes documented, including why a lambda cannot be assigned to a marker-typed field without them.
- 📝 **`Comparisons` and `CultureInfoMode`** documented member by member, with the part that bites: a number written by one culture and parsed by another loses its fraction rather than failing.
- 🐛 **`GenericFuncConverter(IConverter)` threw `NullReferenceException`** where the `<exception>` tag above it promised `ArgumentNullException`; all 70 wrappers funnel through that constructor.
- 🐛 **The `Vector2`/`Vector3` Combine constructors** called non-nullable `Func` parameters "Optional" — null means "skip this stage" only in the converter overload.

## Notes for review

- ⚠️ The `GenericFuncConverter` fix is a behaviour change (`NullReferenceException` → `ArgumentNullException`), so the blast radius is a test asserting the exact type; `GenericFuncConverterTests` pins it both ways.
- ✅ 1036 EditMode tests, 1034 passed, 0 failed, 2 skipped (two platform-dependent narrowing tests deferred to audit Phase 2).

<details>
<summary>🇷🇺 Описание на русском</summary>

📝 Пункты аудита 4.4–4.6: поверхность API конвертеров без документации вообще, плюс два места, где имевшаяся документация была неверна.

## Итог

- 📝 **40 маркер-интерфейсов** теперь говорят, чьим псевдонимом являются и что поведения в них нет — это shim для сериализации в Unity < 2023.1.
- 📝 **70 обёрток `ToConvert` / `ToConvertSpecific`** и 6 содержащих их классов задокументированы, включая то, почему лямбду нельзя присвоить полю маркерного типа без них.
- 📝 **`Comparisons` и `CultureInfoMode`** описаны по членам, с тем, что реально кусается: число, записанное одной культурой и разобранное другой, теряет дробную часть, а не падает.
- 🐛 **`GenericFuncConverter(IConverter)` бросал `NullReferenceException`** там, где тег `<exception>` над ним обещал `ArgumentNullException`; через этот конструктор идут все 70 обёрток.
- 🐛 **Конструкторы Combine для `Vector2`/`Vector3`** называли non-nullable параметры `Func` «Optional» — «пропустить стадию» означает null только в перегрузке с конвертерами.

## Заметки для ревью

- ⚠️ Правка `GenericFuncConverter` — изменение поведения (`NullReferenceException` → `ArgumentNullException`), поэтому радиус поражения — тест, проверяющий точный тип; `GenericFuncConverterTests` фиксирует контракт в обе стороны.
- ✅ 1036 EditMode-тестов, 1034 прошло, 0 упало, 2 пропущено (два платформозависимых теста сужения отложены в Фазу 2 аудита).

</details>

