### PR TITLE
Drop the pre-2023.1 converter compatibility gate

### DIFF
--- a/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Runtime/Binders/Switchers/SwitcherFloatBinder.cs
+++ b/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Runtime/Binders/Switchers/SwitcherFloatBinder.cs
@@ -1,9 +1,4 @@
-using System.Runtime.CompilerServices;
-#if UNITY_2023_1_OR_NEWER
 using Converter = Aspid.MVVM.StarterKit.IConverter<float, float>;
-#else
-using Converter = Aspid.MVVM.StarterKit.IConverterFloat;
-#endif
 
 // ReSharper disable once CheckNamespace
 namespace Aspid.MVVM.StarterKit
@@ -22,17 +17,8 @@ namespace Aspid.MVVM.StarterKit
             float falseValue,
             IConverter<float, float>? converter, 
             BindMode mode = BindMode.OneWay)
-            : base(target, trueValue, falseValue, GetConverter(converter), mode) { }
+            : base(target, trueValue, falseValue, converter, mode) { }
 
-        [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        private static Converter? GetConverter(IConverter<float, float>? converter)
-        {
-            #if UNITY_2023_1_OR_NEWER
-            return converter;
-            #else
-            return converter?.ToConvertSpecific();
-            #endif
-        }
 
         protected override void SetValue(float value)
         {

--- a/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Runtime/Binders/Switchers/SwitcherIntBinder.cs
+++ b/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Runtime/Binders/Switchers/SwitcherIntBinder.cs
@@ -1,9 +1,4 @@
-using System.Runtime.CompilerServices;
-#if UNITY_2023_1_OR_NEWER
 using Converter = Aspid.MVVM.StarterKit.IConverter<int, int>;
-#else
-using Converter = Aspid.MVVM.StarterKit.IConverterInt;
-#endif
 
 // ReSharper disable once CheckNamespace
 namespace Aspid.MVVM.StarterKit
@@ -22,16 +17,7 @@ namespace Aspid.MVVM.StarterKit
             int falseValue,
             IConverter<int, int>? converter, 
             BindMode mode = BindMode.OneWay)
-            : base(target, trueValue, falseValue, GetConverter(converter), mode) { }
+            : base(target, trueValue, falseValue, converter, mode) { }
 
-        [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        private static Converter? GetConverter(IConverter<int, int>? converter)
-        {
-            #if UNITY_2023_1_OR_NEWER
-            return converter;
-            #else
-            return converter?.ToConvertSpecific();
-            #endif
-        }
     }
 }

--- a/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Runtime/Binders/Switchers/SwitcherStringBinder.cs
+++ b/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Runtime/Binders/Switchers/SwitcherStringBinder.cs
@@ -1,9 +1,4 @@
-using System.Runtime.CompilerServices;
-#if UNITY_2023_1_OR_NEWER
 using Converter = Aspid.MVVM.StarterKit.IConverter<string?, string?>;
-#else
-using Converter = Aspid.MVVM.StarterKit.IConverterString;
-#endif
 
 // ReSharper disable once CheckNamespace
 namespace Aspid.MVVM.StarterKit
@@ -22,16 +17,7 @@ namespace Aspid.MVVM.StarterKit
             string falseValue, 
             IConverter<string?, string?>? converter,
             BindMode mode = BindMode.OneWay) 
-            : base(target, trueValue, falseValue, GetConverter(converter), mode) { }
+            : base(target, trueValue, falseValue, converter, mode) { }
         
-        [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        private static Converter? GetConverter(IConverter<string?, string?>? converter)
-        {
-            #if UNITY_2023_1_OR_NEWER
-            return converter;
-            #else
-            return converter?.ToConvertSpecific();
-            #endif
-        }
     }
 }

--- a/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Runtime/Binders/TargetProperty/TargetFloatBinder.cs
+++ b/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Runtime/Binders/TargetProperty/TargetFloatBinder.cs
@@ -1,10 +1,5 @@
 using System;
-using System.Runtime.CompilerServices;
-#if UNITY_2023_1_OR_NEWER
 using Converter = Aspid.MVVM.StarterKit.IConverter<float, float>;
-#else
-using Converter = Aspid.MVVM.StarterKit.IConverterFloat;
-#endif
 
 // ReSharper disable once CheckNamespace
 namespace Aspid.MVVM.StarterKit
@@ -34,7 +29,7 @@ namespace Aspid.MVVM.StarterKit
         
         /// <inheritdoc/>
          protected TargetFloatBinder(TTarget target, IConverter<float, float>? converter, BindMode mode = BindMode.OneWay)
-             : base(target, GetConverter(converter), mode) { }
+             : base(target, converter, mode) { }
 
         /// <summary>
         /// Sets the target float property from an <see cref="int"/> value.
@@ -81,14 +76,5 @@ namespace Aspid.MVVM.StarterKit
             }
         }
         
-        [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        private static Converter? GetConverter(IConverter<float, float>? converter)
-        {
-            #if UNITY_2023_1_OR_NEWER
-            return converter;
-            #else
-            return converter?.ToConvertSpecific();
-            #endif
-        }
     }
 }

--- a/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Runtime/Binders/TargetProperty/TargetIntBinder.cs
+++ b/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Runtime/Binders/TargetProperty/TargetIntBinder.cs
@@ -1,10 +1,5 @@
 using System;
-using System.Runtime.CompilerServices;
-#if UNITY_2023_1_OR_NEWER
 using Converter = Aspid.MVVM.StarterKit.IConverter<int, int>;
-#else
-using Converter = Aspid.MVVM.StarterKit.IConverterInt;
-#endif
 
 // ReSharper disable once CheckNamespace
 namespace Aspid.MVVM.StarterKit
@@ -34,7 +29,7 @@ namespace Aspid.MVVM.StarterKit
 
         /// <inheritdoc/>
         protected TargetIntBinder(TTarget target, IConverter<int, int>? converter, BindMode mode = BindMode.OneWay)
-            : base(target, GetConverter(converter), mode) { }
+            : base(target, converter, mode) { }
 
         /// <summary>
         /// Sets the target int property from a <see cref="long"/> value, truncating to <see cref="int"/>.
@@ -81,14 +76,5 @@ namespace Aspid.MVVM.StarterKit
             }
         }
         
-        [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        private static Converter? GetConverter(IConverter<int, int>? converter)
-        {
-            #if UNITY_2023_1_OR_NEWER
-            return converter;
-            #else
-            return converter?.ToConvertSpecific();
-            #endif
-        }
     }
 }

--- a/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Runtime/Binders/TargetProperty/TargetStringBinder.cs
+++ b/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Runtime/Binders/TargetProperty/TargetStringBinder.cs
@@ -1,9 +1,4 @@
-using System.Runtime.CompilerServices;
-#if UNITY_2023_1_OR_NEWER
 using Converter = Aspid.MVVM.StarterKit.IConverter<string?, string?>;
-#else
-using Converter = Aspid.MVVM.StarterKit.IConverterString;
-#endif
 
 // ReSharper disable once CheckNamespace
 namespace Aspid.MVVM.StarterKit
@@ -16,16 +11,7 @@ namespace Aspid.MVVM.StarterKit
     {
         /// <inheritdoc/>
         protected TargetStringBinder(TTarget target, IConverter<string?, string?>? converter, BindMode mode) 
-            : base(target, GetConverter(converter), mode) { }
+            : base(target, converter, mode) { }
         
-        [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        private static Converter? GetConverter(IConverter<string?, string?>? converter)
-        {
-            #if UNITY_2023_1_OR_NEWER
-            return converter;
-            #else
-            return converter?.ToConvertSpecific();
-            #endif
-        }
     }
 }

--- a/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Runtime/Binders/Values/OneWayValue.cs
+++ b/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Runtime/Binders/Values/OneWayValue.cs
@@ -28,9 +28,7 @@ namespace Aspid.MVVM.StarterKit
         [UnityEngine.SerializeField]
         private T? _value;
 
-#if UNITY_2023_1_OR_NEWER
         [UnityEngine.SerializeReference]
-#endif
         private IConverter<T?, T?>? _converter;
 
         /// <summary>

--- a/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Runtime/Binders/Values/TwoWayValue.cs
+++ b/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Runtime/Binders/Values/TwoWayValue.cs
@@ -50,9 +50,7 @@ namespace Aspid.MVVM.StarterKit
         [UnityEngine.SerializeField]
         private T? _value;
 
-#if UNITY_2023_1_OR_NEWER
         [UnityEngine.SerializeReference]
-#endif
         private IConverter<T?, T?>? _converter;
 
         private Action<T?>? _valueChanged;

