### PR TITLE
Repair the converter picker tooltips that lost their type names

### DIFF
--- a/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Runtime/Converters/Composition/NullGuardConverter.cs
+++ b/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Runtime/Converters/Composition/NullGuardConverter.cs
@@ -16,7 +16,7 @@ namespace Aspid.MVVM.StarterKit
     /// Inspector. Wrapping one settles the question at the point of use.
     /// </remarks>
     [Serializable]
-    [TypeSelectorDisplay(Group = "Aspid/Composition", Name = "Null Guard", Tooltip = "Substitutes a fixed result for a  input instead of passing it on")]
+    [TypeSelectorDisplay(Group = "Aspid/Composition", Name = "Null Guard", Tooltip = "Substitutes a fixed result for a null input instead of passing it on")]
     public sealed class NullGuardConverter<TFrom, TTo> : IConverter<TFrom?, TTo?>
     {
         [Tooltip("The converter to run for a non-null value. When empty, the null result is used for every value.")]

--- a/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Runtime/Converters/Numbers/SmoothStepConverter.cs
+++ b/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Runtime/Converters/Numbers/SmoothStepConverter.cs
@@ -9,7 +9,7 @@ namespace Aspid.MVVM.StarterKit
     /// Eases a value between two bounds with <see cref="Mathf.SmoothStep"/>.
     /// </summary>
     [Serializable]
-    [TypeSelectorDisplay(Group = "Aspid/Number", Name = "Smooth Step", Tooltip = "Eases a value between two bounds with ")]
+    [TypeSelectorDisplay(Group = "Aspid/Number", Name = "Smooth Step", Tooltip = "Eases a value between two bounds with smoothstep")]
     public sealed class SmoothStepConverter : IConverterFloat
     {
         [Tooltip("The value that maps to 0.")]

--- a/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Runtime/Converters/Strings/TimeSpanToStringConverter.cs
+++ b/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Runtime/Converters/Strings/TimeSpanToStringConverter.cs
@@ -13,7 +13,7 @@ namespace Aspid.MVVM.StarterKit
     /// <c>"mm\\:ss"</c> that <see cref="TimeSpan.ToString(string)"/> would take comes back as itself.
     /// </remarks>
     [Serializable]
-    [TypeSelectorDisplay(Group = "Aspid/String", Name = "Time Span To String", Tooltip = "for  values, with optional formatting")]
+    [TypeSelectorDisplay(Group = "Aspid/String", Name = "Time Span To String", Tooltip = "Writes a TimeSpan as text, with optional formatting")]
     public sealed class TimeSpanToStringConverter : GenericToString<TimeSpan>, IConverterTimeSpanToString
     {
         public TimeSpanToStringConverter() { }

--- a/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Runtime/Converters/Times/DateTimeFormatConverter.cs
+++ b/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Runtime/Converters/Times/DateTimeFormatConverter.cs
@@ -9,7 +9,7 @@ namespace Aspid.MVVM.StarterKit
     /// Formats a <see cref="DateTime"/>.
     /// </summary>
     [Serializable]
-    [TypeSelectorDisplay(Group = "Aspid/Time", Name = "Date Time Format", Tooltip = "Formats a ")]
+    [TypeSelectorDisplay(Group = "Aspid/Time", Name = "Date Time Format", Tooltip = "Formats a DateTime")]
     public sealed class DateTimeFormatConverter : IConverter<DateTime, string>
     {
         [Tooltip("A DateTime format string, for example dd.MM.yyyy or HH:mm.")]

--- a/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Runtime/Converters/Times/DateTimeToBoolConverter.cs
+++ b/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Runtime/Converters/Times/DateTimeToBoolConverter.cs
@@ -10,7 +10,7 @@ namespace Aspid.MVVM.StarterKit
     /// </summary>
     /// <remarks>Gating on "the event has started" or "the cooldown has expired".</remarks>
     [Serializable]
-    [TypeSelectorDisplay(Group = "Aspid/Time", Name = "Date Time To Bool", Tooltip = "Compares a  with a reference moment")]
+    [TypeSelectorDisplay(Group = "Aspid/Time", Name = "Date Time To Bool", Tooltip = "Compares a DateTime with a reference moment")]
     public sealed class DateTimeToBoolConverter : IConverter<DateTime, bool>
     {
         [Tooltip("How the bound moment is compared with the reference.")]

--- a/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Runtime/Converters/Times/SecondsToTimeSpanConverter.cs
+++ b/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Runtime/Converters/Times/SecondsToTimeSpanConverter.cs
@@ -8,7 +8,7 @@ namespace Aspid.MVVM.StarterKit
     /// Converts a number of seconds to a <see cref="TimeSpan"/>.
     /// </summary>
     [Serializable]
-    [TypeSelectorDisplay(Group = "Aspid/Time", Name = "Seconds To Time Span", Tooltip = "Converts a number of seconds to a ")]
+    [TypeSelectorDisplay(Group = "Aspid/Time", Name = "Seconds To Time Span", Tooltip = "Converts a number of seconds to a TimeSpan")]
     public sealed class SecondsToTimeSpanConverter : ITwoWayConverter<float, TimeSpan>
     {
         /// <summary>

--- a/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Runtime/Converters/Times/TimeSpanFormatConverter.cs
+++ b/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Runtime/Converters/Times/TimeSpanFormatConverter.cs
@@ -14,7 +14,7 @@ namespace Aspid.MVVM.StarterKit
     /// This takes the pattern directly, the way <see cref="TimeSpan.ToString(string)"/> does.
     /// </remarks>
     [Serializable]
-    [TypeSelectorDisplay(Group = "Aspid/Time", Name = "Time Span Format", Tooltip = "Formats a  with a real  format string")]
+    [TypeSelectorDisplay(Group = "Aspid/Time", Name = "Time Span Format", Tooltip = "Formats a TimeSpan with a real TimeSpan format string")]
     public sealed class TimeSpanFormatConverter : IConverterTimeSpanToString
     {
         [Tooltip(@"A TimeSpan format string, for example mm\:ss or hh\:mm\:ss.")]

--- a/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Runtime/Converters/Times/TimeSpanToNumberConverter.cs
+++ b/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Runtime/Converters/Times/TimeSpanToNumberConverter.cs
@@ -10,7 +10,7 @@ namespace Aspid.MVVM.StarterKit
     /// </summary>
     /// <remarks>For feeding a duration into a slider or a fill amount.</remarks>
     [Serializable]
-    [TypeSelectorDisplay(Group = "Aspid/Time", Name = "Time Span To Number", Tooltip = "Measures a  as a number")]
+    [TypeSelectorDisplay(Group = "Aspid/Time", Name = "Time Span To Number", Tooltip = "Measures a TimeSpan as a number")]
     public sealed class TimeSpanToNumberConverter : IConverter<TimeSpan, float>
     {
         [Tooltip("Which unit to measure in.")]

--- a/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Runtime/Converters/Times/UnixTimestampToDateTimeConverter.cs
+++ b/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Runtime/Converters/Times/UnixTimestampToDateTimeConverter.cs
@@ -10,7 +10,7 @@ namespace Aspid.MVVM.StarterKit
     /// </summary>
     /// <remarks>A backend that speaks epoch seconds, which most do.</remarks>
     [Serializable]
-    [TypeSelectorDisplay(Group = "Aspid/Time", Name = "Unix Timestamp To Date Time", Tooltip = "Converts a Unix timestamp to a ")]
+    [TypeSelectorDisplay(Group = "Aspid/Time", Name = "Unix Timestamp To Date Time", Tooltip = "Converts a Unix timestamp to a DateTime")]
     public sealed class UnixTimestampToDateTimeConverter : ITwoWayConverter<long, DateTime>
     {
         [Tooltip("The timestamp is in milliseconds rather than seconds.")]

--- a/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Unity/Runtime/Converters/Assets/ConverterAssetReference.cs
+++ b/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Unity/Runtime/Converters/Assets/ConverterAssetReference.cs
@@ -18,7 +18,7 @@ namespace Aspid.MVVM.StarterKit
     /// shared converters without changing.
     /// </remarks>
     [Serializable]
-    [TypeSelectorDisplay(Group = "Aspid/Asset", Name = "Converter Asset Reference", Tooltip = "Forwards conversion to a shared ")]
+    [TypeSelectorDisplay(Group = "Aspid/Asset", Name = "Converter Asset Reference", Tooltip = "Forwards conversion to a shared ConverterAsset")]
     public sealed class ConverterAssetReference<TFrom, TTo> : IConverter<TFrom?, TTo?>
     {
         [Tooltip("The shared converter asset. When empty, the default value is returned.")]

--- a/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Unity/Runtime/Converters/Bools/UnityObjectNullToBoolConverter.cs
+++ b/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Unity/Runtime/Converters/Bools/UnityObjectNullToBoolConverter.cs
@@ -17,7 +17,7 @@ namespace Aspid.MVVM.StarterKit
     /// overloaded <c>==</c>, which is the only check that catches both cases.
     /// </remarks>
     [Serializable]
-    [TypeSelectorDisplay(Group = "Aspid/Bool", Name = "Unity Object Null To Bool", Tooltip = "Converts a  reference to a boolean based on whether it is alive")]
+    [TypeSelectorDisplay(Group = "Aspid/Bool", Name = "Unity Object Null To Bool", Tooltip = "Converts a Unity Object reference to a boolean based on whether it is alive")]
     public sealed class UnityObjectNullToBoolConverter : IConverter<Object?, bool>
     {
         [Tooltip("Invert the result — true when the object is alive.")]

--- a/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Unity/Runtime/Converters/Colors/ColorBlockAlphaConverter.cs
+++ b/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Unity/Runtime/Converters/Colors/ColorBlockAlphaConverter.cs
@@ -12,7 +12,7 @@ namespace Aspid.MVVM.StarterKit
     /// </summary>
     /// <remarks>Dimming a whole interactive element without touching its hues.</remarks>
     [Serializable]
-    [TypeSelectorDisplay(Group = "Aspid/Colour", Name = "Color Block Alpha", Tooltip = "Changes the alpha of every colour in a ")]
+    [TypeSelectorDisplay(Group = "Aspid/Colour", Name = "Color Block Alpha", Tooltip = "Changes the alpha of every colour in a ColorBlock")]
     public sealed class ColorBlockAlphaConverter : IConverterColorBlock
     {
         [Tooltip("The alpha applied to every state.")]

--- a/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Unity/Runtime/Converters/Colors/ColorBlockFadeDurationConverter.cs
+++ b/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Unity/Runtime/Converters/Colors/ColorBlockFadeDurationConverter.cs
@@ -15,7 +15,7 @@ namespace Aspid.MVVM.StarterKit
     /// reaches without rebuilding the whole block.
     /// </remarks>
     [Serializable]
-    [TypeSelectorDisplay(Group = "Aspid/Colour", Name = "Color Block Fade Duration", Tooltip = "Sets how long a  takes to change state")]
+    [TypeSelectorDisplay(Group = "Aspid/Colour", Name = "Color Block Fade Duration", Tooltip = "Sets how long a ColorBlock takes to change state")]
     public sealed class ColorBlockFadeDurationConverter : IConverterColorBlock
     {
         [Tooltip("How long a state change takes.")]

--- a/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Unity/Runtime/Converters/Colors/ColorBlockTintConverter.cs
+++ b/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Unity/Runtime/Converters/Colors/ColorBlockTintConverter.cs
@@ -12,7 +12,7 @@ namespace Aspid.MVVM.StarterKit
     /// </summary>
     /// <remarks>Theming a whole button at once — faction colours, a disabled palette.</remarks>
     [Serializable]
-    [TypeSelectorDisplay(Group = "Aspid/Colour", Name = "Color Block Tint", Tooltip = "Tints every colour of a ")]
+    [TypeSelectorDisplay(Group = "Aspid/Colour", Name = "Color Block Tint", Tooltip = "Tints every colour of a ColorBlock")]
     public sealed class ColorBlockTintConverter : IConverterColorBlock
     {
         [Tooltip("The colour every state is combined with.")]

--- a/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Unity/Runtime/Converters/Colors/ColorToColorBlockConverter.cs
+++ b/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Unity/Runtime/Converters/Colors/ColorToColorBlockConverter.cs
@@ -15,7 +15,7 @@ namespace Aspid.MVVM.StarterKit
     /// the one colour that varies, so the ViewModel does not have to model UGUI interaction states.
     /// </remarks>
     [Serializable]
-    [TypeSelectorDisplay(Group = "Aspid/Colour", Name = "Color To Color Block", Tooltip = "Builds a full  out of one colour")]
+    [TypeSelectorDisplay(Group = "Aspid/Colour", Name = "Color To Color Block", Tooltip = "Builds a full ColorBlock out of one colour")]
     public sealed class ColorToColorBlockConverter : IConverter<Color, ColorBlock>
     {
         [Tooltip("Scales the colour for the highlighted state.")]

--- a/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Unity/Runtime/Converters/Colors/GradientEvaluateConverter.cs
+++ b/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Unity/Runtime/Converters/Colors/GradientEvaluateConverter.cs
@@ -15,7 +15,7 @@ namespace Aspid.MVVM.StarterKit
     /// number it already has.
     /// </remarks>
     [Serializable]
-    [TypeSelectorDisplay(Group = "Aspid/Colour", Name = "Gradient Evaluate", Tooltip = "Reads a colour off a ")]
+    [TypeSelectorDisplay(Group = "Aspid/Colour", Name = "Gradient Evaluate", Tooltip = "Reads a colour off a Gradient")]
     public sealed class GradientEvaluateConverter : IConverter<float, Color>
     {
         [Tooltip("The gradient the value is read from.")]

--- a/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Unity/Runtime/Converters/Colors/ParseHtmlStringConverter.cs
+++ b/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Unity/Runtime/Converters/Colors/ParseHtmlStringConverter.cs
@@ -15,7 +15,7 @@ namespace Aspid.MVVM.StarterKit
     /// every time, whichever mode is chosen.
     /// </remarks>
     [Serializable]
-    [TypeSelectorDisplay(Group = "Aspid/Colour", Name = "Parse Html String", Tooltip = "Converts HTML color strings (e.g., '#FF0000') to  values")]
+    [TypeSelectorDisplay(Group = "Aspid/Colour", Name = "Parse Html String", Tooltip = "Converts HTML color strings (e.g., '#FF0000') to Color values")]
     public sealed class ParseHtmlStringConverter : IConverterStringToColor
     {
         [Tooltip("What to do with a string that does not parse. ReturnInput is not available here — the input is a string and the output a colour — and behaves as ReturnFallback.")]

--- a/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Unity/Runtime/Converters/Layouts/Vector4ToRectOffsetConverter.cs
+++ b/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Unity/Runtime/Converters/Layouts/Vector4ToRectOffsetConverter.cs
@@ -14,7 +14,7 @@ namespace Aspid.MVVM.StarterKit
     /// would have to be allocated on its side.
     /// </remarks>
     [Serializable]
-    [TypeSelectorDisplay(Group = "Aspid/Layout", Name = "Vector4 To Rect Offset", Tooltip = "Turns the four numbers of a  into a padding")]
+    [TypeSelectorDisplay(Group = "Aspid/Layout", Name = "Vector4 To Rect Offset", Tooltip = "Turns the four numbers of a Vector4 into a padding")]
     public sealed class Vector4ToRectOffsetConverter : IConverter<Vector4, RectOffset>
     {
         [Tooltip("Which way to drop the fraction.")]

--- a/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Unity/Runtime/Converters/Numbers/AnimationCurveConverter.cs
+++ b/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Unity/Runtime/Converters/Numbers/AnimationCurveConverter.cs
@@ -15,7 +15,7 @@ namespace Aspid.MVVM.StarterKit
     /// asking for one.
     /// </remarks>
     [Serializable]
-    [TypeSelectorDisplay(Group = "Aspid/Number", Name = "Animation Curve", Tooltip = "Passes a number through an ")]
+    [TypeSelectorDisplay(Group = "Aspid/Number", Name = "Animation Curve", Tooltip = "Passes a number through an AnimationCurve")]
     public sealed class AnimationCurveConverter : IConverterFloat
     {
         [Tooltip("The curve the value is passed through.")]

--- a/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Unity/Runtime/Converters/Numbers/AudioLinearToDecibelConverter.cs
+++ b/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Unity/Runtime/Converters/Numbers/AudioLinearToDecibelConverter.cs
@@ -15,7 +15,7 @@ namespace Aspid.MVVM.StarterKit
     /// nothing. This is the conversion that makes a linear slider sound linear.
     /// </remarks>
     [Serializable]
-    [TypeSelectorDisplay(Group = "Aspid/Number", Name = "Audio Linear To Decibel", Tooltip = "Converts a 0..1 slider position to the decibels an  expects")]
+    [TypeSelectorDisplay(Group = "Aspid/Number", Name = "Audio Linear To Decibel", Tooltip = "Converts a 0..1 slider position to the decibels an AudioMixer expects")]
     public sealed class AudioLinearToDecibelConverter : ITwoWayConverter<float, float>
     {
         [Tooltip("The decibel value silence maps to.")]

--- a/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Unity/Runtime/Converters/Textures/SpriteToTextureConverter.cs
+++ b/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Unity/Runtime/Converters/Textures/SpriteToTextureConverter.cs
@@ -14,7 +14,7 @@ namespace Aspid.MVVM.StarterKit
     /// <see cref="Texture"/> — two properties for one picture.
     /// </remarks>
     [Serializable]
-    [TypeSelectorDisplay(Group = "Aspid/Texture", Name = "Sprite To Texture", Tooltip = "Takes the texture a  is drawn from")]
+    [TypeSelectorDisplay(Group = "Aspid/Texture", Name = "Sprite To Texture", Tooltip = "Takes the texture a Sprite is drawn from")]
     public sealed class SpriteToTextureConverter : IConverter<Sprite?, Texture?>
     {
         /// <summary>

--- a/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Unity/Runtime/Converters/Textures/Texture2DToSpriteConverter.cs
+++ b/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Unity/Runtime/Converters/Textures/Texture2DToSpriteConverter.cs
@@ -15,7 +15,7 @@ namespace Aspid.MVVM.StarterKit
     /// against the texture it came from. Without that, a bound avatar leaks a sprite per frame.
     /// </remarks>
     [Serializable]
-    [TypeSelectorDisplay(Group = "Aspid/Texture", Name = "Texture2 D To Sprite", Tooltip = "Wraps a  in a ")]
+    [TypeSelectorDisplay(Group = "Aspid/Texture", Name = "Texture2 D To Sprite", Tooltip = "Wraps a Texture2D in a Sprite")]
     public sealed class Texture2DToSpriteConverter : IConverter<Texture2D?, Sprite?>
     {
         [Tooltip("Where the sprite's pivot sits, in normalised coordinates.")]

--- a/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Unity/Runtime/Converters/Vectors/Vector2CombineConverter.cs
+++ b/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Unity/Runtime/Converters/Vectors/Vector2CombineConverter.cs
@@ -16,7 +16,7 @@ namespace Aspid.MVVM.StarterKit
     /// Supports optional pre- and post-conversion transformations.
     /// </summary>
     [Serializable]
-    [TypeSelectorDisplay(Group = "Aspid/Vector", Name = "Vector2 Combine", Tooltip = "Combines two  values by selecting which components to use from each vector")]
+    [TypeSelectorDisplay(Group = "Aspid/Vector", Name = "Vector2 Combine", Tooltip = "Combines two Vector2 values by selecting which components to use from each vector")]
     public sealed class Vector2CombineConverter
     {
         [Tooltip("Which components come from the bound vector; the rest come from the reference one.")]

--- a/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Unity/Runtime/Converters/Vectors/Vector2SubstitutionConverter.cs
+++ b/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Unity/Runtime/Converters/Vectors/Vector2SubstitutionConverter.cs
@@ -11,7 +11,7 @@ namespace Aspid.MVVM.StarterKit
     /// Converts <see cref="Vector2"/> values by substituting and rearranging their components.
     /// </summary>
     [Serializable]
-    [TypeSelectorDisplay(Group = "Aspid/Vector", Name = "Vector2 Substitution", Tooltip = "Converts  values by substituting and rearranging their components")]
+    [TypeSelectorDisplay(Group = "Aspid/Vector", Name = "Vector2 Substitution", Tooltip = "Converts Vector2 values by substituting and rearranging their components")]
     public sealed class Vector2SubstitutionConverter : IConverterVector2
     {
         [Tooltip("How the components are rearranged.")]

--- a/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Unity/Runtime/Converters/Vectors/Vector2ToVector3Converter.cs
+++ b/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Unity/Runtime/Converters/Vectors/Vector2ToVector3Converter.cs
@@ -10,7 +10,7 @@ namespace Aspid.MVVM.StarterKit
     /// Converts <see cref="Vector2"/> values to <see cref="Vector3"/> by specifying which components to use and a constant value for the third component.
     /// </summary>
     [Serializable]
-    [TypeSelectorDisplay(Group = "Aspid/Vector", Name = "Vector2 To Vector3", Tooltip = "Converts  values to  by specifying which components to use and a constant value for the third component")]
+    [TypeSelectorDisplay(Group = "Aspid/Vector", Name = "Vector2 To Vector3", Tooltip = "Converts Vector2 values to Vector3 by specifying which components to use and a constant value for the third component")]
     public sealed class Vector2ToVector3Converter : IConverterVector2ToVector3
     {
         [Tooltip("Which axes of the 3D vector the 2D components are written into.")]

--- a/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Unity/Runtime/Converters/Vectors/Vector3SubstitutionConverter.cs
+++ b/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Unity/Runtime/Converters/Vectors/Vector3SubstitutionConverter.cs
@@ -11,7 +11,7 @@ namespace Aspid.MVVM.StarterKit
     /// Converts <see cref="Vector3"/> values by substituting and rearranging their components.
     /// </summary>
     [Serializable]
-    [TypeSelectorDisplay(Group = "Aspid/Vector", Name = "Vector3 Substitution", Tooltip = "Converts  values by substituting and rearranging their components")]
+    [TypeSelectorDisplay(Group = "Aspid/Vector", Name = "Vector3 Substitution", Tooltip = "Converts Vector3 values by substituting and rearranging their components")]
     public sealed class Vector3SubstitutionConverter : IConverterVector3
     {
         [Tooltip("How the components are rearranged.")]

--- a/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Unity/Runtime/Converters/Vectors/Vector3ToVector2Converter.cs
+++ b/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Unity/Runtime/Converters/Vectors/Vector3ToVector2Converter.cs
@@ -11,7 +11,7 @@ namespace Aspid.MVVM.StarterKit
     /// Converts <see cref="Vector3"/> values to <see cref="Vector2"/> by selecting which components to use.
     /// </summary>
     [Serializable]
-    [TypeSelectorDisplay(Group = "Aspid/Vector", Name = "Vector3 To Vector2", Tooltip = "Converts  values to  by selecting which components to use")]
+    [TypeSelectorDisplay(Group = "Aspid/Vector", Name = "Vector3 To Vector2", Tooltip = "Converts Vector3 values to Vector2 by selecting which components to use")]
     public sealed class Vector3ToVector2Converter : IConverterVector3ToVector2
     {
         [Tooltip("Which components of the 3D vector are kept, and in what order.")]

--- a/Aspid.MVVM/Packages/tech.aspid.mvvm/Tests/Editor/Converters/ConverterInspectorContractTests.cs
+++ b/Aspid.MVVM/Packages/tech.aspid.mvvm/Tests/Editor/Converters/ConverterInspectorContractTests.cs
@@ -62,11 +62,9 @@ namespace Aspid.MVVM.StarterKit.Tests
         /// A picker tooltip must not have a hole where a type name should be.
         /// </summary>
         /// <remarks>
-        /// The tooltips were derived from the XML <c>&lt;summary&gt;</c> of each converter, and the
-        /// derivation dropped every <c>&lt;see cref="…"/&gt;</c> element rather than replacing it with
-        /// the name it referred to. The result read "Wraps a  in a " — grammatical debris in the one
-        /// piece of documentation a designer actually sees. Both symptoms are exact: a doubled space
-        /// where the element was, or a trailing space where it ended the sentence.
+        /// Tooltips are derived from each converter's XML <c>&lt;summary&gt;</c>, and the derivation used
+        /// to drop <c>&lt;see cref="…"/&gt;</c> elements instead of substituting the name they referred
+        /// to. Both symptoms are exact: a doubled space where the element was, or a trailing space.
         /// </remarks>
         [Test]
         public void EveryPickerTooltipIsWhole()

--- a/Aspid.MVVM/Packages/tech.aspid.mvvm/Tests/Editor/Converters/ConverterInspectorContractTests.cs
+++ b/Aspid.MVVM/Packages/tech.aspid.mvvm/Tests/Editor/Converters/ConverterInspectorContractTests.cs
@@ -58,6 +58,36 @@ namespace Aspid.MVVM.StarterKit.Tests
                 + string.Join(Environment.NewLine, ungrouped.Select(type => "  - " + type.Name)));
         }
 
+        /// <summary>
+        /// A picker tooltip must not have a hole where a type name should be.
+        /// </summary>
+        /// <remarks>
+        /// The tooltips were derived from the XML <c>&lt;summary&gt;</c> of each converter, and the
+        /// derivation dropped every <c>&lt;see cref="…"/&gt;</c> element rather than replacing it with
+        /// the name it referred to. The result read "Wraps a  in a " — grammatical debris in the one
+        /// piece of documentation a designer actually sees. Both symptoms are exact: a doubled space
+        /// where the element was, or a trailing space where it ended the sentence.
+        /// </remarks>
+        [Test]
+        public void EveryPickerTooltipIsWhole()
+        {
+            var broken = ConverterTypes()
+                .Select(type => (type, tooltip: type
+                    .GetCustomAttribute<Aspid.FastTools.Types.TypeSelectorDisplayAttribute>(inherit: false)
+                    ?.Tooltip))
+                .Where(pair => !string.IsNullOrEmpty(pair.tooltip))
+                .Where(pair => pair.tooltip!.Contains("  ") || pair.tooltip.Trim() != pair.tooltip)
+                .ToArray();
+
+            Assert.IsEmpty(
+                broken,
+                "These picker tooltips have a gap where a type name belongs:"
+                + Environment.NewLine
+                + string.Join(
+                    Environment.NewLine,
+                    broken.Select(pair => $"  - {pair.type.Name}: \"{pair.tooltip}\"")));
+        }
+
         // Guards the check above from passing because the scan stopped finding fields.
         [Test]
         public void TheScanSeesTheSerializedFields() =>


### PR DESCRIPTION
🐛 28 converter tooltips in the `[SerializeReference]` picker had a hole where a type name belongs.

## Summary

- 🐛 The tooltips are derived from each converter's XML `<summary>`, and the derivation **dropped** every `<see cref="…"/>` instead of substituting the name — the picker showed `Wraps a  in a `, `Formats a `, `Takes the texture a  is drawn from`.
- ✅ A test forbids both exact symptoms (a doubled space, or a trailing space where the element ended the sentence), so the next batch of converters cannot reintroduce it.

## Notes for review

- 📝 The tooltip is the only explanation that reaches the person choosing a converter — XML docs are invisible in the Inspector — so this is the third rule in `ConverterInspectorContractTests`, after `[Tooltip]` and `Group`.
- ⚠️ `DirectionToAngleConverter` trips the heuristic legitimately ("Reads the angle a direction points in") and is left alone; the committed test only checks whitespace, which has no false positives.
- ✅ 1037 EditMode tests, 1035 passed, 0 failed, 2 skipped.

<details>
<summary>🇷🇺 Описание на русском</summary>

🐛 У 28 тултипов конвертеров в пикере `[SerializeReference]` была дыра на месте имени типа.

## Итог

- 🐛 Тултипы выводятся из XML `<summary>` конвертера, и вывод **выбрасывал** каждый `<see cref="…"/>` вместо подстановки имени — пикер показывал `Wraps a  in a `, `Formats a `, `Takes the texture a  is drawn from`.
- ✅ Тест запрещает оба точных симптома (двойной пробел и хвостовой пробел там, где элемент завершал предложение), так что следующая партия конвертеров это не вернёт.

## Заметки для ревью

- 📝 Тултип — единственное объяснение, доходящее до того, кто выбирает конвертер (XML-доки в инспекторе не видны), поэтому это третье правило в `ConverterInspectorContractTests` после `[Tooltip]` и `Group`.
- ⚠️ `DirectionToAngleConverter` срабатывает на эвристику законно («Reads the angle a direction points in») и оставлен как есть; закоммиченный тест проверяет только пробелы, где ложных срабатываний нет.
- ✅ 1037 EditMode-тестов, 1035 прошло, 0 упало, 2 пропущено.

</details>