--- a/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Runtime/Commands/CanExecuteView/SequenceCanExecuteView.cs
+++ b/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Runtime/Commands/CanExecuteView/SequenceCanExecuteView.cs
@@ -6,9 +6,7 @@ namespace Aspid.MVVM.StarterKit
     [Serializable]
     public sealed class SequenceCanExecuteView : ICanExecuteView
     {
-        #if UNITY_2023_1_OR_NEWER
         [UnityEngine.SerializeReference] 
-        #endif
         private ICanExecuteView[] _canExecuteViews;
 
         public SequenceCanExecuteView(params ICanExecuteView[] canExecuteViews)

--- a/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Unity/Runtime/Binders/Animators/AnimatorSetFloatBinder.cs
+++ b/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Unity/Runtime/Binders/Animators/AnimatorSetFloatBinder.cs
@@ -1,11 +1,7 @@
 #nullable enable
 using System;
 using UnityEngine;
-#if UNITY_2023_1_OR_NEWER
 using Converter = Aspid.MVVM.StarterKit.IConverter<float, float>;
-#else
-using Converter = Aspid.MVVM.StarterKit.IConverterFloat;
-#endif
 
 // ReSharper disable once CheckNamespace
 namespace Aspid.MVVM.StarterKit

--- a/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Unity/Runtime/Binders/Animators/AnimatorSetIntBinder.cs
+++ b/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Unity/Runtime/Binders/Animators/AnimatorSetIntBinder.cs
@@ -1,11 +1,7 @@
 #nullable enable
 using System;
 using UnityEngine;
-#if UNITY_2023_1_OR_NEWER
 using Converter = Aspid.MVVM.StarterKit.IConverter<int, int>;
-#else
-using Converter = Aspid.MVVM.StarterKit.IConverterInt;
-#endif
 
 // ReSharper disable once CheckNamespace
 namespace Aspid.MVVM.StarterKit

--- a/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Unity/Runtime/Binders/Animators/Mono/AnimatorSetFloatMonoBinder.cs
+++ b/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Unity/Runtime/Binders/Animators/Mono/AnimatorSetFloatMonoBinder.cs
@@ -1,9 +1,5 @@
 using UnityEngine;
-#if UNITY_2023_1_OR_NEWER
 using Converter = Aspid.MVVM.StarterKit.IConverter<float, float>;
-#else
-using Converter = Aspid.MVVM.StarterKit.IConverterFloat;
-#endif
 
 // ReSharper disable once CheckNamespace
 namespace Aspid.MVVM.StarterKit

--- a/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Unity/Runtime/Binders/Animators/Mono/AnimatorSetIntMonoBinder.cs
+++ b/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Unity/Runtime/Binders/Animators/Mono/AnimatorSetIntMonoBinder.cs
@@ -1,9 +1,5 @@
 using UnityEngine;
-#if UNITY_2023_1_OR_NEWER
 using Converter = Aspid.MVVM.StarterKit.IConverter<int, int>;
-#else
-using Converter = Aspid.MVVM.StarterKit.IConverterInt;
-#endif
 
 // ReSharper disable once CheckNamespace
 namespace Aspid.MVVM.StarterKit

--- a/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Unity/Runtime/Binders/AudioSources/MinMaxDistance/AudioSourceMinMaxDistanceBinder.cs
+++ b/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Unity/Runtime/Binders/AudioSources/MinMaxDistance/AudioSourceMinMaxDistanceBinder.cs
@@ -1,11 +1,7 @@
 #nullable enable
 using System;
 using UnityEngine;
-#if UNITY_2023_1_OR_NEWER
 using Converter = Aspid.MVVM.StarterKit.IConverter<UnityEngine.Vector2, UnityEngine.Vector2>;
-#else
-using Converter = Aspid.MVVM.StarterKit.IConverterVector2;
-#endif
 
 // ReSharper disable once CheckNamespace
 namespace Aspid.MVVM.StarterKit

--- a/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Unity/Runtime/Binders/AudioSources/MinMaxDistance/AudioSourceMinMaxDistanceSwitcherBinder.cs
+++ b/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Unity/Runtime/Binders/AudioSources/MinMaxDistance/AudioSourceMinMaxDistanceSwitcherBinder.cs
@@ -1,11 +1,7 @@
 #nullable enable
 using System;
 using UnityEngine;
-#if UNITY_2023_1_OR_NEWER
 using Converter = Aspid.MVVM.StarterKit.IConverter<UnityEngine.Vector2, UnityEngine.Vector2>;
-#else
-using Converter = Aspid.MVVM.StarterKit.IConverterVector2;
-#endif
 
 // ReSharper disable once CheckNamespace
 namespace Aspid.MVVM.StarterKit

--- a/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Unity/Runtime/Binders/AudioSources/MinMaxDistance/Mono/AudioSourceMinMaxDistanceEnumGroupMonoBinder.cs
+++ b/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Unity/Runtime/Binders/AudioSources/MinMaxDistance/Mono/AudioSourceMinMaxDistanceEnumGroupMonoBinder.cs
@@ -1,9 +1,5 @@
 using UnityEngine;
-#if UNITY_2023_1_OR_NEWER
 using Converter = Aspid.MVVM.StarterKit.IConverter<UnityEngine.Vector2, UnityEngine.Vector2>;
-#else
-using Converter = Aspid.MVVM.StarterKit.IConverterVector2;
-#endif
 
 // ReSharper disable once CheckNamespace
 namespace Aspid.MVVM.StarterKit

--- a/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Unity/Runtime/Binders/AudioSources/MinMaxDistance/Mono/AudioSourceMinMaxDistanceEnumMonoBinder.cs
+++ b/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Unity/Runtime/Binders/AudioSources/MinMaxDistance/Mono/AudioSourceMinMaxDistanceEnumMonoBinder.cs
@@ -1,9 +1,5 @@
 using UnityEngine;
-#if UNITY_2023_1_OR_NEWER
 using Converter = Aspid.MVVM.StarterKit.IConverter<UnityEngine.Vector2, UnityEngine.Vector2>;
-#else
-using Converter = Aspid.MVVM.StarterKit.IConverterVector2;
-#endif
 
 // ReSharper disable once CheckNamespace
 namespace Aspid.MVVM.StarterKit

--- a/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Unity/Runtime/Binders/AudioSources/MinMaxDistance/Mono/AudioSourceMinMaxDistanceMonoBinder.cs
+++ b/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Unity/Runtime/Binders/AudioSources/MinMaxDistance/Mono/AudioSourceMinMaxDistanceMonoBinder.cs
@@ -1,9 +1,5 @@
 using UnityEngine;
-#if UNITY_2023_1_OR_NEWER
 using Converter = Aspid.MVVM.StarterKit.IConverter<UnityEngine.Vector2, UnityEngine.Vector2>;
-#else
-using Converter = Aspid.MVVM.StarterKit.IConverterVector2;
-#endif
 
 // ReSharper disable once CheckNamespace
 namespace Aspid.MVVM.StarterKit

--- a/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Unity/Runtime/Binders/AudioSources/MinMaxDistance/Mono/AudioSourceMinMaxDistanceSwitcherMonoBinder.cs
+++ b/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Unity/Runtime/Binders/AudioSources/MinMaxDistance/Mono/AudioSourceMinMaxDistanceSwitcherMonoBinder.cs
@@ -1,9 +1,5 @@
 using UnityEngine;
-#if UNITY_2023_1_OR_NEWER
 using Converter = Aspid.MVVM.StarterKit.IConverter<UnityEngine.Vector2, UnityEngine.Vector2>;
-#else
-using Converter = Aspid.MVVM.StarterKit.IConverterVector2;
-#endif
 
 // ReSharper disable once CheckNamespace
 namespace Aspid.MVVM.StarterKit

--- a/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Unity/Runtime/Binders/Casters/Mono/AnyToStringCasterMonoBinder.cs
+++ b/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Unity/Runtime/Binders/Casters/Mono/AnyToStringCasterMonoBinder.cs
@@ -1,10 +1,6 @@
 using UnityEngine;
 using UnityEngine.Events;
-#if UNITY_2023_1_OR_NEWER
 using Converter = Aspid.MVVM.StarterKit.IConverter<object, string>;
-#else
-using Converter = Aspid.MVVM.StarterKit.IConverterObjectToString;
-#endif
 
 // ReSharper disable once CheckNamespace
 namespace Aspid.MVVM.StarterKit

--- a/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Unity/Runtime/Binders/Casters/Mono/GenericToStringCasterMonoBinder.cs
+++ b/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Unity/Runtime/Binders/Casters/Mono/GenericToStringCasterMonoBinder.cs
@@ -4,7 +4,6 @@ using UnityEngine.Events;
 // ReSharper disable once CheckNamespace
 namespace Aspid.MVVM.StarterKit
 {
-#if UNITY_2023_1_OR_NEWER
     /// <summary>
     /// Abstract base <see cref="MonoBinder"/> implementing <see cref="IBinder{T}"/> that converts a bound value
     /// of type <typeparamref name="T"/> to a <see cref="string"/> using a configurable converter and forwards
@@ -39,42 +38,4 @@ namespace Aspid.MVVM.StarterKit
             _casted.Invoke(_converter.Convert(value));
         }
     }
-#else
-    /// <summary>
-    /// Abstract base <see cref="MonoBinder"/> implementing <see cref="IBinder{T}"/> that converts a bound value
-    /// of type <typeparamref name="T"/> to a <see cref="string"/> using a configurable converter and forwards
-    /// the result to a target <see cref="UnityEvent{T}"/>.
-    /// </summary>
-    /// <typeparam name="T">The type of value received from the ViewModel.</typeparam>
-    public abstract partial class GenericToStringCasterMonoBinder<T> : MonoBinder, IBinder<T>
-    {
-        [Tooltip("Invoked with the converted string value each time a new value arrives from the ViewModel.")]
-        [SerializeField] private UnityEvent<string> _casted;
-        
-        /// <summary>
-        /// Gets the converter used to transform the bound value to a <see cref="string"/>.
-        /// </summary>
-        protected abstract IConverter<T, string> Converter { get; }
-        
-        /// <summary>
-        /// Converts <paramref name="value"/> to a <see cref="string"/> using the configured converter
-        /// and invokes the target <see cref="UnityEvent{T}"/>.
-        /// </summary>
-        /// <param name="value">The value received from the ViewModel.</param>
-        /// <remarks>
-        /// If no converter is assigned, logs a Unity error and returns without invoking the event.
-        /// </remarks>
-        [BinderLog]
-        public void SetValue(T value)
-        {
-            if (Converter is null)
-            {
-                Debug.LogError($"No converter assigned to {nameof(GenericToStringCasterMonoBinder<T>)}", context: this);
-                return;
-            }
-
-	        _casted.Invoke(Converter.Convert(value));
-        }
-    }
-#endif
 }

--- a/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Unity/Runtime/Binders/Casters/Mono/StringToBoolCasterMonoBinder.cs
+++ b/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Unity/Runtime/Binders/Casters/Mono/StringToBoolCasterMonoBinder.cs
@@ -1,10 +1,6 @@
 using UnityEngine;
 using UnityEngine.Events;
-#if UNITY_2023_1_OR_NEWER
 using Converter = Aspid.MVVM.StarterKit.IConverter<string, bool>;
-#else
-using Converter = Aspid.MVVM.StarterKit.IConverterStringToBool;
-#endif
 
 // ReSharper disable once CheckNamespace
 namespace Aspid.MVVM.StarterKit

--- a/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Unity/Runtime/Binders/Casters/Mono/TimeSpanToStringCasterMonoBinder.cs
+++ b/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Unity/Runtime/Binders/Casters/Mono/TimeSpanToStringCasterMonoBinder.cs
@@ -10,23 +10,5 @@ namespace Aspid.MVVM.StarterKit
     [AddBinderContextMenuByType(typeof(string))]
     [AddComponentMenu("Aspid/MVVM/Binders/Casters/TimeSpan To String Caster Binder")]
     [AddBinderContextMenu(typeof(Component), Path = "Add General Binder/Casters/TimeSpan To String Caster Binder")]
-#if UNITY_2023_1_OR_NEWER
     public sealed class TimeSpanToStringCasterMonoBinder : GenericToStringCasterMonoBinder<TimeSpan> { }
-#else
-    public sealed class TimeSpanToStringCasterMonoBinder : GenericToStringCasterMonoBinder<TimeSpan>
-    {
-        [Tooltip("The converter used to transform the bound TimeSpan to a string.")]
-        [SerializeReference] private IConverterTimeSpanToString _converter = new TimeSpanToStringConverter();
-
-        /// <inheritdoc/>
-        protected override IConverter<TimeSpan, string> Converter => _converter;
-
-        /// <summary>
-        /// Called by Unity in the Editor when a serialized field value changes.
-        /// Assigns the default <see cref="TimeSpanToStringConverter"/> if no converter is set.
-        /// </summary>
-        private void OnValidate() =>
-            _converter ??= new TimeSpanToStringConverter();
-    }
-#endif
 }

--- a/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Unity/Runtime/Binders/Casters/Mono/Vector2ToVector3CasterMonoBinder.cs
+++ b/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Unity/Runtime/Binders/Casters/Mono/Vector2ToVector3CasterMonoBinder.cs
@@ -1,10 +1,6 @@
 using UnityEngine;
 using UnityEngine.Events;
-#if UNITY_2023_1_OR_NEWER
 using Converter = Aspid.MVVM.StarterKit.IConverter<UnityEngine.Vector2, UnityEngine.Vector3>;
-#else
-using Converter = Aspid.MVVM.StarterKit.IConverterVector2ToVector3;
-#endif
 
 // ReSharper disable once CheckNamespace
 namespace Aspid.MVVM.StarterKit

--- a/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Unity/Runtime/Binders/Casters/Mono/Vector3ToVector2CasterMonoBinder.cs
+++ b/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Unity/Runtime/Binders/Casters/Mono/Vector3ToVector2CasterMonoBinder.cs
@@ -1,10 +1,6 @@
 using UnityEngine;
 using UnityEngine.Events;
-#if UNITY_2023_1_OR_NEWER
 using Converter = Aspid.MVVM.StarterKit.IConverter<UnityEngine.Vector3, UnityEngine.Vector2>;
-#else
-using Converter = Aspid.MVVM.StarterKit.IConverterVector3ToVector2;
-#endif
 
 // ReSharper disable once CheckNamespace
 namespace Aspid.MVVM.StarterKit

--- a/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Unity/Runtime/Binders/Collections/ObservableDictionaries/ViewModel/ObservableDictionaryViewModelBinder.cs
+++ b/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Unity/Runtime/Binders/Collections/ObservableDictionaries/ViewModel/ObservableDictionaryViewModelBinder.cs
@@ -1,11 +1,7 @@
 using System;
 using UnityEngine;
 using System.Collections.Generic;
-#if UNITY_2023_1_OR_NEWER
 using ViewFactory = Aspid.MVVM.StarterKit.IViewFactory<Aspid.MVVM.MonoView>;
-#else
-using ViewFactory = Aspid.MVVM.StarterKit.IViewFactoryMonoView;
-#endif
 
 // ReSharper disable once CheckNamespace
 namespace Aspid.MVVM.StarterKit

--- a/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Unity/Runtime/Binders/Collections/ObservableLists/ViewModel/Mono/ObservableListViewModelMonoBinder.cs
+++ b/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Unity/Runtime/Binders/Collections/ObservableLists/ViewModel/Mono/ObservableListViewModelMonoBinder.cs
@@ -1,15 +1,9 @@
 using UnityEngine;
 using System.Collections.Generic;
 using Aspid.Collections.Observable.Filtered;
-#if UNITY_2023_1_OR_NEWER
 using Filter = Aspid.MVVM.StarterKit.ICollectionFilter<Aspid.MVVM.IViewModel>;
 using Comparer = Aspid.MVVM.StarterKit.ICollectionComparer<Aspid.MVVM.IViewModel>;
 using ViewFactory = Aspid.MVVM.StarterKit.IViewFactory<Aspid.MVVM.MonoView>;
-#else
-using ViewFactory = Aspid.MVVM.StarterKit.IViewFactoryMonoView;
-using Filter = Aspid.MVVM.StarterKit.IViewModelCollectionFilter;
-using Comparer = Aspid.MVVM.StarterKit.IViewModelCollectionComparer;
-#endif
 
 // ReSharper disable once CheckNamespace
 namespace Aspid.MVVM.StarterKit

--- a/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Unity/Runtime/Binders/Collections/ObservableLists/ViewModel/ObservableListViewModelBinder.cs
+++ b/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Unity/Runtime/Binders/Collections/ObservableLists/ViewModel/ObservableListViewModelBinder.cs
@@ -2,15 +2,9 @@ using System;
 using UnityEngine;
 using System.Collections.Generic;
 using Aspid.Collections.Observable.Filtered;
-#if UNITY_2023_1_OR_NEWER
 using Filter = Aspid.MVVM.StarterKit.ICollectionFilter<Aspid.MVVM.IViewModel>;
 using Comparer = Aspid.MVVM.StarterKit.ICollectionComparer<Aspid.MVVM.IViewModel>;
 using ViewFactory = Aspid.MVVM.StarterKit.IViewFactory<Aspid.MVVM.MonoView>;
-#else
-using ViewFactory = Aspid.MVVM.StarterKit.IViewFactoryMonoView;
-using Filter = Aspid.MVVM.StarterKit.IViewModelCollectionFilter;
-using Comparer = Aspid.MVVM.StarterKit.IViewModelCollectionComparer;
-#endif
 
 // ReSharper disable once CheckNamespace
 namespace Aspid.MVVM.StarterKit

--- a/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Unity/Runtime/Binders/Colliders/Colliders/Material/ColliderMaterialBinder.cs
+++ b/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Unity/Runtime/Binders/Colliders/Colliders/Material/ColliderMaterialBinder.cs
@@ -1,13 +1,8 @@
 #nullable enable
 using System;
 using UnityEngine;
-#if UNITY_6000_0_OR_NEWER
 using PhysicsMaterial = UnityEngine.PhysicsMaterial;
 using Converter = Aspid.MVVM.StarterKit.IConverter<UnityEngine.PhysicsMaterial?, UnityEngine.PhysicsMaterial?>;
-#else
-using PhysicsMaterial = UnityEngine.PhysicMaterial;
-using Converter = Aspid.MVVM.StarterKit.IConverterPhysicsMaterial;
-#endif
 
 // ReSharper disable once CheckNamespace
 namespace Aspid.MVVM.StarterKit

--- a/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Unity/Runtime/Binders/Colliders/Colliders/Material/ColliderMaterialSwitcherBinder.cs
+++ b/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Unity/Runtime/Binders/Colliders/Colliders/Material/ColliderMaterialSwitcherBinder.cs
@@ -1,13 +1,8 @@
 #nullable enable
 using System;
 using UnityEngine;
-#if UNITY_6000_0_OR_NEWER
 using PhysicsMaterial = UnityEngine.PhysicsMaterial;
 using Converter = Aspid.MVVM.StarterKit.IConverter<UnityEngine.PhysicsMaterial?, UnityEngine.PhysicsMaterial?>;
-#else
-using PhysicsMaterial = UnityEngine.PhysicMaterial;
-using Converter = Aspid.MVVM.StarterKit.IConverterPhysicsMaterial;
-#endif
 
 // ReSharper disable once CheckNamespace
 namespace Aspid.MVVM.StarterKit

--- a/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Unity/Runtime/Binders/Colliders/Colliders/Material/Mono/ColliderMaterialEnumGroupMonoBinder.cs
+++ b/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Unity/Runtime/Binders/Colliders/Colliders/Material/Mono/ColliderMaterialEnumGroupMonoBinder.cs
@@ -1,11 +1,6 @@
 using UnityEngine;
-#if UNITY_6000_0_OR_NEWER
 using PhysicsMaterial = UnityEngine.PhysicsMaterial;
 using Converter = Aspid.MVVM.StarterKit.IConverter<UnityEngine.PhysicsMaterial, UnityEngine.PhysicsMaterial>;
-#else
-using PhysicsMaterial = UnityEngine.PhysicMaterial;
-using Converter = Aspid.MVVM.StarterKit.IConverterPhysicsMaterial;
-#endif
 
 // ReSharper disable once CheckNamespace
 namespace Aspid.MVVM.StarterKit

--- a/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Unity/Runtime/Binders/Colliders/Colliders/Material/Mono/ColliderMaterialEnumMonoBinder.cs
+++ b/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Unity/Runtime/Binders/Colliders/Colliders/Material/Mono/ColliderMaterialEnumMonoBinder.cs
@@ -1,11 +1,6 @@
 using UnityEngine;
-#if UNITY_6000_0_OR_NEWER
 using PhysicsMaterial = UnityEngine.PhysicsMaterial;
 using Converter = Aspid.MVVM.StarterKit.IConverter<UnityEngine.PhysicsMaterial, UnityEngine.PhysicsMaterial>;
-#else
-using PhysicsMaterial = UnityEngine.PhysicMaterial;
-using Converter = Aspid.MVVM.StarterKit.IConverterPhysicsMaterial;
-#endif
 
 // ReSharper disable once CheckNamespace
 namespace Aspid.MVVM.StarterKit

--- a/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Unity/Runtime/Binders/Colliders/Colliders/Material/Mono/ColliderMaterialMonoBinder.cs
+++ b/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Unity/Runtime/Binders/Colliders/Colliders/Material/Mono/ColliderMaterialMonoBinder.cs
@@ -1,11 +1,6 @@
 using UnityEngine;
-#if UNITY_6000_0_OR_NEWER
 using PhysicsMaterial = UnityEngine.PhysicsMaterial;
 using Converter = Aspid.MVVM.StarterKit.IConverter<UnityEngine.PhysicsMaterial, UnityEngine.PhysicsMaterial>;
-#else
-using PhysicsMaterial = UnityEngine.PhysicMaterial;
-using Converter = Aspid.MVVM.StarterKit.IConverterPhysicsMaterial;
-#endif
 
 // ReSharper disable once CheckNamespace
 namespace Aspid.MVVM.StarterKit

--- a/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Unity/Runtime/Binders/Colliders/Colliders/Material/Mono/ColliderMaterialSwitcherMonoBinder.cs
+++ b/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Unity/Runtime/Binders/Colliders/Colliders/Material/Mono/ColliderMaterialSwitcherMonoBinder.cs
@@ -1,11 +1,6 @@
 using UnityEngine;
-#if UNITY_6000_0_OR_NEWER
 using PhysicsMaterial = UnityEngine.PhysicsMaterial;
 using Converter = Aspid.MVVM.StarterKit.IConverter<UnityEngine.PhysicsMaterial, UnityEngine.PhysicsMaterial>;
-#else
-using PhysicsMaterial = UnityEngine.PhysicMaterial;
-using Converter = Aspid.MVVM.StarterKit.IConverterPhysicsMaterial;
-#endif
 
 // ReSharper disable once CheckNamespace
 namespace Aspid.MVVM.StarterKit

--- a/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Unity/Runtime/Binders/Colliders/MeshColliders/Mesh/MeshColliderMeshBinder.cs
+++ b/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Unity/Runtime/Binders/Colliders/MeshColliders/Mesh/MeshColliderMeshBinder.cs
@@ -1,11 +1,7 @@
 #nullable enable
 using System;
 using UnityEngine;
-#if UNITY_2023_1_OR_NEWER
 using Converter = Aspid.MVVM.StarterKit.IConverter<UnityEngine.Mesh?, UnityEngine.Mesh?>;
-#else
-using Converter = Aspid.MVVM.StarterKit.IConverterMesh;
-#endif
 
 // ReSharper disable once CheckNamespace
 namespace Aspid.MVVM.StarterKit

--- a/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Unity/Runtime/Binders/Colliders/MeshColliders/Mesh/MeshColliderMeshSwitcherBinder.cs
+++ b/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Unity/Runtime/Binders/Colliders/MeshColliders/Mesh/MeshColliderMeshSwitcherBinder.cs
@@ -1,11 +1,7 @@
 #nullable enable
 using System;
 using UnityEngine;
-#if UNITY_2023_1_OR_NEWER
 using Converter = Aspid.MVVM.StarterKit.IConverter<UnityEngine.Mesh?, UnityEngine.Mesh?>;
-#else
-using Converter = Aspid.MVVM.StarterKit.IConverterMesh;
-#endif
 
 // ReSharper disable once CheckNamespace
 namespace Aspid.MVVM.StarterKit

--- a/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Unity/Runtime/Binders/Colliders/MeshColliders/Mesh/Mono/MeshColliderMeshEnumGroupMonoBinder.cs
+++ b/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Unity/Runtime/Binders/Colliders/MeshColliders/Mesh/Mono/MeshColliderMeshEnumGroupMonoBinder.cs
@@ -1,9 +1,5 @@
 using UnityEngine;
-#if UNITY_2023_1_OR_NEWER
 using Converter = Aspid.MVVM.StarterKit.IConverter<UnityEngine.Mesh, UnityEngine.Mesh>;
-#else
-using Converter = Aspid.MVVM.StarterKit.IConverterMesh;
-#endif
 
 // ReSharper disable once CheckNamespace
 namespace Aspid.MVVM.StarterKit

--- a/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Unity/Runtime/Binders/Colliders/MeshColliders/Mesh/Mono/MeshColliderMeshEnumMonoBinder.cs
+++ b/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Unity/Runtime/Binders/Colliders/MeshColliders/Mesh/Mono/MeshColliderMeshEnumMonoBinder.cs
@@ -1,9 +1,5 @@
 using UnityEngine;
-#if UNITY_2023_1_OR_NEWER
 using Converter = Aspid.MVVM.StarterKit.IConverter<UnityEngine.Mesh, UnityEngine.Mesh>;
-#else
-using Converter = Aspid.MVVM.StarterKit.IConverterMesh;
-#endif
 
 // ReSharper disable once CheckNamespace
 namespace Aspid.MVVM.StarterKit

--- a/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Unity/Runtime/Binders/Colliders/MeshColliders/Mesh/Mono/MeshColliderMeshMonoBinder.cs
+++ b/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Unity/Runtime/Binders/Colliders/MeshColliders/Mesh/Mono/MeshColliderMeshMonoBinder.cs
@@ -1,9 +1,5 @@
 using UnityEngine;
-#if UNITY_2023_1_OR_NEWER
 using Converter = Aspid.MVVM.StarterKit.IConverter<UnityEngine.Mesh, UnityEngine.Mesh>;
-#else
-using Converter = Aspid.MVVM.StarterKit.IConverterMesh;
-#endif
 
 // ReSharper disable once CheckNamespace
 namespace Aspid.MVVM.StarterKit

--- a/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Unity/Runtime/Binders/Colliders/MeshColliders/Mesh/Mono/MeshColliderMeshSwitcherMonoBinder.cs
+++ b/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Unity/Runtime/Binders/Colliders/MeshColliders/Mesh/Mono/MeshColliderMeshSwitcherMonoBinder.cs
@@ -1,9 +1,5 @@
 using UnityEngine;
-#if UNITY_2023_1_OR_NEWER
 using Converter = Aspid.MVVM.StarterKit.IConverter<UnityEngine.Mesh, UnityEngine.Mesh>;
-#else
-using Converter = Aspid.MVVM.StarterKit.IConverterMesh;
-#endif
 
 // ReSharper disable once CheckNamespace
 namespace Aspid.MVVM.StarterKit

--- a/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Unity/Runtime/Binders/Debugs/Log/DebugLogBinder.cs
+++ b/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Unity/Runtime/Binders/Debugs/Log/DebugLogBinder.cs
@@ -1,10 +1,6 @@
 using System;
 using UnityEngine;
-#if UNITY_2023_1_OR_NEWER
 using Converter = Aspid.MVVM.StarterKit.IConverter<object, string>;
-#else
-using Converter = Aspid.MVVM.StarterKit.IConverterObjectToString;
-#endif
 
 // ReSharper disable once CheckNamespace
 namespace Aspid.MVVM.StarterKit

--- a/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Unity/Runtime/Binders/Debugs/Log/Mono/DebugLogMonoBinder.cs
+++ b/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Unity/Runtime/Binders/Debugs/Log/Mono/DebugLogMonoBinder.cs
@@ -1,10 +1,6 @@
 using System;
 using UnityEngine;
-#if UNITY_2023_1_OR_NEWER
 using Converter = Aspid.MVVM.StarterKit.IConverter<object, string>;
-#else
-using Converter = Aspid.MVVM.StarterKit.IConverterObjectToString;
-#endif
 
 // ReSharper disable once CheckNamespace
 namespace Aspid.MVVM.StarterKit

--- a/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Unity/Runtime/Binders/Dropdowns/Options/Mono/DropdownOptionsByEnumMonoBinder.cs
+++ b/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Unity/Runtime/Binders/Dropdowns/Options/Mono/DropdownOptionsByEnumMonoBinder.cs
@@ -2,11 +2,7 @@
 using TMPro;
 using System;
 using UnityEngine;
-#if UNITY_2023_1_OR_NEWER
 using Converter = Aspid.MVVM.StarterKit.IConverter<System.Enum, System.Collections.Generic.IEnumerable<TMPro.TMP_Dropdown.OptionData>>;
-#else
-using Converter = Aspid.MVVM.StarterKit.IConverterEnumToDropdownOptionData;
-#endif
 
 // ReSharper disable once CheckNamespace
 namespace Aspid.MVVM.StarterKit

--- a/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Unity/Runtime/Binders/GameObjects/Tag/GameObjectTagBinder.cs
+++ b/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Unity/Runtime/Binders/GameObjects/Tag/GameObjectTagBinder.cs
@@ -1,11 +1,7 @@
 #nullable enable
 using System;
 using UnityEngine;
-#if UNITY_2023_1_OR_NEWER
 using Converter = Aspid.MVVM.StarterKit.IConverter<string?, string?>;
-#else
-using Converter = Aspid.MVVM.StarterKit.IConverterString;
-#endif
 
 // ReSharper disable once CheckNamespace
 namespace Aspid.MVVM.StarterKit

--- a/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Unity/Runtime/Binders/GameObjects/Tag/Mono/GameObjectTagMonoBinder.cs
+++ b/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Unity/Runtime/Binders/GameObjects/Tag/Mono/GameObjectTagMonoBinder.cs
@@ -1,10 +1,6 @@
 using System;
 using UnityEngine;
-#if UNITY_2023_1_OR_NEWER
 using Converter = Aspid.MVVM.StarterKit.IConverter<string, string>;
-#else
-using Converter = Aspid.MVVM.StarterKit.IConverterString;
-#endif
 
 // ReSharper disable once CheckNamespace
 namespace Aspid.MVVM.StarterKit

--- a/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Unity/Runtime/Binders/Graphics/Material/GraphicMaterialBinder.cs
+++ b/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Unity/Runtime/Binders/Graphics/Material/GraphicMaterialBinder.cs
@@ -2,11 +2,7 @@
 using System;
 using UnityEngine;
 using UnityEngine.UI;
-#if UNITY_2023_1_OR_NEWER
 using Converter = Aspid.MVVM.StarterKit.IConverter<UnityEngine.Material?, UnityEngine.Material?>;
-#else
-using Converter = Aspid.MVVM.StarterKit.IConverterMaterial;
-#endif
 
 // ReSharper disable once CheckNamespace
 namespace Aspid.MVVM.StarterKit

--- a/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Unity/Runtime/Binders/Graphics/Material/GraphicMaterialSwitcherBinder.cs
+++ b/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Unity/Runtime/Binders/Graphics/Material/GraphicMaterialSwitcherBinder.cs
@@ -2,11 +2,7 @@
 using System;
 using UnityEngine;
 using UnityEngine.UI;
-#if UNITY_2023_1_OR_NEWER
 using Converter = Aspid.MVVM.StarterKit.IConverter<UnityEngine.Material?, UnityEngine.Material?>;
-#else
-using Converter = Aspid.MVVM.StarterKit.IConverterMaterial;
-#endif
 
 // ReSharper disable once CheckNamespace
 namespace Aspid.MVVM.StarterKit

--- a/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Unity/Runtime/Binders/Graphics/Material/Mono/GraphicMaterialEnumGroupMonoBinder.cs
+++ b/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Unity/Runtime/Binders/Graphics/Material/Mono/GraphicMaterialEnumGroupMonoBinder.cs
@@ -1,10 +1,6 @@
 using UnityEngine;
 using UnityEngine.UI;
-#if UNITY_2023_1_OR_NEWER
 using Converter = Aspid.MVVM.StarterKit.IConverter<UnityEngine.Material, UnityEngine.Material>;
-#else
-using Converter = Aspid.MVVM.StarterKit.IConverterMaterial;
-#endif
 
 // ReSharper disable once CheckNamespace
 namespace Aspid.MVVM.StarterKit

--- a/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Unity/Runtime/Binders/Graphics/Material/Mono/GraphicMaterialEnumMonoBinder.cs
+++ b/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Unity/Runtime/Binders/Graphics/Material/Mono/GraphicMaterialEnumMonoBinder.cs
@@ -1,10 +1,6 @@
 using UnityEngine;
 using UnityEngine.UI;
-#if UNITY_2023_1_OR_NEWER
 using Converter = Aspid.MVVM.StarterKit.IConverter<UnityEngine.Material, UnityEngine.Material>;
-#else
-using Converter = Aspid.MVVM.StarterKit.IConverterMaterial;
-#endif
 
 // ReSharper disable once CheckNamespace
 namespace Aspid.MVVM.StarterKit

--- a/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Unity/Runtime/Binders/Graphics/Material/Mono/GraphicMaterialMonoBinder.cs
+++ b/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Unity/Runtime/Binders/Graphics/Material/Mono/GraphicMaterialMonoBinder.cs
@@ -1,10 +1,6 @@
 using UnityEngine;
 using UnityEngine.UI;
-#if UNITY_2023_1_OR_NEWER
 using Converter = Aspid.MVVM.StarterKit.IConverter<UnityEngine.Material, UnityEngine.Material>;
-#else
-using Converter = Aspid.MVVM.StarterKit.IConverterMaterial;
-#endif
 
 // ReSharper disable once CheckNamespace
 namespace Aspid.MVVM.StarterKit

--- a/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Unity/Runtime/Binders/Graphics/Material/Mono/GraphicMaterialSwitcherMonoBinder.cs
+++ b/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Unity/Runtime/Binders/Graphics/Material/Mono/GraphicMaterialSwitcherMonoBinder.cs
@@ -1,10 +1,6 @@
 using UnityEngine;
 using UnityEngine.UI;
-#if UNITY_2023_1_OR_NEWER
 using Converter = Aspid.MVVM.StarterKit.IConverter<UnityEngine.Material, UnityEngine.Material>;
-#else
-using Converter = Aspid.MVVM.StarterKit.IConverterMaterial;
-#endif
 
 // ReSharper disable once CheckNamespace
 namespace Aspid.MVVM.StarterKit

--- a/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Unity/Runtime/Binders/InputFields/Text/InputFieldBinder.cs
+++ b/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Unity/Runtime/Binders/InputFields/Text/InputFieldBinder.cs
@@ -4,11 +4,7 @@ using TMPro;
 using System;
 using UnityEngine;
 using System.Globalization;
-#if UNITY_2023_1_OR_NEWER
 using Converter = Aspid.MVVM.StarterKit.IConverter<string?, string?>;
-#else
-using Converter = Aspid.MVVM.StarterKit.IConverterString;
-#endif
 
 // ReSharper disable once CheckNamespace
 namespace Aspid.MVVM.StarterKit

--- a/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Unity/Runtime/Binders/InputFields/Text/Mono/InputFieldMonoBinder.cs
+++ b/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Unity/Runtime/Binders/InputFields/Text/Mono/InputFieldMonoBinder.cs
@@ -3,11 +3,7 @@ using TMPro;
 using System;
 using UnityEngine;
 using System.Globalization;
-#if UNITY_2023_1_OR_NEWER
 using Converter = Aspid.MVVM.StarterKit.IConverter<string, string>;
-#else
-using Converter = Aspid.MVVM.StarterKit.IConverterString;
-#endif
 
 // ReSharper disable once CheckNamespace
 // ReSharper disable ConditionIsAlwaysTrueOrFalse

--- a/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Unity/Runtime/Binders/Layouts/LayoutGroup/Padding/LayoutGroupPaddingBinder.cs
+++ b/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Unity/Runtime/Binders/Layouts/LayoutGroup/Padding/LayoutGroupPaddingBinder.cs
@@ -2,11 +2,7 @@
 using System;
 using UnityEngine;
 using UnityEngine.UI;
-#if UNITY_2023_1_OR_NEWER
 using Converter = Aspid.MVVM.StarterKit.IConverter<UnityEngine.RectOffset?, UnityEngine.RectOffset?>;
-#else
-using Converter = Aspid.MVVM.StarterKit.IConverterRectOffset;
-#endif
 
 // ReSharper disable once CheckNamespace
 namespace Aspid.MVVM.StarterKit

--- a/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Unity/Runtime/Binders/Layouts/LayoutGroup/Padding/LayoutGroupPaddingSwitcherBinder.cs
+++ b/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Unity/Runtime/Binders/Layouts/LayoutGroup/Padding/LayoutGroupPaddingSwitcherBinder.cs
@@ -2,11 +2,7 @@
 using System;
 using UnityEngine;
 using UnityEngine.UI;
-#if UNITY_2023_1_OR_NEWER
 using Converter = Aspid.MVVM.StarterKit.IConverter<UnityEngine.RectOffset?, UnityEngine.RectOffset?>;
-#else
-using Converter = Aspid.MVVM.StarterKit.IConverterRectOffset;
-#endif
 
 // ReSharper disable once CheckNamespace
 namespace Aspid.MVVM.StarterKit

--- a/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Unity/Runtime/Binders/Layouts/LayoutGroup/Padding/Mono/LayoutGroupPaddingEnumGroupMonoBinder.cs
+++ b/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Unity/Runtime/Binders/Layouts/LayoutGroup/Padding/Mono/LayoutGroupPaddingEnumGroupMonoBinder.cs
@@ -1,10 +1,6 @@
 using UnityEngine;
 using UnityEngine.UI;
-#if UNITY_2023_1_OR_NEWER
 using Converter = Aspid.MVVM.StarterKit.IConverter<UnityEngine.RectOffset, UnityEngine.RectOffset>;
-#else
-using Converter = Aspid.MVVM.StarterKit.IConverterRectOffset;
-#endif
 
 // ReSharper disable once CheckNamespace
 namespace Aspid.MVVM.StarterKit

--- a/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Unity/Runtime/Binders/Layouts/LayoutGroup/Padding/Mono/LayoutGroupPaddingEnumMonoBinder.cs
+++ b/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Unity/Runtime/Binders/Layouts/LayoutGroup/Padding/Mono/LayoutGroupPaddingEnumMonoBinder.cs
@@ -1,10 +1,6 @@
 using UnityEngine;
 using UnityEngine.UI;
-#if UNITY_2023_1_OR_NEWER
 using Converter = Aspid.MVVM.StarterKit.IConverter<UnityEngine.RectOffset, UnityEngine.RectOffset>;
-#else
-using Converter = Aspid.MVVM.StarterKit.IConverterRectOffset;
-#endif
 
 // ReSharper disable once CheckNamespace
 namespace Aspid.MVVM.StarterKit

--- a/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Unity/Runtime/Binders/Layouts/LayoutGroup/Padding/Mono/LayoutGroupPaddingMonoBinder.cs
+++ b/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Unity/Runtime/Binders/Layouts/LayoutGroup/Padding/Mono/LayoutGroupPaddingMonoBinder.cs
@@ -1,10 +1,6 @@
 using UnityEngine;
 using UnityEngine.UI;
-#if UNITY_2023_1_OR_NEWER
 using Converter = Aspid.MVVM.StarterKit.IConverter<UnityEngine.RectOffset, UnityEngine.RectOffset>;
-#else
-using Converter = Aspid.MVVM.StarterKit.IConverterRectOffset;
-#endif
 
 // ReSharper disable once CheckNamespace
 namespace Aspid.MVVM.StarterKit

--- a/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Unity/Runtime/Binders/Layouts/LayoutGroup/Padding/Mono/LayoutGroupPaddingSwitcherMonoBinder.cs
+++ b/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Unity/Runtime/Binders/Layouts/LayoutGroup/Padding/Mono/LayoutGroupPaddingSwitcherMonoBinder.cs
@@ -1,10 +1,6 @@
 using UnityEngine;
 using UnityEngine.UI;
-#if UNITY_2023_1_OR_NEWER
 using Converter = Aspid.MVVM.StarterKit.IConverter<UnityEngine.RectOffset, UnityEngine.RectOffset>;
-#else
-using Converter = Aspid.MVVM.StarterKit.IConverterRectOffset;
-#endif
 
 // ReSharper disable once CheckNamespace
 namespace Aspid.MVVM.StarterKit

--- a/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Unity/Runtime/Binders/Mono/ComponentProperty/ComponentColorMonoBinder.cs
+++ b/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Unity/Runtime/Binders/Mono/ComponentProperty/ComponentColorMonoBinder.cs
@@ -1,9 +1,5 @@
 using UnityEngine;
-#if UNITY_2023_1_OR_NEWER
 using Converter = Aspid.MVVM.StarterKit.IConverter<UnityEngine.Color, UnityEngine.Color>;
-#else
-using Converter = Aspid.MVVM.StarterKit.IConverterColor;
-#endif
 
 // ReSharper disable once CheckNamespace
 namespace Aspid.MVVM.StarterKit

--- a/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Unity/Runtime/Binders/Mono/ComponentProperty/ComponentFloatMonoBinder.cs
+++ b/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Unity/Runtime/Binders/Mono/ComponentProperty/ComponentFloatMonoBinder.cs
@@ -1,10 +1,6 @@
 using System;
 using UnityEngine;
-#if UNITY_2023_1_OR_NEWER
 using Converter = Aspid.MVVM.StarterKit.IConverter<float, float>;
-#else
-using Converter = Aspid.MVVM.StarterKit.IConverterFloat;
-#endif
 
 // ReSharper disable once CheckNamespace
 namespace Aspid.MVVM.StarterKit

--- a/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Unity/Runtime/Binders/Mono/ComponentProperty/ComponentIntMonoBinder.cs
+++ b/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Unity/Runtime/Binders/Mono/ComponentProperty/ComponentIntMonoBinder.cs
@@ -1,10 +1,6 @@
 using System;
 using UnityEngine;
-#if UNITY_2023_1_OR_NEWER
 using Converter = Aspid.MVVM.StarterKit.IConverter<int, int>;
-#else
-using Converter = Aspid.MVVM.StarterKit.IConverterInt;
-#endif
 
 // ReSharper disable once CheckNamespace
 namespace Aspid.MVVM.StarterKit

--- a/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Unity/Runtime/Binders/Mono/ComponentProperty/ComponentStringMonoBinder.cs
+++ b/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Unity/Runtime/Binders/Mono/ComponentProperty/ComponentStringMonoBinder.cs
@@ -1,9 +1,5 @@
 using UnityEngine;
-#if UNITY_2023_1_OR_NEWER
 using Converter = Aspid.MVVM.StarterKit.IConverter<string, string>;
-#else
-using Converter = Aspid.MVVM.StarterKit.IConverterString;
-#endif
 
 // ReSharper disable once CheckNamespace
 namespace Aspid.MVVM.StarterKit

--- a/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Unity/Runtime/Binders/Mono/ComponentProperty/ComponentVector3MonoBinder.cs
+++ b/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Unity/Runtime/Binders/Mono/ComponentProperty/ComponentVector3MonoBinder.cs
@@ -1,9 +1,5 @@
 using UnityEngine;
-#if UNITY_2023_1_OR_NEWER
 using Converter = Aspid.MVVM.StarterKit.IConverter<UnityEngine.Vector3, UnityEngine.Vector3>;
-#else
-using Converter = Aspid.MVVM.StarterKit.IConverterVector3;
-#endif
 
 // ReSharper disable once CheckNamespace
 namespace Aspid.MVVM.StarterKit

--- a/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Unity/Runtime/Binders/Mono/EnumGroups/EnumGroupColorMonoBinder.cs
+++ b/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Unity/Runtime/Binders/Mono/EnumGroups/EnumGroupColorMonoBinder.cs
@@ -1,9 +1,5 @@
 using UnityEngine;
-#if UNITY_2023_1_OR_NEWER
 using Converter = Aspid.MVVM.StarterKit.IConverter<UnityEngine.Color, UnityEngine.Color>;
-#else
-using Converter = Aspid.MVVM.StarterKit.IConverterColor;
-#endif
 
 // ReSharper disable once CheckNamespace
 namespace Aspid.MVVM.StarterKit

--- a/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Unity/Runtime/Binders/Mono/EnumGroups/EnumGroupFloatMonoBinder.cs
+++ b/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Unity/Runtime/Binders/Mono/EnumGroups/EnumGroupFloatMonoBinder.cs
@@ -1,8 +1,4 @@
-#if UNITY_2023_1_OR_NEWER
 using Converter = Aspid.MVVM.StarterKit.IConverter<float, float>;
-#else
-using Converter = Aspid.MVVM.StarterKit.IConverterFloat;
-#endif
 
 // ReSharper disable once CheckNamespace
 namespace Aspid.MVVM.StarterKit

--- a/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Unity/Runtime/Binders/Mono/EnumGroups/EnumGroupIntMonoBinder.cs
+++ b/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Unity/Runtime/Binders/Mono/EnumGroups/EnumGroupIntMonoBinder.cs
@@ -1,8 +1,4 @@
-#if UNITY_2023_1_OR_NEWER
 using Converter = Aspid.MVVM.StarterKit.IConverter<int, int>;
-#else
-using Converter = Aspid.MVVM.StarterKit.IConverterInt;
-#endif
 
 // ReSharper disable once CheckNamespace
 namespace Aspid.MVVM.StarterKit

--- a/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Unity/Runtime/Binders/Mono/EnumGroups/EnumGroupStringMonoBinder.cs
+++ b/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Unity/Runtime/Binders/Mono/EnumGroups/EnumGroupStringMonoBinder.cs
@@ -1,8 +1,4 @@
-#if UNITY_2023_1_OR_NEWER
 using Converter = Aspid.MVVM.StarterKit.IConverter<string, string>;
-#else
-using Converter = Aspid.MVVM.StarterKit.IConverterString;
-#endif
 
 // ReSharper disable once CheckNamespace
 namespace Aspid.MVVM.StarterKit

--- a/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Unity/Runtime/Binders/Mono/EnumGroups/EnumGroupVector3MonoBinder.cs
+++ b/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Unity/Runtime/Binders/Mono/EnumGroups/EnumGroupVector3MonoBinder.cs
@@ -1,9 +1,5 @@
 using UnityEngine;
-#if UNITY_2023_1_OR_NEWER
 using Converter = Aspid.MVVM.StarterKit.IConverter<UnityEngine.Vector3, UnityEngine.Vector3>;
-#else
-using Converter = Aspid.MVVM.StarterKit.IConverterVector3;
-#endif
 
 // ReSharper disable once CheckNamespace
 namespace Aspid.MVVM.StarterKit

--- a/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Unity/Runtime/Binders/Mono/Enums/EnumColorMonoBinder.cs
+++ b/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Unity/Runtime/Binders/Mono/Enums/EnumColorMonoBinder.cs
@@ -1,9 +1,5 @@
 using UnityEngine;
-#if UNITY_2023_1_OR_NEWER
 using Converter = Aspid.MVVM.StarterKit.IConverter<UnityEngine.Color, UnityEngine.Color>;
-#else
-using Converter = Aspid.MVVM.StarterKit.IConverterColor;
-#endif
 
 // ReSharper disable once CheckNamespace
 namespace Aspid.MVVM.StarterKit

--- a/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Unity/Runtime/Binders/Mono/Enums/EnumFloatMonoBinder.cs
+++ b/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Unity/Runtime/Binders/Mono/Enums/EnumFloatMonoBinder.cs
@@ -1,9 +1,5 @@
 using UnityEngine;
-#if UNITY_2023_1_OR_NEWER
 using Converter = Aspid.MVVM.StarterKit.IConverter<float, float>;
-#else
-using Converter = Aspid.MVVM.StarterKit.IConverterFloat;
-#endif
 
 // ReSharper disable once CheckNamespace
 namespace Aspid.MVVM.StarterKit

--- a/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Unity/Runtime/Binders/Mono/Enums/EnumIntMonoBinder.cs
+++ b/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Unity/Runtime/Binders/Mono/Enums/EnumIntMonoBinder.cs
@@ -1,9 +1,5 @@
 using UnityEngine;
-#if UNITY_2023_1_OR_NEWER
 using Converter = Aspid.MVVM.StarterKit.IConverter<int, int>;
-#else
-using Converter = Aspid.MVVM.StarterKit.IConverterInt;
-#endif
 
 // ReSharper disable once CheckNamespace
 namespace Aspid.MVVM.StarterKit

--- a/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Unity/Runtime/Binders/Mono/Enums/EnumStringMonoBinder.cs
+++ b/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Unity/Runtime/Binders/Mono/Enums/EnumStringMonoBinder.cs
@@ -1,9 +1,5 @@
 using UnityEngine;
-#if UNITY_2023_1_OR_NEWER
 using Converter = Aspid.MVVM.StarterKit.IConverter<string, string>;
-#else
-using Converter = Aspid.MVVM.StarterKit.IConverterString;
-#endif
 
 // ReSharper disable once CheckNamespace
 namespace Aspid.MVVM.StarterKit

--- a/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Unity/Runtime/Binders/Mono/Enums/EnumVector3MonoBinder.cs
+++ b/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Unity/Runtime/Binders/Mono/Enums/EnumVector3MonoBinder.cs
@@ -1,9 +1,5 @@
 using UnityEngine;
-#if UNITY_2023_1_OR_NEWER
 using Converter = Aspid.MVVM.StarterKit.IConverter<UnityEngine.Vector3, UnityEngine.Vector3>;
-#else
-using Converter = Aspid.MVVM.StarterKit.IConverterVector3;
-#endif
 
 // ReSharper disable once CheckNamespace
 namespace Aspid.MVVM.StarterKit

--- a/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Unity/Runtime/Binders/Mono/Switchers/SwitcherColorMonoBinder.cs
+++ b/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Unity/Runtime/Binders/Mono/Switchers/SwitcherColorMonoBinder.cs
@@ -1,9 +1,5 @@
 using UnityEngine;
-#if UNITY_2023_1_OR_NEWER
 using Converter = Aspid.MVVM.StarterKit.IConverter<UnityEngine.Color, UnityEngine.Color>;
-#else
-using Converter = Aspid.MVVM.StarterKit.IConverterColor;
-#endif
 
 // ReSharper disable once CheckNamespace
 namespace Aspid.MVVM.StarterKit

--- a/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Unity/Runtime/Binders/Mono/Switchers/SwitcherFloatMonoBinder.cs
+++ b/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Unity/Runtime/Binders/Mono/Switchers/SwitcherFloatMonoBinder.cs
@@ -1,9 +1,5 @@
 using UnityEngine;
-#if UNITY_2023_1_OR_NEWER
 using Converter = Aspid.MVVM.StarterKit.IConverter<float, float>;
-#else
-using Converter = Aspid.MVVM.StarterKit.IConverterFloat;
-#endif
 
 // ReSharper disable once CheckNamespace
 namespace Aspid.MVVM.StarterKit

--- a/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Unity/Runtime/Binders/Mono/Switchers/SwitcherIntMonoBinder.cs
+++ b/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Unity/Runtime/Binders/Mono/Switchers/SwitcherIntMonoBinder.cs
@@ -1,9 +1,5 @@
 using UnityEngine;
-#if UNITY_2023_1_OR_NEWER
 using Converter = Aspid.MVVM.StarterKit.IConverter<int, int>;
-#else
-using Converter = Aspid.MVVM.StarterKit.IConverterInt;
-#endif
 
 // ReSharper disable once CheckNamespace
 namespace Aspid.MVVM.StarterKit

--- a/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Unity/Runtime/Binders/Mono/Switchers/SwitcherStringMonoBinder.cs
+++ b/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Unity/Runtime/Binders/Mono/Switchers/SwitcherStringMonoBinder.cs
@@ -1,9 +1,5 @@
 using UnityEngine;
-#if UNITY_2023_1_OR_NEWER
 using Converter = Aspid.MVVM.StarterKit.IConverter<string, string>;
-#else
-using Converter = Aspid.MVVM.StarterKit.IConverterString;
-#endif
 
 // ReSharper disable once CheckNamespace
 namespace Aspid.MVVM.StarterKit

--- a/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Unity/Runtime/Binders/Mono/Switchers/SwitcherVector3MonoBinder.cs
+++ b/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Unity/Runtime/Binders/Mono/Switchers/SwitcherVector3MonoBinder.cs
@@ -1,9 +1,5 @@
 using UnityEngine;
-#if UNITY_2023_1_OR_NEWER
 using Converter = Aspid.MVVM.StarterKit.IConverter<UnityEngine.Vector3, UnityEngine.Vector3>;
-#else
-using Converter = Aspid.MVVM.StarterKit.IConverterVector3;
-#endif
 
 // ReSharper disable once CheckNamespace
 namespace Aspid.MVVM.StarterKit

--- a/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Unity/Runtime/Binders/Objects/Mono/ObjectNameMonoBinder.cs
+++ b/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Unity/Runtime/Binders/Objects/Mono/ObjectNameMonoBinder.cs
@@ -1,11 +1,7 @@
 using System;
 using UnityEngine;
 using Object = UnityEngine.Object;
-#if UNITY_2023_1_OR_NEWER
 using Converter = Aspid.MVVM.StarterKit.IConverter<string, string>;
-#else
-using Converter = Aspid.MVVM.StarterKit.IConverterString;
-#endif
 
 // ReSharper disable once CheckNamespace
 namespace Aspid.MVVM.StarterKit

--- a/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Unity/Runtime/Binders/Objects/ObjectNameBinder.cs
+++ b/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Unity/Runtime/Binders/Objects/ObjectNameBinder.cs
@@ -2,11 +2,7 @@
 using System;
 using UnityEngine;
 using Object = UnityEngine.Object;
-#if UNITY_2023_1_OR_NEWER
 using Converter = Aspid.MVVM.StarterKit.IConverter<string?, string?>;
-#else
-using Converter = Aspid.MVVM.StarterKit.IConverterString;
-#endif
 
 // ReSharper disable once CheckNamespace
 namespace Aspid.MVVM.StarterKit

--- a/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Unity/Runtime/Binders/RawImages/Texture/Mono/RawImageTextureEnumGroupMonoBinder.cs
+++ b/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Unity/Runtime/Binders/RawImages/Texture/Mono/RawImageTextureEnumGroupMonoBinder.cs
@@ -1,10 +1,6 @@
 using UnityEngine;
 using UnityEngine.UI;
-#if UNITY_2023_1_OR_NEWER
 using Converter = Aspid.MVVM.StarterKit.IConverter<UnityEngine.Texture, UnityEngine.Texture>;
-#else
-using Converter = Aspid.MVVM.StarterKit.IConverterTexture;
-#endif
 
 // ReSharper disable once CheckNamespace
 namespace Aspid.MVVM.StarterKit

--- a/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Unity/Runtime/Binders/RawImages/Texture/Mono/RawImageTextureEnumMonoBinder.cs
+++ b/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Unity/Runtime/Binders/RawImages/Texture/Mono/RawImageTextureEnumMonoBinder.cs
@@ -1,10 +1,6 @@
 using UnityEngine;
 using UnityEngine.UI;
-#if UNITY_2023_1_OR_NEWER
 using Converter = Aspid.MVVM.StarterKit.IConverter<UnityEngine.Texture, UnityEngine.Texture>;
-#else
-using Converter = Aspid.MVVM.StarterKit.IConverterTexture;
-#endif
 
 // ReSharper disable once CheckNamespace
 namespace Aspid.MVVM.StarterKit

--- a/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Unity/Runtime/Binders/RawImages/Texture/Mono/RawImageTextureMonoBinder.cs
+++ b/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Unity/Runtime/Binders/RawImages/Texture/Mono/RawImageTextureMonoBinder.cs
@@ -1,10 +1,6 @@
 using UnityEngine;
 using UnityEngine.UI;
-#if UNITY_2023_1_OR_NEWER
 using Converter = Aspid.MVVM.StarterKit.IConverter<UnityEngine.Texture, UnityEngine.Texture>;
-#else
-using Converter = Aspid.MVVM.StarterKit.IConverterTexture;
-#endif
 
 // ReSharper disable once CheckNamespace
 namespace Aspid.MVVM.StarterKit

--- a/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Unity/Runtime/Binders/RawImages/Texture/Mono/RawImageTextureSwitcherMonoBinder.cs
+++ b/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Unity/Runtime/Binders/RawImages/Texture/Mono/RawImageTextureSwitcherMonoBinder.cs
@@ -1,10 +1,6 @@
 using UnityEngine;
 using UnityEngine.UI;
-#if UNITY_2023_1_OR_NEWER
 using Converter = Aspid.MVVM.StarterKit.IConverter<UnityEngine.Texture, UnityEngine.Texture>;
-#else
-using Converter = Aspid.MVVM.StarterKit.IConverterTexture;
-#endif
 
 // ReSharper disable once CheckNamespace
 namespace Aspid.MVVM.StarterKit

--- a/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Unity/Runtime/Binders/RawImages/Texture/RawImageTextureBinder.cs
+++ b/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Unity/Runtime/Binders/RawImages/Texture/RawImageTextureBinder.cs
@@ -2,11 +2,7 @@
 using System;
 using UnityEngine;
 using UnityEngine.UI;
-#if UNITY_2023_1_OR_NEWER
 using Converter = Aspid.MVVM.StarterKit.IConverter<UnityEngine.Texture?, UnityEngine.Texture?>;
-#else
-using Converter = Aspid.MVVM.StarterKit.IConverterTexture;
-#endif
 
 // ReSharper disable once CheckNamespace
 namespace Aspid.MVVM.StarterKit

--- a/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Unity/Runtime/Binders/RawImages/Texture/RawImageTextureSwitcherBinder.cs
+++ b/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Unity/Runtime/Binders/RawImages/Texture/RawImageTextureSwitcherBinder.cs
@@ -2,11 +2,7 @@
 using System;
 using UnityEngine;
 using UnityEngine.UI;
-#if UNITY_2023_1_OR_NEWER
 using Converter = Aspid.MVVM.StarterKit.IConverter<UnityEngine.Texture?, UnityEngine.Texture?>;
-#else
-using Converter = Aspid.MVVM.StarterKit.IConverterTexture;
-#endif
 
 // ReSharper disable once CheckNamespace
 namespace Aspid.MVVM.StarterKit

--- a/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Unity/Runtime/Binders/Renderers/Materials/Mono/RendererMaterialsEnumGroupMonoBinder.cs
+++ b/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Unity/Runtime/Binders/Renderers/Materials/Mono/RendererMaterialsEnumGroupMonoBinder.cs
@@ -1,9 +1,5 @@
 using UnityEngine;
-#if UNITY_2023_1_OR_NEWER
 using Converter = Aspid.MVVM.StarterKit.IConverter<UnityEngine.Material, UnityEngine.Material>;
-#else
-using Converter = Aspid.MVVM.StarterKit.IConverterMaterial;
-#endif
 
 // ReSharper disable once CheckNamespace
 namespace Aspid.MVVM.StarterKit

--- a/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Unity/Runtime/Binders/Renderers/Materials/Mono/RendererMaterialsEnumMonoBinder.cs
+++ b/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Unity/Runtime/Binders/Renderers/Materials/Mono/RendererMaterialsEnumMonoBinder.cs
@@ -1,9 +1,5 @@
 using UnityEngine;
-#if UNITY_2023_1_OR_NEWER
 using Converter = Aspid.MVVM.StarterKit.IConverter<UnityEngine.Material, UnityEngine.Material>;
-#else
-using Converter = Aspid.MVVM.StarterKit.IConverterMaterial;
-#endif
 
 // ReSharper disable once CheckNamespace
 namespace Aspid.MVVM.StarterKit

--- a/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Unity/Runtime/Binders/Renderers/Materials/Mono/RendererMaterialsMonoBinder.cs
+++ b/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Unity/Runtime/Binders/Renderers/Materials/Mono/RendererMaterialsMonoBinder.cs
@@ -1,11 +1,7 @@
 using System;
 using UnityEngine;
 using System.Collections.Generic;
-#if UNITY_2023_1_OR_NEWER
 using Converter = Aspid.MVVM.StarterKit.IConverter<UnityEngine.Material, UnityEngine.Material>;
-#else
-using Converter = Aspid.MVVM.StarterKit.IConverterMaterial;
-#endif
 
 // ReSharper disable once CheckNamespace
 namespace Aspid.MVVM.StarterKit

--- a/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Unity/Runtime/Binders/Renderers/Materials/Mono/RendererMaterialsSwitcherMonoBinder.cs
+++ b/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Unity/Runtime/Binders/Renderers/Materials/Mono/RendererMaterialsSwitcherMonoBinder.cs
@@ -1,9 +1,5 @@
 using UnityEngine;
-#if UNITY_2023_1_OR_NEWER
 using Converter = Aspid.MVVM.StarterKit.IConverter<UnityEngine.Material, UnityEngine.Material>;
-#else
-using Converter = Aspid.MVVM.StarterKit.IConverterMaterial;
-#endif
 
 // ReSharper disable once CheckNamespace
 namespace Aspid.MVVM.StarterKit

--- a/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Unity/Runtime/Binders/Renderers/Materials/RendererMaterialsBinder.cs
+++ b/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Unity/Runtime/Binders/Renderers/Materials/RendererMaterialsBinder.cs
@@ -2,11 +2,7 @@
 using System;
 using UnityEngine;
 using System.Collections.Generic;
-#if UNITY_2023_1_OR_NEWER
 using Converter = Aspid.MVVM.StarterKit.IConverter<UnityEngine.Material?, UnityEngine.Material?>;
-#else
-using Converter = Aspid.MVVM.StarterKit.IConverterMaterial;
-#endif
 
 // ReSharper disable once CheckNamespace
 namespace Aspid.MVVM.StarterKit

--- a/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Unity/Runtime/Binders/Renderers/Materials/RendererMaterialsSwitcherBinder.cs
+++ b/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Unity/Runtime/Binders/Renderers/Materials/RendererMaterialsSwitcherBinder.cs
@@ -1,11 +1,7 @@
 #nullable enable
 using System;
 using UnityEngine;
-#if UNITY_2023_1_OR_NEWER
 using Converter = Aspid.MVVM.StarterKit.IConverter<UnityEngine.Material?, UnityEngine.Material?>;
-#else
-using Converter = Aspid.MVVM.StarterKit.IConverterMaterial;
-#endif
 
 // ReSharper disable once CheckNamespace
 namespace Aspid.MVVM.StarterKit

--- a/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Unity/Runtime/Binders/Selectables/ColorBlock/Mono/SelectableColorBlockEnumGroupMonoBinder.cs
+++ b/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Unity/Runtime/Binders/Selectables/ColorBlock/Mono/SelectableColorBlockEnumGroupMonoBinder.cs
@@ -1,10 +1,6 @@
 using UnityEngine;
 using UnityEngine.UI;
-#if UNITY_2023_1_OR_NEWER
 using Converter = Aspid.MVVM.StarterKit.IConverter<UnityEngine.UI.ColorBlock, UnityEngine.UI.ColorBlock>;
-#else
-using Converter = Aspid.MVVM.StarterKit.IConverterColorBlock;
-#endif
 
 // ReSharper disable once CheckNamespace
 namespace Aspid.MVVM.StarterKit

--- a/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Unity/Runtime/Binders/Selectables/ColorBlock/Mono/SelectableColorBlockEnumMonoBinder.cs
+++ b/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Unity/Runtime/Binders/Selectables/ColorBlock/Mono/SelectableColorBlockEnumMonoBinder.cs
@@ -1,10 +1,6 @@
 using UnityEngine;
 using UnityEngine.UI;
-#if UNITY_2023_1_OR_NEWER
 using Converter = Aspid.MVVM.StarterKit.IConverter<UnityEngine.UI.ColorBlock, UnityEngine.UI.ColorBlock>;
-#else
-using Converter = Aspid.MVVM.StarterKit.IConverterColorBlock;
-#endif
 
 // ReSharper disable once CheckNamespace
 namespace Aspid.MVVM.StarterKit

--- a/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Unity/Runtime/Binders/Selectables/ColorBlock/Mono/SelectableColorBlockMonoBinder.cs
+++ b/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Unity/Runtime/Binders/Selectables/ColorBlock/Mono/SelectableColorBlockMonoBinder.cs
@@ -1,10 +1,6 @@
 using UnityEngine;
 using UnityEngine.UI;
-#if UNITY_2023_1_OR_NEWER
 using Converter = Aspid.MVVM.StarterKit.IConverter<UnityEngine.UI.ColorBlock, UnityEngine.UI.ColorBlock>;
-#else
-using Converter = Aspid.MVVM.StarterKit.IConverterColorBlock;
-#endif
 
 // ReSharper disable once CheckNamespace
 namespace Aspid.MVVM.StarterKit

--- a/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Unity/Runtime/Binders/Selectables/ColorBlock/Mono/SelectableColorBlockSwitcherMonoBinder.cs
+++ b/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Unity/Runtime/Binders/Selectables/ColorBlock/Mono/SelectableColorBlockSwitcherMonoBinder.cs
@@ -1,10 +1,6 @@
 using UnityEngine;
 using UnityEngine.UI;
-#if UNITY_2023_1_OR_NEWER
 using Converter = Aspid.MVVM.StarterKit.IConverter<UnityEngine.UI.ColorBlock, UnityEngine.UI.ColorBlock>;
-#else
-using Converter = Aspid.MVVM.StarterKit.IConverterColorBlock;
-#endif
 
 // ReSharper disable once CheckNamespace
 namespace Aspid.MVVM.StarterKit

--- a/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Unity/Runtime/Binders/Selectables/ColorBlock/SelectableColorBlockBinder.cs
+++ b/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Unity/Runtime/Binders/Selectables/ColorBlock/SelectableColorBlockBinder.cs
@@ -1,11 +1,7 @@
 #nullable enable
 using System;
 using UnityEngine.UI;
-#if UNITY_2023_1_OR_NEWER
 using Converter = Aspid.MVVM.StarterKit.IConverter<UnityEngine.UI.ColorBlock, UnityEngine.UI.ColorBlock>;
-#else
-using Converter = Aspid.MVVM.StarterKit.IConverterColorBlock;
-#endif
 
 // ReSharper disable once CheckNamespace
 namespace Aspid.MVVM.StarterKit

--- a/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Unity/Runtime/Binders/Selectables/ColorBlock/SelectableColorBlockSwitcherBinder.cs
+++ b/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Unity/Runtime/Binders/Selectables/ColorBlock/SelectableColorBlockSwitcherBinder.cs
@@ -2,11 +2,7 @@
 #nullable enable
 using System;
 using UnityEngine.UI;
-#if UNITY_2023_1_OR_NEWER
 using Converter = Aspid.MVVM.StarterKit.IConverter<UnityEngine.UI.ColorBlock, UnityEngine.UI.ColorBlock>;
-#else
-using Converter = Aspid.MVVM.StarterKit.IConverterColorBlock;
-#endif
 
 // ReSharper disable once CheckNamespace
 namespace Aspid.MVVM.StarterKit

--- a/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Unity/Runtime/Binders/Sliders/MinMax/Mono/SliderMinMaxEnumGroupMonoBinder.cs
+++ b/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Unity/Runtime/Binders/Sliders/MinMax/Mono/SliderMinMaxEnumGroupMonoBinder.cs
@@ -1,10 +1,6 @@
 using UnityEngine;
 using UnityEngine.UI;
-#if UNITY_2023_1_OR_NEWER
 using Converter = Aspid.MVVM.StarterKit.IConverter<UnityEngine.Vector2, UnityEngine.Vector2>;
-#else
-using Converter = Aspid.MVVM.StarterKit.IConverterVector2;
-#endif
 
 // ReSharper disable once CheckNamespace
 namespace Aspid.MVVM.StarterKit

--- a/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Unity/Runtime/Binders/Sliders/MinMax/Mono/SliderMinMaxEnumMonoBinder.cs
+++ b/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Unity/Runtime/Binders/Sliders/MinMax/Mono/SliderMinMaxEnumMonoBinder.cs
@@ -1,10 +1,6 @@
 using UnityEngine;
 using UnityEngine.UI;
-#if UNITY_2023_1_OR_NEWER
 using Converter = Aspid.MVVM.StarterKit.IConverter<UnityEngine.Vector2, UnityEngine.Vector2>;
-#else
-using Converter = Aspid.MVVM.StarterKit.IConverterVector2;
-#endif
 
 // ReSharper disable once CheckNamespace
 namespace Aspid.MVVM.StarterKit

--- a/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Unity/Runtime/Binders/Sliders/MinMax/Mono/SliderMinMaxMonoBinder.cs
+++ b/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Unity/Runtime/Binders/Sliders/MinMax/Mono/SliderMinMaxMonoBinder.cs
@@ -1,10 +1,6 @@
 using UnityEngine;
 using UnityEngine.UI;
-#if UNITY_2023_1_OR_NEWER
 using Converter = Aspid.MVVM.StarterKit.IConverter<UnityEngine.Vector2, UnityEngine.Vector2>;
-#else
-using Converter = Aspid.MVVM.StarterKit.IConverterVector2;
-#endif
 
 // ReSharper disable once CheckNamespace
 namespace Aspid.MVVM.StarterKit

--- a/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Unity/Runtime/Binders/Sliders/MinMax/Mono/SliderMinMaxSwitcherMonoBinder.cs
+++ b/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Unity/Runtime/Binders/Sliders/MinMax/Mono/SliderMinMaxSwitcherMonoBinder.cs
@@ -1,10 +1,6 @@
 using UnityEngine;
 using UnityEngine.UI;
-#if UNITY_2023_1_OR_NEWER
 using Converter = Aspid.MVVM.StarterKit.IConverter<UnityEngine.Vector2, UnityEngine.Vector2>;
-#else
-using Converter = Aspid.MVVM.StarterKit.IConverterVector2;
-#endif
 
 // ReSharper disable once CheckNamespace
 namespace Aspid.MVVM.StarterKit

--- a/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Unity/Runtime/Binders/Sliders/MinMax/SliderMinMaxBinder.cs
+++ b/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Unity/Runtime/Binders/Sliders/MinMax/SliderMinMaxBinder.cs
@@ -2,11 +2,7 @@
 using System;
 using UnityEngine;
 using UnityEngine.UI;
-#if UNITY_2023_1_OR_NEWER
 using Converter = Aspid.MVVM.StarterKit.IConverter<UnityEngine.Vector2, UnityEngine.Vector2>;
-#else
-using Converter = Aspid.MVVM.StarterKit.IConverterVector2;
-#endif
 
 // ReSharper disable once CheckNamespace
 namespace Aspid.MVVM.StarterKit

--- a/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Unity/Runtime/Binders/Sliders/MinMax/SliderMinMaxSwitcherBinder.cs
+++ b/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Unity/Runtime/Binders/Sliders/MinMax/SliderMinMaxSwitcherBinder.cs
@@ -2,11 +2,7 @@
 using System;
 using UnityEngine;
 using UnityEngine.UI;
-#if UNITY_2023_1_OR_NEWER
 using Converter = Aspid.MVVM.StarterKit.IConverter<UnityEngine.Vector2, UnityEngine.Vector2>;
-#else
-using Converter = Aspid.MVVM.StarterKit.IConverterVector2;
-#endif
 
 // ReSharper disable once CheckNamespace
 namespace Aspid.MVVM.StarterKit

--- a/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Unity/Runtime/Binders/Sliders/Value/Mono/SliderValueMonoBinder.cs
+++ b/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Unity/Runtime/Binders/Sliders/Value/Mono/SliderValueMonoBinder.cs
@@ -1,11 +1,7 @@
 using System;
 using UnityEngine;
 using UnityEngine.UI;
-#if UNITY_2023_1_OR_NEWER
 using Converter = Aspid.MVVM.StarterKit.IConverter<float, float>;
-#else
-using Converter = Aspid.MVVM.StarterKit.IConverterFloat;
-#endif
 
 // ReSharper disable once CheckNamespace
 // ReSharper disable NotNullOrRequiredMemberIsNotInitialized

--- a/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Unity/Runtime/Binders/Sliders/Value/SliderValueBinder.cs
+++ b/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Unity/Runtime/Binders/Sliders/Value/SliderValueBinder.cs
@@ -2,11 +2,7 @@
 using System;
 using UnityEngine;
 using UnityEngine.UI;
-#if UNITY_2023_1_OR_NEWER
 using Converter = Aspid.MVVM.StarterKit.IConverter<float, float>;
-#else
-using Converter = Aspid.MVVM.StarterKit.IConverterFloat;
-#endif
 
 // ReSharper disable once CheckNamespace
 namespace Aspid.MVVM.StarterKit

--- a/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Unity/Runtime/Binders/SwitcherColorBinder.cs
+++ b/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Unity/Runtime/Binders/SwitcherColorBinder.cs
@@ -1,11 +1,6 @@
 #nullable enable
 using UnityEngine;
-using System.Runtime.CompilerServices;
-#if UNITY_2023_1_OR_NEWER
 using Converter = Aspid.MVVM.StarterKit.IConverter<UnityEngine.Color, UnityEngine.Color>;
-#else
-using Converter = Aspid.MVVM.StarterKit.IConverterColor;
-#endif
 
 // ReSharper disable once CheckNamespace
 namespace Aspid.MVVM.StarterKit
@@ -24,16 +19,6 @@ namespace Aspid.MVVM.StarterKit
             Color falseValue,
             IConverter<Color, Color>? converter, 
             BindMode mode = BindMode.OneWay)
-            : base(target, trueValue, falseValue, GetConverter(converter), mode) { }
-
-        [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        private static Converter? GetConverter(IConverter<Color, Color>? converter)
-        {
-            #if UNITY_2023_1_OR_NEWER
-            return converter;
-            #else
-            return converter?.ToConvertSpecific();
-            #endif
-        }
+            : base(target, trueValue, falseValue, converter, mode) { }
     }
 }

--- a/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Unity/Runtime/Binders/SwitcherVector3Binder.cs
+++ b/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Unity/Runtime/Binders/SwitcherVector3Binder.cs
@@ -1,10 +1,5 @@
 using UnityEngine;
-using System.Runtime.CompilerServices;
-#if UNITY_2023_1_OR_NEWER
 using Converter = Aspid.MVVM.StarterKit.IConverter<UnityEngine.Vector3, UnityEngine.Vector3>;
-#else
-using Converter = Aspid.MVVM.StarterKit.IConverterVector3;
-#endif
 
 // ReSharper disable once CheckNamespace
 namespace Aspid.MVVM.StarterKit
@@ -23,16 +18,7 @@ namespace Aspid.MVVM.StarterKit
             Vector3 falseValue,
             IConverter<Vector3, Vector3>? converter, 
             BindMode mode = BindMode.OneWay)
-            : base(target, trueValue, falseValue, GetConverter(converter), mode) { }
+            : base(target, trueValue, falseValue, converter, mode) { }
 
-        [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        private static Converter? GetConverter(IConverter<Vector3, Vector3>? converter)
-        {
-            #if UNITY_2023_1_OR_NEWER
-            return converter;
-            #else
-            return converter?.ToConvertSpecific();
-            #endif
-        }
     }
 }

--- a/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Unity/Runtime/Binders/TargetColorBinder.cs
+++ b/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Unity/Runtime/Binders/TargetColorBinder.cs
@@ -1,11 +1,6 @@
 #nullable enable
 using UnityEngine;
-using System.Runtime.CompilerServices;
-#if UNITY_2023_1_OR_NEWER
 using Converter = Aspid.MVVM.StarterKit.IConverter<UnityEngine.Color, UnityEngine.Color>;
-#else
-using Converter = Aspid.MVVM.StarterKit.IConverterColor;
-#endif
 
 // ReSharper disable once CheckNamespace
 namespace Aspid.MVVM.StarterKit
@@ -19,16 +14,7 @@ namespace Aspid.MVVM.StarterKit
     {
         /// <inheritdoc/>
         protected TargetColorBinder(TTarget target, IConverter<Color, Color>? converter, BindMode mode = BindMode.OneWay)
-            : base(target, GetConverter(converter), mode) { }
+            : base(target, converter, mode) { }
         
-        [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        private static Converter? GetConverter(IConverter<Color, Color>? converter)
-        {
-            #if UNITY_2023_1_OR_NEWER
-            return converter;
-            #else
-            return converter?.ToConvertSpecific();
-            #endif
-        }
     }
 }

--- a/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Unity/Runtime/Binders/TargetVector3Binder.cs
+++ b/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Unity/Runtime/Binders/TargetVector3Binder.cs
@@ -1,11 +1,6 @@
 #nullable enable
 using UnityEngine;
-using System.Runtime.CompilerServices;
-#if UNITY_2023_1_OR_NEWER
 using Converter = Aspid.MVVM.StarterKit.IConverter<UnityEngine.Vector3, UnityEngine.Vector3>;
-#else
-using Converter = Aspid.MVVM.StarterKit.IConverterVector3;
-#endif
 
 // ReSharper disable once CheckNamespace
 namespace Aspid.MVVM.StarterKit
@@ -23,7 +18,7 @@ namespace Aspid.MVVM.StarterKit
     {
         /// <inheritdoc/>
         protected TargetVector3Binder(TTarget target, IConverter<Vector3, Vector3>? converter, BindMode mode = BindMode.OneWay)
-            : base(target, GetConverter(converter), mode) { }
+            : base(target, converter, mode) { }
 
         /// <summary>
         /// Sets the bound property by promoting <paramref name="value"/> to a <see cref="Vector3"/> with Z set to zero.
@@ -60,14 +55,5 @@ namespace Aspid.MVVM.StarterKit
         public void SetValue(double value) =>
             SetValue((float)value);
         
-        [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        private static Converter? GetConverter(IConverter<Vector3, Vector3>? converter)
-        {
-            #if UNITY_2023_1_OR_NEWER
-            return converter;
-            #else
-            return converter?.ToConvertSpecific();
-            #endif
-        }
     }
 }

--- a/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Unity/Runtime/Binders/Transforms/Transforms/Rotation/Mono/TransformRotationMonoBinder.cs
+++ b/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Unity/Runtime/Binders/Transforms/Transforms/Rotation/Mono/TransformRotationMonoBinder.cs
@@ -1,9 +1,5 @@
 using UnityEngine;
-#if UNITY_2023_1_OR_NEWER
 using Converter = Aspid.MVVM.StarterKit.IConverter<UnityEngine.Quaternion, UnityEngine.Quaternion>;
-#else
-using Converter = Aspid.MVVM.StarterKit.IConverterQuaternion;
-#endif
 
 // ReSharper disable once CheckNamespace
 namespace Aspid.MVVM.StarterKit

--- a/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Unity/Runtime/Binders/Transforms/Transforms/Rotation/TransformRotationBinder.cs
+++ b/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Unity/Runtime/Binders/Transforms/Transforms/Rotation/TransformRotationBinder.cs
@@ -1,11 +1,7 @@
 #nullable enable
 using System;
 using UnityEngine;
-#if UNITY_2023_1_OR_NEWER
 using Converter = Aspid.MVVM.StarterKit.IConverter<UnityEngine.Quaternion, UnityEngine.Quaternion>;
-#else
-using Converter = Aspid.MVVM.StarterKit.IConverterQuaternion;
-#endif
 
 // ReSharper disable once CheckNamespace
 namespace Aspid.MVVM.StarterKit

--- a/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Unity/Runtime/Binders/UnityEvents/Mono/UnityEventColorMonoBinder.cs
+++ b/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Unity/Runtime/Binders/UnityEvents/Mono/UnityEventColorMonoBinder.cs
@@ -1,10 +1,6 @@
 using UnityEngine;
 using UnityEngine.Events;
-#if UNITY_2023_1_OR_NEWER
 using Converter = Aspid.MVVM.StarterKit.IConverter<UnityEngine.Color, UnityEngine.Color>;
-#else
-using Converter = Aspid.MVVM.StarterKit.IConverterColor;
-#endif
 
 // ReSharper disable once CheckNamespace
 namespace Aspid.MVVM.StarterKit

--- a/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Unity/Runtime/Binders/UnityEvents/Mono/UnityEventDoubleMonoBinder.cs
+++ b/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Unity/Runtime/Binders/UnityEvents/Mono/UnityEventDoubleMonoBinder.cs
@@ -1,10 +1,6 @@
 using UnityEngine;
 using UnityEngine.Events;
-#if UNITY_2023_1_OR_NEWER
 using Converter = Aspid.MVVM.StarterKit.IConverter<double, double>;
-#else
-using Converter = Aspid.MVVM.StarterKit.IConverterDouble;
-#endif
 
 // ReSharper disable once CheckNamespace
 namespace Aspid.MVVM.StarterKit

--- a/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Unity/Runtime/Binders/UnityEvents/Mono/UnityEventFloatMonoBinder.cs
+++ b/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Unity/Runtime/Binders/UnityEvents/Mono/UnityEventFloatMonoBinder.cs
@@ -1,10 +1,6 @@
 using UnityEngine;
 using UnityEngine.Events;
-#if UNITY_2023_1_OR_NEWER
 using Converter = Aspid.MVVM.StarterKit.IConverter<float, float>;
-#else
-using Converter = Aspid.MVVM.StarterKit.IConverterFloat;
-#endif
 
 // ReSharper disable once CheckNamespace
 namespace Aspid.MVVM.StarterKit

--- a/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Unity/Runtime/Binders/UnityEvents/Mono/UnityEventIntMonoBinder.cs
+++ b/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Unity/Runtime/Binders/UnityEvents/Mono/UnityEventIntMonoBinder.cs
@@ -1,10 +1,6 @@
 using UnityEngine;
 using UnityEngine.Events;
-#if UNITY_2023_1_OR_NEWER
 using Converter = Aspid.MVVM.StarterKit.IConverter<int, int>;
-#else
-using Converter = Aspid.MVVM.StarterKit.IConverterInt;
-#endif
 
 // ReSharper disable once CheckNamespace
 namespace Aspid.MVVM.StarterKit

--- a/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Unity/Runtime/Binders/UnityEvents/Mono/UnityEventLongMonoBinder.cs
+++ b/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Unity/Runtime/Binders/UnityEvents/Mono/UnityEventLongMonoBinder.cs
@@ -1,10 +1,6 @@
 using UnityEngine;
 using UnityEngine.Events;
-#if UNITY_2023_1_OR_NEWER
 using Converter = Aspid.MVVM.StarterKit.IConverter<long, long>;
-#else
-using Converter = Aspid.MVVM.StarterKit.IConverterLong;
-#endif
 
 // ReSharper disable once CheckNamespace
 namespace Aspid.MVVM.StarterKit

--- a/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Unity/Runtime/Binders/UnityEvents/Mono/UnityEventNumberConditionMonoBinder.cs
+++ b/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Unity/Runtime/Binders/UnityEvents/Mono/UnityEventNumberConditionMonoBinder.cs
@@ -1,10 +1,6 @@
 using UnityEngine;
 using UnityEngine.Events;
-#if UNITY_2023_1_OR_NEWER
 using Converter = Aspid.MVVM.StarterKit.IConverter<float, bool>;
-#else
-using Converter = Aspid.MVVM.StarterKit.IConverterFloatToBool;
-#endif
 
 // ReSharper disable once CheckNamespace
 namespace Aspid.MVVM.StarterKit

--- a/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Unity/Runtime/Binders/UnityEvents/Mono/UnityEventNumberConditionSwitcherMonoBinder.cs
+++ b/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Unity/Runtime/Binders/UnityEvents/Mono/UnityEventNumberConditionSwitcherMonoBinder.cs
@@ -1,10 +1,6 @@
 using UnityEngine;
 using UnityEngine.Events;
-#if UNITY_2023_1_OR_NEWER
 using Converter = Aspid.MVVM.StarterKit.IConverter<float, bool>;
-#else
-using Converter = Aspid.MVVM.StarterKit.IConverterFloatToBool;
-#endif
 
 // ReSharper disable once CheckNamespace
 namespace Aspid.MVVM.StarterKit

--- a/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Unity/Runtime/Binders/UnityEvents/Mono/UnityEventQuaternionMonoBinder.cs
+++ b/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Unity/Runtime/Binders/UnityEvents/Mono/UnityEventQuaternionMonoBinder.cs
@@ -1,10 +1,6 @@
 using UnityEngine;
 using UnityEngine.Events;
-#if UNITY_2023_1_OR_NEWER
 using Converter = Aspid.MVVM.StarterKit.IConverter<UnityEngine.Quaternion, UnityEngine.Quaternion>;
-#else
-using Converter = Aspid.MVVM.StarterKit.IConverterQuaternion;
-#endif
 
 // ReSharper disable once CheckNamespace
 namespace Aspid.MVVM.StarterKit

--- a/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Unity/Runtime/Binders/UnityEvents/Mono/UnityEventStringMonoBinder.cs
+++ b/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Unity/Runtime/Binders/UnityEvents/Mono/UnityEventStringMonoBinder.cs
@@ -1,10 +1,6 @@
 using UnityEngine;
 using UnityEngine.Events;
-#if UNITY_2023_1_OR_NEWER
 using Converter = Aspid.MVVM.StarterKit.IConverter<string, string>;
-#else
-using Converter = Aspid.MVVM.StarterKit.IConverterString;
-#endif
 
 // ReSharper disable once CheckNamespace
 namespace Aspid.MVVM.StarterKit

--- a/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Unity/Runtime/Binders/UnityEvents/Mono/UnityEventVector2MonoBinder.cs
+++ b/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Unity/Runtime/Binders/UnityEvents/Mono/UnityEventVector2MonoBinder.cs
@@ -1,10 +1,6 @@
 using UnityEngine;
 using UnityEngine.Events;
-#if UNITY_2023_1_OR_NEWER
 using Converter = Aspid.MVVM.StarterKit.IConverter<UnityEngine.Vector2, UnityEngine.Vector2>;
-#else
-using Converter = Aspid.MVVM.StarterKit.IConverterVector2;
-#endif
 
 // ReSharper disable once CheckNamespace
 namespace Aspid.MVVM.StarterKit

--- a/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Unity/Runtime/Binders/UnityEvents/Mono/UnityEventVector3MonoBinder.cs
+++ b/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Unity/Runtime/Binders/UnityEvents/Mono/UnityEventVector3MonoBinder.cs
@@ -1,10 +1,6 @@
 using UnityEngine;
 using UnityEngine.Events;
-#if UNITY_2023_1_OR_NEWER
 using Converter = Aspid.MVVM.StarterKit.IConverter<UnityEngine.Vector3, UnityEngine.Vector3>;
-#else
-using Converter = Aspid.MVVM.StarterKit.IConverterVector3;
-#endif
 
 // ReSharper disable once CheckNamespace
 namespace Aspid.MVVM.StarterKit

--- a/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Unity/Runtime/Binders/VirtualizedLists/ItemSource/Mono/VirtualizedListItemSourceMonoBinder.cs
+++ b/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Unity/Runtime/Binders/VirtualizedLists/ItemSource/Mono/VirtualizedListItemSourceMonoBinder.cs
@@ -1,13 +1,8 @@
 using UnityEngine;
 using System.Collections.Generic;
 using Aspid.Collections.Observable.Filtered;
-#if UNITY_2023_1_OR_NEWER
 using Filter = Aspid.MVVM.StarterKit.ICollectionFilter<Aspid.MVVM.IViewModel>;
 using Comparer = Aspid.MVVM.StarterKit.ICollectionComparer<Aspid.MVVM.IViewModel>;
-#else
-using Filter = Aspid.MVVM.StarterKit.IViewModelCollectionFilter;
-using Comparer = Aspid.MVVM.StarterKit.IViewModelCollectionComparer;
-#endif
 
 // ReSharper disable once CheckNamespace
 namespace Aspid.MVVM.StarterKit

--- a/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Unity/Runtime/Binders/VirtualizedLists/ItemSource/VirtualizedListItemSourceBinder.cs
+++ b/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Unity/Runtime/Binders/VirtualizedLists/ItemSource/VirtualizedListItemSourceBinder.cs
@@ -2,13 +2,8 @@ using System;
 using UnityEngine;
 using System.Collections.Generic;
 using Aspid.Collections.Observable.Filtered;
-#if UNITY_2023_1_OR_NEWER
 using Filter = Aspid.MVVM.StarterKit.ICollectionFilter<Aspid.MVVM.IViewModel>;
 using Comparer = Aspid.MVVM.StarterKit.ICollectionComparer<Aspid.MVVM.IViewModel>;
-#else
-using Filter = Aspid.MVVM.StarterKit.IViewModelCollectionFilter;
-using Comparer = Aspid.MVVM.StarterKit.IViewModelCollectionComparer;
-#endif
 
 // ReSharper disable once CheckNamespace
 namespace Aspid.MVVM.StarterKit

--- a/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Unity/Runtime/Converters/Specific/ConverterSpecificExtensions.cs
+++ b/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Unity/Runtime/Converters/Specific/ConverterSpecificExtensions.cs
@@ -2,11 +2,7 @@
 using System;
 using Aspid.FastTools.Types;
 using UnityEngine;
-#if UNITY_6000_0_OR_NEWER
 using PhysicsMaterial = UnityEngine.PhysicsMaterial;
-#else
-using PhysicsMaterial = UnityEngine.PhysicMaterial;
-#endif
 
 // ReSharper disable once CheckNamespace
 namespace Aspid.MVVM.StarterKit

--- a/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Unity/Runtime/Converters/Specific/IConverterPhysicsMaterial.cs
+++ b/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Unity/Runtime/Converters/Specific/IConverterPhysicsMaterial.cs
@@ -1,9 +1,5 @@
 #nullable enable
-#if UNITY_6000_0_OR_NEWER
 using PhysicsMaterial = UnityEngine.PhysicsMaterial;
-#else
-using PhysicsMaterial = UnityEngine.PhysicMaterial;
-#endif
 
 // ReSharper disable once CheckNamespace
 namespace Aspid.MVVM.StarterKit

--- a/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Unity/Runtime/Converters/Vectors/Vector2CombineConverter.cs
+++ b/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Unity/Runtime/Converters/Vectors/Vector2CombineConverter.cs
@@ -2,11 +2,7 @@
 using Aspid.FastTools.Types;
 using System;
 using UnityEngine;
-#if UNITY_2023_1_OR_NEWER
 using Converter = Aspid.MVVM.StarterKit.IConverter<UnityEngine.Vector2, UnityEngine.Vector2>;
-#else
-using Converter = Aspid.MVVM.StarterKit.IConverterVector2;
-#endif
 
 // ReSharper disable once CheckNamespace
 namespace Aspid.MVVM.StarterKit

--- a/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Unity/Runtime/Converters/Vectors/Vector3CombineConverter.cs
+++ b/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Unity/Runtime/Converters/Vectors/Vector3CombineConverter.cs
@@ -1,11 +1,7 @@
 #nullable enable
 using System;
 using UnityEngine;
-#if UNITY_2023_1_OR_NEWER
 using Converter = Aspid.MVVM.StarterKit.IConverter<UnityEngine.Vector3, UnityEngine.Vector3>;
-#else
-using Converter = Aspid.MVVM.StarterKit.IConverterVector3;
-#endif
 
 // ReSharper disable once CheckNamespace
 namespace Aspid.MVVM.StarterKit


### PR DESCRIPTION
🔧 650 lines of code that compiled in no configuration the package supports — `package.json` has declared `"unity": "6000.0"` since 1.1.0, so every `#else` behind `UNITY_2023_1_OR_NEWER` was unreachable.

## Summary

- 🔧 **117 `using Converter = …` alias pairs** collapse to the generic form.
- 🔧 **12 inline branches** that ran `converter?.ToConvertSpecific()` on the dead path.
- 🔧 **4 conditional `[SerializeReference]` attributes**, conditional because pre-2023.1 Unity could not serialize a generic managed reference.
- ♻️ **10 `GetConverter` helpers** the collapse turned into `x => x` behind `AggressiveInlining`.
- 🔧 **8 `UNITY_6000_0_OR_NEWER` branches** naming the pre-Unity-6 `PhysicMaterial` — the converter subsystem now has no version gate at all.

## Notes for review

- 📝 Nothing changes in the compiled output: the preprocessor already resolved every site the same way on every supported version, so the diff is large and the risk is not.
- ⚠️ The TMP integration gate (62 sites) and the `MonoView.InstantiateAsync` / `ObservableListViewModelMonoBinder` gates are deliberately out of scope — same symbol, but about feature availability rather than a generic converter interface.
- ✅ 1037 EditMode tests, 1035 passed, 0 failed, 2 skipped.

<details>
<summary>🇷🇺 Описание на русском</summary>

🔧 650 строк кода, не компилировавшихся ни в одной поддерживаемой конфигурации: `package.json` объявляет `"unity": "6000.0"` с версии 1.1.0, поэтому каждая ветка `#else` за `UNITY_2023_1_OR_NEWER` была недостижима.

## Итог

- 🔧 **117 пар-псевдонимов `using Converter = …`** свёрнуты к генерик-форме.
- 🔧 **12 встроенных ветвлений**, вызывавших `converter?.ToConvertSpecific()` на мёртвом пути.
- 🔧 **4 условных атрибута `[SerializeReference]`** — условных потому, что Unity до 2023.1 не сериализовала generic managed reference.
- ♻️ **10 хелперов `GetConverter`**, которые после сворачивания стали `x => x` за `AggressiveInlining`.
- 🔧 **8 веток `UNITY_6000_0_OR_NEWER`** с `PhysicMaterial` из времён до Unity 6 — в подсистеме конвертеров не осталось ни одного version gate.

## Заметки для ревью

- 📝 В скомпилированном результате не меняется ничего: препроцессор и так разрешал каждое место одинаково на любой поддерживаемой версии, поэтому дифф большой, а риск — нет.
- ⚠️ Гейт интеграции TMP (62 места) и гейты `MonoView.InstantiateAsync` / `ObservableListViewModelMonoBinder` намеренно вне области — символ тот же, но речь о доступности фич, а не о генерик-интерфейсе конвертера.
- ✅ 1037 EditMode-тестов, 1035 прошло, 0 упало, 2 пропущено.

</details>

