### PR TITLE
Deprecate the named converter aliases and their wrappers

### DIFF
--- a/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Runtime/Converters/Bools/NumberToBoolConverter.cs
+++ b/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Runtime/Converters/Bools/NumberToBoolConverter.cs
@@ -1,6 +1,11 @@
 using Aspid.FastTools.Types;
 using System;
 
+// The named converter aliases are [Obsolete]. The converters below keep implementing them for
+// one release so that a [SerializeReference] field a project declares as one still
+// deserializes; the base lists go with the aliases in the next major.
+#pragma warning disable CS0618 // Type or member is obsolete
+
 // ReSharper disable once CheckNamespace
 namespace Aspid.MVVM.StarterKit
 {

--- a/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Runtime/Converters/Bools/ObjectNullToBoolConverter.cs
+++ b/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Runtime/Converters/Bools/ObjectNullToBoolConverter.cs
@@ -1,6 +1,11 @@
 using Aspid.FastTools.Types;
 using System;
 
+// The named converter aliases are [Obsolete]. The converters below keep implementing them for
+// one release so that a [SerializeReference] field a project declares as one still
+// deserializes; the base lists go with the aliases in the next major.
+#pragma warning disable CS0618 // Type or member is obsolete
+
 // ReSharper disable once CheckNamespace
 namespace Aspid.MVVM.StarterKit
 {

--- a/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Runtime/Converters/Bools/StringEmptyToBoolConverter.cs
+++ b/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Runtime/Converters/Bools/StringEmptyToBoolConverter.cs
@@ -2,6 +2,11 @@ using Aspid.FastTools.Types;
 using System;
 using UnityEngine;
 
+// The named converter aliases are [Obsolete]. The converters below keep implementing them for
+// one release so that a [SerializeReference] field a project declares as one still
+// deserializes; the base lists go with the aliases in the next major.
+#pragma warning disable CS0618 // Type or member is obsolete
+
 // ReSharper disable once CheckNamespace
 namespace Aspid.MVVM.StarterKit
 {

--- a/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Runtime/Converters/Bools/StringMatchToBoolConverter.cs
+++ b/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Runtime/Converters/Bools/StringMatchToBoolConverter.cs
@@ -2,6 +2,11 @@ using Aspid.FastTools.Types;
 using System;
 using UnityEngine;
 
+// The named converter aliases are [Obsolete]. The converters below keep implementing them for
+// one release so that a [SerializeReference] field a project declares as one still
+// deserializes; the base lists go with the aliases in the next major.
+#pragma warning disable CS0618 // Type or member is obsolete
+
 // ReSharper disable once CheckNamespace
 namespace Aspid.MVVM.StarterKit
 {

--- a/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Runtime/Converters/ConverterExtensions.cs
+++ b/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Runtime/Converters/ConverterExtensions.cs
@@ -3,8 +3,24 @@ using System;
 // ReSharper disable once CheckNamespace
 namespace Aspid.MVVM.StarterKit
 {
+    /// <summary>
+    /// Turns a function into a converter.
+    /// </summary>
     public static class ConverterExtensions
     {
+        /// <summary>
+        /// Wraps the specified function as an <see cref="IConverter{TFrom, TTo}"/>.
+        /// </summary>
+        /// <typeparam name="TFrom">The type the function accepts.</typeparam>
+        /// <typeparam name="TTo">The type it returns.</typeparam>
+        /// <param name="converter">The function to wrap.</param>
+        /// <returns>A converter that calls the function.</returns>
+        /// <exception cref="ArgumentNullException">Thrown when <paramref name="converter"/> is <see langword="null"/>.</exception>
+        /// <remarks>
+        /// This is the one that stays. The <c>ToConvert</c> overloads on the
+        /// <c>…SpecificExtensions</c> classes wrap a lambda as one of the named aliases and are
+        /// deprecated along with them.
+        /// </remarks>
         public static IConverter<TFrom?, TTo?> ToConvert<TFrom, TTo>(this Func<TFrom?, TTo?> converter) =>
             new GenericFuncConverter<TFrom, TTo>(converter);
     }

--- a/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Runtime/Converters/Numbers/ArithmeticNumberConverter.cs
+++ b/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Runtime/Converters/Numbers/ArithmeticNumberConverter.cs
@@ -2,6 +2,11 @@ using Aspid.FastTools.Types;
 using System;
 using UnityEngine;
 
+// The named converter aliases are [Obsolete]. The converters below keep implementing them for
+// one release so that a [SerializeReference] field a project declares as one still
+// deserializes; the base lists go with the aliases in the next major.
+#pragma warning disable CS0618 // Type or member is obsolete
+
 // ReSharper disable once CheckNamespace
 namespace Aspid.MVVM.StarterKit
 {

--- a/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Runtime/Converters/Numbers/ClampNumberConverter.cs
+++ b/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Runtime/Converters/Numbers/ClampNumberConverter.cs
@@ -2,6 +2,11 @@ using Aspid.FastTools.Types;
 using System;
 using UnityEngine;
 
+// The named converter aliases are [Obsolete]. The converters below keep implementing them for
+// one release so that a [SerializeReference] field a project declares as one still
+// deserializes; the base lists go with the aliases in the next major.
+#pragma warning disable CS0618 // Type or member is obsolete
+
 // ReSharper disable once CheckNamespace
 namespace Aspid.MVVM.StarterKit
 {

--- a/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Runtime/Converters/Numbers/CountdownProgressConverter.cs
+++ b/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Runtime/Converters/Numbers/CountdownProgressConverter.cs
@@ -2,6 +2,11 @@ using Aspid.FastTools.Types;
 using System;
 using UnityEngine;
 
+// The named converter aliases are [Obsolete]. The converters below keep implementing them for
+// one release so that a [SerializeReference] field a project declares as one still
+// deserializes; the base lists go with the aliases in the next major.
+#pragma warning disable CS0618 // Type or member is obsolete
+
 // ReSharper disable once CheckNamespace
 namespace Aspid.MVVM.StarterKit
 {

--- a/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Runtime/Converters/Numbers/RoundNumberConverter.cs
+++ b/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Runtime/Converters/Numbers/RoundNumberConverter.cs
@@ -2,6 +2,11 @@ using Aspid.FastTools.Types;
 using System;
 using UnityEngine;
 
+// The named converter aliases are [Obsolete]. The converters below keep implementing them for
+// one release so that a [SerializeReference] field a project declares as one still
+// deserializes; the base lists go with the aliases in the next major.
+#pragma warning disable CS0618 // Type or member is obsolete
+
 // ReSharper disable once CheckNamespace
 namespace Aspid.MVVM.StarterKit
 {

--- a/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Runtime/Converters/Numbers/SmoothStepConverter.cs
+++ b/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Runtime/Converters/Numbers/SmoothStepConverter.cs
@@ -2,6 +2,11 @@ using Aspid.FastTools.Types;
 using System;
 using UnityEngine;
 
+// The named converter aliases are [Obsolete]. The converters below keep implementing them for
+// one release so that a [SerializeReference] field a project declares as one still
+// deserializes; the base lists go with the aliases in the next major.
+#pragma warning disable CS0618 // Type or member is obsolete
+
 // ReSharper disable once CheckNamespace
 namespace Aspid.MVVM.StarterKit
 {

--- a/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Runtime/Converters/Numbers/SnapToStepConverter.cs
+++ b/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Runtime/Converters/Numbers/SnapToStepConverter.cs
@@ -2,6 +2,11 @@ using Aspid.FastTools.Types;
 using System;
 using UnityEngine;
 
+// The named converter aliases are [Obsolete]. The converters below keep implementing them for
+// one release so that a [SerializeReference] field a project declares as one still
+// deserializes; the base lists go with the aliases in the next major.
+#pragma warning disable CS0618 // Type or member is obsolete
+
 // ReSharper disable once CheckNamespace
 namespace Aspid.MVVM.StarterKit
 {

--- a/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Runtime/Converters/Numbers/UnaryMathConverter.cs
+++ b/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Runtime/Converters/Numbers/UnaryMathConverter.cs
@@ -2,6 +2,11 @@ using Aspid.FastTools.Types;
 using System;
 using UnityEngine;
 
+// The named converter aliases are [Obsolete]. The converters below keep implementing them for
+// one release so that a [SerializeReference] field a project declares as one still
+// deserializes; the base lists go with the aliases in the next major.
+#pragma warning disable CS0618 // Type or member is obsolete
+
 // ReSharper disable once CheckNamespace
 namespace Aspid.MVVM.StarterKit
 {

--- a/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Runtime/Converters/Numbers/WrapNumberConverter.cs
+++ b/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Runtime/Converters/Numbers/WrapNumberConverter.cs
@@ -2,6 +2,11 @@ using Aspid.FastTools.Types;
 using System;
 using UnityEngine;
 
+// The named converter aliases are [Obsolete]. The converters below keep implementing them for
+// one release so that a [SerializeReference] field a project declares as one still
+// deserializes; the base lists go with the aliases in the next major.
+#pragma warning disable CS0618 // Type or member is obsolete
+
 // ReSharper disable once CheckNamespace
 namespace Aspid.MVVM.StarterKit
 {

--- a/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Runtime/Converters/Specific/Bool/BoolConverterSpecificExtensions.cs
+++ b/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Runtime/Converters/Specific/Bool/BoolConverterSpecificExtensions.cs
@@ -14,6 +14,7 @@ namespace Aspid.MVVM.StarterKit
     /// Unity 2023.1 declares its field as the named interface rather than the generic one,
     /// so a lambda cannot be assigned to it directly.
     /// </remarks>
+    [Obsolete("Only needed to assign a lambda to a field typed as a named converter alias, which Unity before 2023.1 required. The package now requires Unity 6000.0, so assign the converter directly. This will be removed in the next major version.")]
     public static class BoolConverterSpecificExtensions
     {
         /// <summary>
@@ -22,6 +23,7 @@ namespace Aspid.MVVM.StarterKit
         /// <param name="converter">The function to wrap.</param>
         /// <returns>A converter of the named interface type.</returns>
         /// <exception cref="System.ArgumentNullException">Thrown when <paramref name="converter"/> is <see langword="null"/>.</exception>
+        [Obsolete("Only needed to assign a lambda to a field typed as a named converter alias, which Unity before 2023.1 required. The package now requires Unity 6000.0, so assign the converter directly. This will be removed in the next major version.")]
         public static IConverterDoubleToBool ToConvert(this Func<double, bool> converter) =>
             new ConverterDoubleToBool(converter);
         
@@ -31,6 +33,7 @@ namespace Aspid.MVVM.StarterKit
         /// <param name="converter">The converter to wrap.</param>
         /// <returns>A converter of the named interface type.</returns>
         /// <exception cref="System.ArgumentNullException">Thrown when <paramref name="converter"/> is <see langword="null"/>.</exception>
+        [Obsolete("Only needed to assign a lambda to a field typed as a named converter alias, which Unity before 2023.1 required. The package now requires Unity 6000.0, so assign the converter directly. This will be removed in the next major version.")]
         public static IConverterDoubleToBool ToConvertSpecific(this IConverter<double, bool> converter) =>
             new ConverterDoubleToBool(converter);
         
@@ -40,6 +43,7 @@ namespace Aspid.MVVM.StarterKit
         /// <param name="converter">The function to wrap.</param>
         /// <returns>A converter of the named interface type.</returns>
         /// <exception cref="System.ArgumentNullException">Thrown when <paramref name="converter"/> is <see langword="null"/>.</exception>
+        [Obsolete("Only needed to assign a lambda to a field typed as a named converter alias, which Unity before 2023.1 required. The package now requires Unity 6000.0, so assign the converter directly. This will be removed in the next major version.")]
         public static IConverterFloatToBool ToConvert(this Func<float, bool> converter) =>
             new ConverterFloatToBool(converter);
         
@@ -49,6 +53,7 @@ namespace Aspid.MVVM.StarterKit
         /// <param name="converter">The converter to wrap.</param>
         /// <returns>A converter of the named interface type.</returns>
         /// <exception cref="System.ArgumentNullException">Thrown when <paramref name="converter"/> is <see langword="null"/>.</exception>
+        [Obsolete("Only needed to assign a lambda to a field typed as a named converter alias, which Unity before 2023.1 required. The package now requires Unity 6000.0, so assign the converter directly. This will be removed in the next major version.")]
         public static IConverterFloatToBool ToConvertSpecific(this IConverter<float, bool> converter) =>
             new ConverterFloatToBool(converter);
         
@@ -58,6 +63,7 @@ namespace Aspid.MVVM.StarterKit
         /// <param name="converter">The function to wrap.</param>
         /// <returns>A converter of the named interface type.</returns>
         /// <exception cref="System.ArgumentNullException">Thrown when <paramref name="converter"/> is <see langword="null"/>.</exception>
+        [Obsolete("Only needed to assign a lambda to a field typed as a named converter alias, which Unity before 2023.1 required. The package now requires Unity 6000.0, so assign the converter directly. This will be removed in the next major version.")]
         public static IConverterIntToBool ToConvert(this Func<int, bool> converter) =>
             new ConverterIntToBool(converter);
         
@@ -67,6 +73,7 @@ namespace Aspid.MVVM.StarterKit
         /// <param name="converter">The converter to wrap.</param>
         /// <returns>A converter of the named interface type.</returns>
         /// <exception cref="System.ArgumentNullException">Thrown when <paramref name="converter"/> is <see langword="null"/>.</exception>
+        [Obsolete("Only needed to assign a lambda to a field typed as a named converter alias, which Unity before 2023.1 required. The package now requires Unity 6000.0, so assign the converter directly. This will be removed in the next major version.")]
         public static IConverterIntToBool ToConvertSpecific(this IConverter<int, bool> converter) =>
             new ConverterIntToBool(converter);
         
@@ -76,6 +83,7 @@ namespace Aspid.MVVM.StarterKit
         /// <param name="converter">The function to wrap.</param>
         /// <returns>A converter of the named interface type.</returns>
         /// <exception cref="System.ArgumentNullException">Thrown when <paramref name="converter"/> is <see langword="null"/>.</exception>
+        [Obsolete("Only needed to assign a lambda to a field typed as a named converter alias, which Unity before 2023.1 required. The package now requires Unity 6000.0, so assign the converter directly. This will be removed in the next major version.")]
         public static IConverterLongToBool ToConvert(this Func<long, bool> converter) =>
             new ConverterLongToBool(converter);
         
@@ -85,6 +93,7 @@ namespace Aspid.MVVM.StarterKit
         /// <param name="converter">The converter to wrap.</param>
         /// <returns>A converter of the named interface type.</returns>
         /// <exception cref="System.ArgumentNullException">Thrown when <paramref name="converter"/> is <see langword="null"/>.</exception>
+        [Obsolete("Only needed to assign a lambda to a field typed as a named converter alias, which Unity before 2023.1 required. The package now requires Unity 6000.0, so assign the converter directly. This will be removed in the next major version.")]
         public static IConverterLongToBool ToConvertSpecific(this IConverter<long, bool> converter) =>
             new ConverterLongToBool(converter);
         
@@ -94,6 +103,7 @@ namespace Aspid.MVVM.StarterKit
         /// <param name="converter">The function to wrap.</param>
         /// <returns>A converter of the named interface type.</returns>
         /// <exception cref="System.ArgumentNullException">Thrown when <paramref name="converter"/> is <see langword="null"/>.</exception>
+        [Obsolete("Only needed to assign a lambda to a field typed as a named converter alias, which Unity before 2023.1 required. The package now requires Unity 6000.0, so assign the converter directly. This will be removed in the next major version.")]
         public static IConverterObjectToBool ToConvert(this Func<object?, bool> converter) =>
             new ConverterObjectToBool(converter);
         
@@ -103,6 +113,7 @@ namespace Aspid.MVVM.StarterKit
         /// <param name="converter">The converter to wrap.</param>
         /// <returns>A converter of the named interface type.</returns>
         /// <exception cref="System.ArgumentNullException">Thrown when <paramref name="converter"/> is <see langword="null"/>.</exception>
+        [Obsolete("Only needed to assign a lambda to a field typed as a named converter alias, which Unity before 2023.1 required. The package now requires Unity 6000.0, so assign the converter directly. This will be removed in the next major version.")]
         public static IConverterObjectToBool ToConvertSpecific(this IConverter<object?, bool> converter) =>
             new ConverterObjectToBool(converter);
         
@@ -112,6 +123,7 @@ namespace Aspid.MVVM.StarterKit
         /// <param name="converter">The function to wrap.</param>
         /// <returns>A converter of the named interface type.</returns>
         /// <exception cref="System.ArgumentNullException">Thrown when <paramref name="converter"/> is <see langword="null"/>.</exception>
+        [Obsolete("Only needed to assign a lambda to a field typed as a named converter alias, which Unity before 2023.1 required. The package now requires Unity 6000.0, so assign the converter directly. This will be removed in the next major version.")]
         public static IConverterStringToBool ToConvert(this Func<string?, bool> converter) =>
             new ConverterStringToBool(converter);
         
@@ -121,6 +133,7 @@ namespace Aspid.MVVM.StarterKit
         /// <param name="converter">The converter to wrap.</param>
         /// <returns>A converter of the named interface type.</returns>
         /// <exception cref="System.ArgumentNullException">Thrown when <paramref name="converter"/> is <see langword="null"/>.</exception>
+        [Obsolete("Only needed to assign a lambda to a field typed as a named converter alias, which Unity before 2023.1 required. The package now requires Unity 6000.0, so assign the converter directly. This will be removed in the next major version.")]
         public static IConverterStringToBool ToConvertSpecific(this IConverter<string?, bool> converter) =>
             new ConverterStringToBool(converter);
         

--- a/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Runtime/Converters/Specific/Bool/IConverterDoubleToBool.cs
+++ b/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Runtime/Converters/Specific/Bool/IConverterDoubleToBool.cs
@@ -7,15 +7,8 @@ namespace Aspid.MVVM.StarterKit
     /// A converter from <see cref="double"/> to <see cref="bool"/>.
     /// </summary>
     /// <remarks>
-    /// A named alias for <see cref="IConverter{TFrom, TTo}"/> closed over these two types. It
-    /// existed because Unity before 2023.1 could not serialize a <c>[SerializeReference]</c> field
-    /// typed as an open generic, so a binder declared the field as this instead.
-    /// <para>
-    /// The package requires Unity 6000.0, so nothing in it declares such a field any more and this
-    /// carries no behaviour of its own. It stays one release so that code naming it keeps compiling
-    /// with a warning, and so that a <c>[SerializeReference]</c> field a project declares as this
-    /// type does not silently deserialize to <see langword="null"/>.
-    /// </para>
+    /// Kept for one release so code naming it still compiles and a <c>[SerializeReference]</c> field
+    /// a project declares as this type does not silently deserialize to <see langword="null"/>.
     /// </remarks>
     [Obsolete("Named converter aliases only existed because Unity before 2023.1 could not serialize a [SerializeReference] field of an open generic type. The package now requires Unity 6000.0, so use IConverter<double, bool> directly. This will be removed in the next major version.")]
     public interface IConverterDoubleToBool : IConverter<double, bool> { }

--- a/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Runtime/Converters/Specific/Bool/IConverterDoubleToBool.cs
+++ b/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Runtime/Converters/Specific/Bool/IConverterDoubleToBool.cs
@@ -1,3 +1,5 @@
+using System;
+
 // ReSharper disable once CheckNamespace
 namespace Aspid.MVVM.StarterKit
 {
@@ -5,10 +7,16 @@ namespace Aspid.MVVM.StarterKit
     /// A converter from <see cref="double"/> to <see cref="bool"/>.
     /// </summary>
     /// <remarks>
-    /// A named alias for <see cref="IConverter{TFrom, TTo}"/> closed over these two types.
-    /// It exists because Unity before 2023.1 cannot serialize a <c>[SerializeReference]</c>
-    /// field typed as an open generic, so a binder declares the field as this instead. From
-    /// 2023.1 the generic form is used directly and this is a compatibility shim.
+    /// A named alias for <see cref="IConverter{TFrom, TTo}"/> closed over these two types. It
+    /// existed because Unity before 2023.1 could not serialize a <c>[SerializeReference]</c> field
+    /// typed as an open generic, so a binder declared the field as this instead.
+    /// <para>
+    /// The package requires Unity 6000.0, so nothing in it declares such a field any more and this
+    /// carries no behaviour of its own. It stays one release so that code naming it keeps compiling
+    /// with a warning, and so that a <c>[SerializeReference]</c> field a project declares as this
+    /// type does not silently deserialize to <see langword="null"/>.
+    /// </para>
     /// </remarks>
+    [Obsolete("Named converter aliases only existed because Unity before 2023.1 could not serialize a [SerializeReference] field of an open generic type. The package now requires Unity 6000.0, so use IConverter<double, bool> directly. This will be removed in the next major version.")]
     public interface IConverterDoubleToBool : IConverter<double, bool> { }
 }

--- a/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Runtime/Converters/Specific/Bool/IConverterFloatToBool.cs
+++ b/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Runtime/Converters/Specific/Bool/IConverterFloatToBool.cs
@@ -7,15 +7,8 @@ namespace Aspid.MVVM.StarterKit
     /// A converter from <see cref="float"/> to <see cref="bool"/>.
     /// </summary>
     /// <remarks>
-    /// A named alias for <see cref="IConverter{TFrom, TTo}"/> closed over these two types. It
-    /// existed because Unity before 2023.1 could not serialize a <c>[SerializeReference]</c> field
-    /// typed as an open generic, so a binder declared the field as this instead.
-    /// <para>
-    /// The package requires Unity 6000.0, so nothing in it declares such a field any more and this
-    /// carries no behaviour of its own. It stays one release so that code naming it keeps compiling
-    /// with a warning, and so that a <c>[SerializeReference]</c> field a project declares as this
-    /// type does not silently deserialize to <see langword="null"/>.
-    /// </para>
+    /// Kept for one release so code naming it still compiles and a <c>[SerializeReference]</c> field
+    /// a project declares as this type does not silently deserialize to <see langword="null"/>.
     /// </remarks>
     [Obsolete("Named converter aliases only existed because Unity before 2023.1 could not serialize a [SerializeReference] field of an open generic type. The package now requires Unity 6000.0, so use IConverter<float, bool> directly. This will be removed in the next major version.")]
     public interface IConverterFloatToBool : IConverter<float, bool> { }

--- a/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Runtime/Converters/Specific/Bool/IConverterFloatToBool.cs
+++ b/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Runtime/Converters/Specific/Bool/IConverterFloatToBool.cs
@@ -1,3 +1,5 @@
+using System;
+
 // ReSharper disable once CheckNamespace
 namespace Aspid.MVVM.StarterKit
 {
@@ -5,10 +7,16 @@ namespace Aspid.MVVM.StarterKit
     /// A converter from <see cref="float"/> to <see cref="bool"/>.
     /// </summary>
     /// <remarks>
-    /// A named alias for <see cref="IConverter{TFrom, TTo}"/> closed over these two types.
-    /// It exists because Unity before 2023.1 cannot serialize a <c>[SerializeReference]</c>
-    /// field typed as an open generic, so a binder declares the field as this instead. From
-    /// 2023.1 the generic form is used directly and this is a compatibility shim.
+    /// A named alias for <see cref="IConverter{TFrom, TTo}"/> closed over these two types. It
+    /// existed because Unity before 2023.1 could not serialize a <c>[SerializeReference]</c> field
+    /// typed as an open generic, so a binder declared the field as this instead.
+    /// <para>
+    /// The package requires Unity 6000.0, so nothing in it declares such a field any more and this
+    /// carries no behaviour of its own. It stays one release so that code naming it keeps compiling
+    /// with a warning, and so that a <c>[SerializeReference]</c> field a project declares as this
+    /// type does not silently deserialize to <see langword="null"/>.
+    /// </para>
     /// </remarks>
+    [Obsolete("Named converter aliases only existed because Unity before 2023.1 could not serialize a [SerializeReference] field of an open generic type. The package now requires Unity 6000.0, so use IConverter<float, bool> directly. This will be removed in the next major version.")]
     public interface IConverterFloatToBool : IConverter<float, bool> { }
 }

--- a/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Runtime/Converters/Specific/Bool/IConverterIntToBool.cs
+++ b/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Runtime/Converters/Specific/Bool/IConverterIntToBool.cs
@@ -1,3 +1,5 @@
+using System;
+
 // ReSharper disable once CheckNamespace
 namespace Aspid.MVVM.StarterKit
 {
@@ -5,10 +7,16 @@ namespace Aspid.MVVM.StarterKit
     /// A converter from <see cref="int"/> to <see cref="bool"/>.
     /// </summary>
     /// <remarks>
-    /// A named alias for <see cref="IConverter{TFrom, TTo}"/> closed over these two types.
-    /// It exists because Unity before 2023.1 cannot serialize a <c>[SerializeReference]</c>
-    /// field typed as an open generic, so a binder declares the field as this instead. From
-    /// 2023.1 the generic form is used directly and this is a compatibility shim.
+    /// A named alias for <see cref="IConverter{TFrom, TTo}"/> closed over these two types. It
+    /// existed because Unity before 2023.1 could not serialize a <c>[SerializeReference]</c> field
+    /// typed as an open generic, so a binder declared the field as this instead.
+    /// <para>
+    /// The package requires Unity 6000.0, so nothing in it declares such a field any more and this
+    /// carries no behaviour of its own. It stays one release so that code naming it keeps compiling
+    /// with a warning, and so that a <c>[SerializeReference]</c> field a project declares as this
+    /// type does not silently deserialize to <see langword="null"/>.
+    /// </para>
     /// </remarks>
+    [Obsolete("Named converter aliases only existed because Unity before 2023.1 could not serialize a [SerializeReference] field of an open generic type. The package now requires Unity 6000.0, so use IConverter<int, bool> directly. This will be removed in the next major version.")]
     public interface IConverterIntToBool : IConverter<int, bool> { }
 }

--- a/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Runtime/Converters/Specific/Bool/IConverterIntToBool.cs
+++ b/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Runtime/Converters/Specific/Bool/IConverterIntToBool.cs
@@ -7,15 +7,8 @@ namespace Aspid.MVVM.StarterKit
     /// A converter from <see cref="int"/> to <see cref="bool"/>.
     /// </summary>
     /// <remarks>
-    /// A named alias for <see cref="IConverter{TFrom, TTo}"/> closed over these two types. It
-    /// existed because Unity before 2023.1 could not serialize a <c>[SerializeReference]</c> field
-    /// typed as an open generic, so a binder declared the field as this instead.
-    /// <para>
-    /// The package requires Unity 6000.0, so nothing in it declares such a field any more and this
-    /// carries no behaviour of its own. It stays one release so that code naming it keeps compiling
-    /// with a warning, and so that a <c>[SerializeReference]</c> field a project declares as this
-    /// type does not silently deserialize to <see langword="null"/>.
-    /// </para>
+    /// Kept for one release so code naming it still compiles and a <c>[SerializeReference]</c> field
+    /// a project declares as this type does not silently deserialize to <see langword="null"/>.
     /// </remarks>
     [Obsolete("Named converter aliases only existed because Unity before 2023.1 could not serialize a [SerializeReference] field of an open generic type. The package now requires Unity 6000.0, so use IConverter<int, bool> directly. This will be removed in the next major version.")]
     public interface IConverterIntToBool : IConverter<int, bool> { }

--- a/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Runtime/Converters/Specific/Bool/IConverterLongToBool.cs
+++ b/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Runtime/Converters/Specific/Bool/IConverterLongToBool.cs
@@ -7,15 +7,8 @@ namespace Aspid.MVVM.StarterKit
     /// A converter from <see cref="long"/> to <see cref="bool"/>.
     /// </summary>
     /// <remarks>
-    /// A named alias for <see cref="IConverter{TFrom, TTo}"/> closed over these two types. It
-    /// existed because Unity before 2023.1 could not serialize a <c>[SerializeReference]</c> field
-    /// typed as an open generic, so a binder declared the field as this instead.
-    /// <para>
-    /// The package requires Unity 6000.0, so nothing in it declares such a field any more and this
-    /// carries no behaviour of its own. It stays one release so that code naming it keeps compiling
-    /// with a warning, and so that a <c>[SerializeReference]</c> field a project declares as this
-    /// type does not silently deserialize to <see langword="null"/>.
-    /// </para>
+    /// Kept for one release so code naming it still compiles and a <c>[SerializeReference]</c> field
+    /// a project declares as this type does not silently deserialize to <see langword="null"/>.
     /// </remarks>
     [Obsolete("Named converter aliases only existed because Unity before 2023.1 could not serialize a [SerializeReference] field of an open generic type. The package now requires Unity 6000.0, so use IConverter<long, bool> directly. This will be removed in the next major version.")]
     public interface IConverterLongToBool : IConverter<long, bool> { }

--- a/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Runtime/Converters/Specific/Bool/IConverterLongToBool.cs
+++ b/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Runtime/Converters/Specific/Bool/IConverterLongToBool.cs
@@ -1,3 +1,5 @@
+using System;
+
 // ReSharper disable once CheckNamespace
 namespace Aspid.MVVM.StarterKit
 {
@@ -5,10 +7,16 @@ namespace Aspid.MVVM.StarterKit
     /// A converter from <see cref="long"/> to <see cref="bool"/>.
     /// </summary>
     /// <remarks>
-    /// A named alias for <see cref="IConverter{TFrom, TTo}"/> closed over these two types.
-    /// It exists because Unity before 2023.1 cannot serialize a <c>[SerializeReference]</c>
-    /// field typed as an open generic, so a binder declares the field as this instead. From
-    /// 2023.1 the generic form is used directly and this is a compatibility shim.
+    /// A named alias for <see cref="IConverter{TFrom, TTo}"/> closed over these two types. It
+    /// existed because Unity before 2023.1 could not serialize a <c>[SerializeReference]</c> field
+    /// typed as an open generic, so a binder declared the field as this instead.
+    /// <para>
+    /// The package requires Unity 6000.0, so nothing in it declares such a field any more and this
+    /// carries no behaviour of its own. It stays one release so that code naming it keeps compiling
+    /// with a warning, and so that a <c>[SerializeReference]</c> field a project declares as this
+    /// type does not silently deserialize to <see langword="null"/>.
+    /// </para>
     /// </remarks>
+    [Obsolete("Named converter aliases only existed because Unity before 2023.1 could not serialize a [SerializeReference] field of an open generic type. The package now requires Unity 6000.0, so use IConverter<long, bool> directly. This will be removed in the next major version.")]
     public interface IConverterLongToBool : IConverter<long, bool> { }
 }

--- a/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Runtime/Converters/Specific/Bool/IConverterObjectToBool.cs
+++ b/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Runtime/Converters/Specific/Bool/IConverterObjectToBool.cs
@@ -1,3 +1,5 @@
+using System;
+
 // ReSharper disable once CheckNamespace
 namespace Aspid.MVVM.StarterKit
 {
@@ -5,10 +7,16 @@ namespace Aspid.MVVM.StarterKit
     /// A converter from <see cref="object"/> to <see cref="bool"/>.
     /// </summary>
     /// <remarks>
-    /// A named alias for <see cref="IConverter{TFrom, TTo}"/> closed over these two types.
-    /// It exists because Unity before 2023.1 cannot serialize a <c>[SerializeReference]</c>
-    /// field typed as an open generic, so a binder declares the field as this instead. From
-    /// 2023.1 the generic form is used directly and this is a compatibility shim.
+    /// A named alias for <see cref="IConverter{TFrom, TTo}"/> closed over these two types. It
+    /// existed because Unity before 2023.1 could not serialize a <c>[SerializeReference]</c> field
+    /// typed as an open generic, so a binder declared the field as this instead.
+    /// <para>
+    /// The package requires Unity 6000.0, so nothing in it declares such a field any more and this
+    /// carries no behaviour of its own. It stays one release so that code naming it keeps compiling
+    /// with a warning, and so that a <c>[SerializeReference]</c> field a project declares as this
+    /// type does not silently deserialize to <see langword="null"/>.
+    /// </para>
     /// </remarks>
+    [Obsolete("Named converter aliases only existed because Unity before 2023.1 could not serialize a [SerializeReference] field of an open generic type. The package now requires Unity 6000.0, so use IConverter<object?, bool> directly. This will be removed in the next major version.")]
     public interface IConverterObjectToBool : IConverter<object?, bool> { }
 }

--- a/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Runtime/Converters/Specific/Bool/IConverterObjectToBool.cs
+++ b/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Runtime/Converters/Specific/Bool/IConverterObjectToBool.cs
@@ -7,15 +7,8 @@ namespace Aspid.MVVM.StarterKit
     /// A converter from <see cref="object"/> to <see cref="bool"/>.
     /// </summary>
     /// <remarks>
-    /// A named alias for <see cref="IConverter{TFrom, TTo}"/> closed over these two types. It
-    /// existed because Unity before 2023.1 could not serialize a <c>[SerializeReference]</c> field
-    /// typed as an open generic, so a binder declared the field as this instead.
-    /// <para>
-    /// The package requires Unity 6000.0, so nothing in it declares such a field any more and this
-    /// carries no behaviour of its own. It stays one release so that code naming it keeps compiling
-    /// with a warning, and so that a <c>[SerializeReference]</c> field a project declares as this
-    /// type does not silently deserialize to <see langword="null"/>.
-    /// </para>
+    /// Kept for one release so code naming it still compiles and a <c>[SerializeReference]</c> field
+    /// a project declares as this type does not silently deserialize to <see langword="null"/>.
     /// </remarks>
     [Obsolete("Named converter aliases only existed because Unity before 2023.1 could not serialize a [SerializeReference] field of an open generic type. The package now requires Unity 6000.0, so use IConverter<object?, bool> directly. This will be removed in the next major version.")]
     public interface IConverterObjectToBool : IConverter<object?, bool> { }

--- a/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Runtime/Converters/Specific/Bool/IConverterStringToBool.cs
+++ b/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Runtime/Converters/Specific/Bool/IConverterStringToBool.cs
@@ -1,3 +1,5 @@
+using System;
+
 // ReSharper disable once CheckNamespace
 namespace Aspid.MVVM.StarterKit
 {
@@ -5,10 +7,16 @@ namespace Aspid.MVVM.StarterKit
     /// A converter from <see cref="string"/> to <see cref="bool"/>.
     /// </summary>
     /// <remarks>
-    /// A named alias for <see cref="IConverter{TFrom, TTo}"/> closed over these two types.
-    /// It exists because Unity before 2023.1 cannot serialize a <c>[SerializeReference]</c>
-    /// field typed as an open generic, so a binder declares the field as this instead. From
-    /// 2023.1 the generic form is used directly and this is a compatibility shim.
+    /// A named alias for <see cref="IConverter{TFrom, TTo}"/> closed over these two types. It
+    /// existed because Unity before 2023.1 could not serialize a <c>[SerializeReference]</c> field
+    /// typed as an open generic, so a binder declared the field as this instead.
+    /// <para>
+    /// The package requires Unity 6000.0, so nothing in it declares such a field any more and this
+    /// carries no behaviour of its own. It stays one release so that code naming it keeps compiling
+    /// with a warning, and so that a <c>[SerializeReference]</c> field a project declares as this
+    /// type does not silently deserialize to <see langword="null"/>.
+    /// </para>
     /// </remarks>
+    [Obsolete("Named converter aliases only existed because Unity before 2023.1 could not serialize a [SerializeReference] field of an open generic type. The package now requires Unity 6000.0, so use IConverter<string?, bool> directly. This will be removed in the next major version.")]
     public interface IConverterStringToBool : IConverter<string?, bool> { }
 }

--- a/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Runtime/Converters/Specific/Bool/IConverterStringToBool.cs
+++ b/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Runtime/Converters/Specific/Bool/IConverterStringToBool.cs
@@ -7,15 +7,8 @@ namespace Aspid.MVVM.StarterKit
     /// A converter from <see cref="string"/> to <see cref="bool"/>.
     /// </summary>
     /// <remarks>
-    /// A named alias for <see cref="IConverter{TFrom, TTo}"/> closed over these two types. It
-    /// existed because Unity before 2023.1 could not serialize a <c>[SerializeReference]</c> field
-    /// typed as an open generic, so a binder declared the field as this instead.
-    /// <para>
-    /// The package requires Unity 6000.0, so nothing in it declares such a field any more and this
-    /// carries no behaviour of its own. It stays one release so that code naming it keeps compiling
-    /// with a warning, and so that a <c>[SerializeReference]</c> field a project declares as this
-    /// type does not silently deserialize to <see langword="null"/>.
-    /// </para>
+    /// Kept for one release so code naming it still compiles and a <c>[SerializeReference]</c> field
+    /// a project declares as this type does not silently deserialize to <see langword="null"/>.
     /// </remarks>
     [Obsolete("Named converter aliases only existed because Unity before 2023.1 could not serialize a [SerializeReference] field of an open generic type. The package now requires Unity 6000.0, so use IConverter<string?, bool> directly. This will be removed in the next major version.")]
     public interface IConverterStringToBool : IConverter<string?, bool> { }

--- a/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Runtime/Converters/Specific/Numbers/IConverterDouble.cs
+++ b/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Runtime/Converters/Specific/Numbers/IConverterDouble.cs
@@ -1,3 +1,5 @@
+using System;
+
 // ReSharper disable once CheckNamespace
 namespace Aspid.MVVM.StarterKit
 {
@@ -5,10 +7,16 @@ namespace Aspid.MVVM.StarterKit
     /// A converter from <see cref="double"/> to <see cref="double"/>.
     /// </summary>
     /// <remarks>
-    /// A named alias for <see cref="IConverter{TFrom, TTo}"/> closed over these two types.
-    /// It exists because Unity before 2023.1 cannot serialize a <c>[SerializeReference]</c>
-    /// field typed as an open generic, so a binder declares the field as this instead. From
-    /// 2023.1 the generic form is used directly and this is a compatibility shim.
+    /// A named alias for <see cref="IConverter{TFrom, TTo}"/> closed over these two types. It
+    /// existed because Unity before 2023.1 could not serialize a <c>[SerializeReference]</c> field
+    /// typed as an open generic, so a binder declared the field as this instead.
+    /// <para>
+    /// The package requires Unity 6000.0, so nothing in it declares such a field any more and this
+    /// carries no behaviour of its own. It stays one release so that code naming it keeps compiling
+    /// with a warning, and so that a <c>[SerializeReference]</c> field a project declares as this
+    /// type does not silently deserialize to <see langword="null"/>.
+    /// </para>
     /// </remarks>
+    [Obsolete("Named converter aliases only existed because Unity before 2023.1 could not serialize a [SerializeReference] field of an open generic type. The package now requires Unity 6000.0, so use IConverter<double, double> directly. This will be removed in the next major version.")]
     public interface IConverterDouble : IConverter<double, double> { }
 }

--- a/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Runtime/Converters/Specific/Numbers/IConverterDouble.cs
+++ b/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Runtime/Converters/Specific/Numbers/IConverterDouble.cs
@@ -7,15 +7,8 @@ namespace Aspid.MVVM.StarterKit
     /// A converter from <see cref="double"/> to <see cref="double"/>.
     /// </summary>
     /// <remarks>
-    /// A named alias for <see cref="IConverter{TFrom, TTo}"/> closed over these two types. It
-    /// existed because Unity before 2023.1 could not serialize a <c>[SerializeReference]</c> field
-    /// typed as an open generic, so a binder declared the field as this instead.
-    /// <para>
-    /// The package requires Unity 6000.0, so nothing in it declares such a field any more and this
-    /// carries no behaviour of its own. It stays one release so that code naming it keeps compiling
-    /// with a warning, and so that a <c>[SerializeReference]</c> field a project declares as this
-    /// type does not silently deserialize to <see langword="null"/>.
-    /// </para>
+    /// Kept for one release so code naming it still compiles and a <c>[SerializeReference]</c> field
+    /// a project declares as this type does not silently deserialize to <see langword="null"/>.
     /// </remarks>
     [Obsolete("Named converter aliases only existed because Unity before 2023.1 could not serialize a [SerializeReference] field of an open generic type. The package now requires Unity 6000.0, so use IConverter<double, double> directly. This will be removed in the next major version.")]
     public interface IConverterDouble : IConverter<double, double> { }

--- a/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Runtime/Converters/Specific/Numbers/IConverterDoubleToFloat.cs
+++ b/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Runtime/Converters/Specific/Numbers/IConverterDoubleToFloat.cs
@@ -1,3 +1,5 @@
+using System;
+
 // ReSharper disable once CheckNamespace
 namespace Aspid.MVVM.StarterKit
 {
@@ -5,10 +7,16 @@ namespace Aspid.MVVM.StarterKit
     /// A converter from <see cref="double"/> to <see cref="float"/>.
     /// </summary>
     /// <remarks>
-    /// A named alias for <see cref="IConverter{TFrom, TTo}"/> closed over these two types.
-    /// It exists because Unity before 2023.1 cannot serialize a <c>[SerializeReference]</c>
-    /// field typed as an open generic, so a binder declares the field as this instead. From
-    /// 2023.1 the generic form is used directly and this is a compatibility shim.
+    /// A named alias for <see cref="IConverter{TFrom, TTo}"/> closed over these two types. It
+    /// existed because Unity before 2023.1 could not serialize a <c>[SerializeReference]</c> field
+    /// typed as an open generic, so a binder declared the field as this instead.
+    /// <para>
+    /// The package requires Unity 6000.0, so nothing in it declares such a field any more and this
+    /// carries no behaviour of its own. It stays one release so that code naming it keeps compiling
+    /// with a warning, and so that a <c>[SerializeReference]</c> field a project declares as this
+    /// type does not silently deserialize to <see langword="null"/>.
+    /// </para>
     /// </remarks>
+    [Obsolete("Named converter aliases only existed because Unity before 2023.1 could not serialize a [SerializeReference] field of an open generic type. The package now requires Unity 6000.0, so use IConverter<double, float> directly. This will be removed in the next major version.")]
     public interface IConverterDoubleToFloat : IConverter<double, float> { }
 }

--- a/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Runtime/Converters/Specific/Numbers/IConverterDoubleToFloat.cs
+++ b/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Runtime/Converters/Specific/Numbers/IConverterDoubleToFloat.cs
@@ -7,15 +7,8 @@ namespace Aspid.MVVM.StarterKit
     /// A converter from <see cref="double"/> to <see cref="float"/>.
     /// </summary>
     /// <remarks>
-    /// A named alias for <see cref="IConverter{TFrom, TTo}"/> closed over these two types. It
-    /// existed because Unity before 2023.1 could not serialize a <c>[SerializeReference]</c> field
-    /// typed as an open generic, so a binder declared the field as this instead.
-    /// <para>
-    /// The package requires Unity 6000.0, so nothing in it declares such a field any more and this
-    /// carries no behaviour of its own. It stays one release so that code naming it keeps compiling
-    /// with a warning, and so that a <c>[SerializeReference]</c> field a project declares as this
-    /// type does not silently deserialize to <see langword="null"/>.
-    /// </para>
+    /// Kept for one release so code naming it still compiles and a <c>[SerializeReference]</c> field
+    /// a project declares as this type does not silently deserialize to <see langword="null"/>.
     /// </remarks>
     [Obsolete("Named converter aliases only existed because Unity before 2023.1 could not serialize a [SerializeReference] field of an open generic type. The package now requires Unity 6000.0, so use IConverter<double, float> directly. This will be removed in the next major version.")]
     public interface IConverterDoubleToFloat : IConverter<double, float> { }

--- a/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Runtime/Converters/Specific/Numbers/IConverterDoubleToInt.cs
+++ b/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Runtime/Converters/Specific/Numbers/IConverterDoubleToInt.cs
@@ -7,15 +7,8 @@ namespace Aspid.MVVM.StarterKit
     /// A converter from <see cref="double"/> to <see cref="int"/>.
     /// </summary>
     /// <remarks>
-    /// A named alias for <see cref="IConverter{TFrom, TTo}"/> closed over these two types. It
-    /// existed because Unity before 2023.1 could not serialize a <c>[SerializeReference]</c> field
-    /// typed as an open generic, so a binder declared the field as this instead.
-    /// <para>
-    /// The package requires Unity 6000.0, so nothing in it declares such a field any more and this
-    /// carries no behaviour of its own. It stays one release so that code naming it keeps compiling
-    /// with a warning, and so that a <c>[SerializeReference]</c> field a project declares as this
-    /// type does not silently deserialize to <see langword="null"/>.
-    /// </para>
+    /// Kept for one release so code naming it still compiles and a <c>[SerializeReference]</c> field
+    /// a project declares as this type does not silently deserialize to <see langword="null"/>.
     /// </remarks>
     [Obsolete("Named converter aliases only existed because Unity before 2023.1 could not serialize a [SerializeReference] field of an open generic type. The package now requires Unity 6000.0, so use IConverter<double, int> directly. This will be removed in the next major version.")]
     public interface IConverterDoubleToInt : IConverter<double, int> { }

--- a/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Runtime/Converters/Specific/Numbers/IConverterDoubleToInt.cs
+++ b/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Runtime/Converters/Specific/Numbers/IConverterDoubleToInt.cs
@@ -1,3 +1,5 @@
+using System;
+
 // ReSharper disable once CheckNamespace
 namespace Aspid.MVVM.StarterKit
 {
@@ -5,10 +7,16 @@ namespace Aspid.MVVM.StarterKit
     /// A converter from <see cref="double"/> to <see cref="int"/>.
     /// </summary>
     /// <remarks>
-    /// A named alias for <see cref="IConverter{TFrom, TTo}"/> closed over these two types.
-    /// It exists because Unity before 2023.1 cannot serialize a <c>[SerializeReference]</c>
-    /// field typed as an open generic, so a binder declares the field as this instead. From
-    /// 2023.1 the generic form is used directly and this is a compatibility shim.
+    /// A named alias for <see cref="IConverter{TFrom, TTo}"/> closed over these two types. It
+    /// existed because Unity before 2023.1 could not serialize a <c>[SerializeReference]</c> field
+    /// typed as an open generic, so a binder declared the field as this instead.
+    /// <para>
+    /// The package requires Unity 6000.0, so nothing in it declares such a field any more and this
+    /// carries no behaviour of its own. It stays one release so that code naming it keeps compiling
+    /// with a warning, and so that a <c>[SerializeReference]</c> field a project declares as this
+    /// type does not silently deserialize to <see langword="null"/>.
+    /// </para>
     /// </remarks>
+    [Obsolete("Named converter aliases only existed because Unity before 2023.1 could not serialize a [SerializeReference] field of an open generic type. The package now requires Unity 6000.0, so use IConverter<double, int> directly. This will be removed in the next major version.")]
     public interface IConverterDoubleToInt : IConverter<double, int> { }
 }

--- a/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Runtime/Converters/Specific/Numbers/IConverterDoubleToLong.cs
+++ b/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Runtime/Converters/Specific/Numbers/IConverterDoubleToLong.cs
@@ -7,15 +7,8 @@ namespace Aspid.MVVM.StarterKit
     /// A converter from <see cref="double"/> to <see cref="long"/>.
     /// </summary>
     /// <remarks>
-    /// A named alias for <see cref="IConverter{TFrom, TTo}"/> closed over these two types. It
-    /// existed because Unity before 2023.1 could not serialize a <c>[SerializeReference]</c> field
-    /// typed as an open generic, so a binder declared the field as this instead.
-    /// <para>
-    /// The package requires Unity 6000.0, so nothing in it declares such a field any more and this
-    /// carries no behaviour of its own. It stays one release so that code naming it keeps compiling
-    /// with a warning, and so that a <c>[SerializeReference]</c> field a project declares as this
-    /// type does not silently deserialize to <see langword="null"/>.
-    /// </para>
+    /// Kept for one release so code naming it still compiles and a <c>[SerializeReference]</c> field
+    /// a project declares as this type does not silently deserialize to <see langword="null"/>.
     /// </remarks>
     [Obsolete("Named converter aliases only existed because Unity before 2023.1 could not serialize a [SerializeReference] field of an open generic type. The package now requires Unity 6000.0, so use IConverter<double, long> directly. This will be removed in the next major version.")]
     public interface IConverterDoubleToLong : IConverter<double, long> { }

--- a/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Runtime/Converters/Specific/Numbers/IConverterDoubleToLong.cs
+++ b/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Runtime/Converters/Specific/Numbers/IConverterDoubleToLong.cs
@@ -1,3 +1,5 @@
+using System;
+
 // ReSharper disable once CheckNamespace
 namespace Aspid.MVVM.StarterKit
 {
@@ -5,10 +7,16 @@ namespace Aspid.MVVM.StarterKit
     /// A converter from <see cref="double"/> to <see cref="long"/>.
     /// </summary>
     /// <remarks>
-    /// A named alias for <see cref="IConverter{TFrom, TTo}"/> closed over these two types.
-    /// It exists because Unity before 2023.1 cannot serialize a <c>[SerializeReference]</c>
-    /// field typed as an open generic, so a binder declares the field as this instead. From
-    /// 2023.1 the generic form is used directly and this is a compatibility shim.
+    /// A named alias for <see cref="IConverter{TFrom, TTo}"/> closed over these two types. It
+    /// existed because Unity before 2023.1 could not serialize a <c>[SerializeReference]</c> field
+    /// typed as an open generic, so a binder declared the field as this instead.
+    /// <para>
+    /// The package requires Unity 6000.0, so nothing in it declares such a field any more and this
+    /// carries no behaviour of its own. It stays one release so that code naming it keeps compiling
+    /// with a warning, and so that a <c>[SerializeReference]</c> field a project declares as this
+    /// type does not silently deserialize to <see langword="null"/>.
+    /// </para>
     /// </remarks>
+    [Obsolete("Named converter aliases only existed because Unity before 2023.1 could not serialize a [SerializeReference] field of an open generic type. The package now requires Unity 6000.0, so use IConverter<double, long> directly. This will be removed in the next major version.")]
     public interface IConverterDoubleToLong : IConverter<double, long> { }
 }

--- a/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Runtime/Converters/Specific/Numbers/IConverterFloat.cs
+++ b/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Runtime/Converters/Specific/Numbers/IConverterFloat.cs
@@ -7,15 +7,8 @@ namespace Aspid.MVVM.StarterKit
     /// A converter from <see cref="float"/> to <see cref="float"/>.
     /// </summary>
     /// <remarks>
-    /// A named alias for <see cref="IConverter{TFrom, TTo}"/> closed over these two types. It
-    /// existed because Unity before 2023.1 could not serialize a <c>[SerializeReference]</c> field
-    /// typed as an open generic, so a binder declared the field as this instead.
-    /// <para>
-    /// The package requires Unity 6000.0, so nothing in it declares such a field any more and this
-    /// carries no behaviour of its own. It stays one release so that code naming it keeps compiling
-    /// with a warning, and so that a <c>[SerializeReference]</c> field a project declares as this
-    /// type does not silently deserialize to <see langword="null"/>.
-    /// </para>
+    /// Kept for one release so code naming it still compiles and a <c>[SerializeReference]</c> field
+    /// a project declares as this type does not silently deserialize to <see langword="null"/>.
     /// </remarks>
     [Obsolete("Named converter aliases only existed because Unity before 2023.1 could not serialize a [SerializeReference] field of an open generic type. The package now requires Unity 6000.0, so use IConverter<float, float> directly. This will be removed in the next major version.")]
     public interface IConverterFloat : IConverter<float, float> { }

--- a/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Runtime/Converters/Specific/Numbers/IConverterFloat.cs
+++ b/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Runtime/Converters/Specific/Numbers/IConverterFloat.cs
@@ -1,3 +1,5 @@
+using System;
+
 // ReSharper disable once CheckNamespace
 namespace Aspid.MVVM.StarterKit
 {
@@ -5,10 +7,16 @@ namespace Aspid.MVVM.StarterKit
     /// A converter from <see cref="float"/> to <see cref="float"/>.
     /// </summary>
     /// <remarks>
-    /// A named alias for <see cref="IConverter{TFrom, TTo}"/> closed over these two types.
-    /// It exists because Unity before 2023.1 cannot serialize a <c>[SerializeReference]</c>
-    /// field typed as an open generic, so a binder declares the field as this instead. From
-    /// 2023.1 the generic form is used directly and this is a compatibility shim.
+    /// A named alias for <see cref="IConverter{TFrom, TTo}"/> closed over these two types. It
+    /// existed because Unity before 2023.1 could not serialize a <c>[SerializeReference]</c> field
+    /// typed as an open generic, so a binder declared the field as this instead.
+    /// <para>
+    /// The package requires Unity 6000.0, so nothing in it declares such a field any more and this
+    /// carries no behaviour of its own. It stays one release so that code naming it keeps compiling
+    /// with a warning, and so that a <c>[SerializeReference]</c> field a project declares as this
+    /// type does not silently deserialize to <see langword="null"/>.
+    /// </para>
     /// </remarks>
+    [Obsolete("Named converter aliases only existed because Unity before 2023.1 could not serialize a [SerializeReference] field of an open generic type. The package now requires Unity 6000.0, so use IConverter<float, float> directly. This will be removed in the next major version.")]
     public interface IConverterFloat : IConverter<float, float> { }
 }

--- a/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Runtime/Converters/Specific/Numbers/IConverterFloatToDouble.cs
+++ b/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Runtime/Converters/Specific/Numbers/IConverterFloatToDouble.cs
@@ -1,3 +1,5 @@
+using System;
+
 // ReSharper disable once CheckNamespace
 namespace Aspid.MVVM.StarterKit
 {
@@ -5,10 +7,16 @@ namespace Aspid.MVVM.StarterKit
     /// A converter from <see cref="float"/> to <see cref="double"/>.
     /// </summary>
     /// <remarks>
-    /// A named alias for <see cref="IConverter{TFrom, TTo}"/> closed over these two types.
-    /// It exists because Unity before 2023.1 cannot serialize a <c>[SerializeReference]</c>
-    /// field typed as an open generic, so a binder declares the field as this instead. From
-    /// 2023.1 the generic form is used directly and this is a compatibility shim.
+    /// A named alias for <see cref="IConverter{TFrom, TTo}"/> closed over these two types. It
+    /// existed because Unity before 2023.1 could not serialize a <c>[SerializeReference]</c> field
+    /// typed as an open generic, so a binder declared the field as this instead.
+    /// <para>
+    /// The package requires Unity 6000.0, so nothing in it declares such a field any more and this
+    /// carries no behaviour of its own. It stays one release so that code naming it keeps compiling
+    /// with a warning, and so that a <c>[SerializeReference]</c> field a project declares as this
+    /// type does not silently deserialize to <see langword="null"/>.
+    /// </para>
     /// </remarks>
+    [Obsolete("Named converter aliases only existed because Unity before 2023.1 could not serialize a [SerializeReference] field of an open generic type. The package now requires Unity 6000.0, so use IConverter<float, double> directly. This will be removed in the next major version.")]
     public interface IConverterFloatToDouble : IConverter<float, double> { }
 }

--- a/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Runtime/Converters/Specific/Numbers/IConverterFloatToDouble.cs
+++ b/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Runtime/Converters/Specific/Numbers/IConverterFloatToDouble.cs
@@ -7,15 +7,8 @@ namespace Aspid.MVVM.StarterKit
     /// A converter from <see cref="float"/> to <see cref="double"/>.
     /// </summary>
     /// <remarks>
-    /// A named alias for <see cref="IConverter{TFrom, TTo}"/> closed over these two types. It
-    /// existed because Unity before 2023.1 could not serialize a <c>[SerializeReference]</c> field
-    /// typed as an open generic, so a binder declared the field as this instead.
-    /// <para>
-    /// The package requires Unity 6000.0, so nothing in it declares such a field any more and this
-    /// carries no behaviour of its own. It stays one release so that code naming it keeps compiling
-    /// with a warning, and so that a <c>[SerializeReference]</c> field a project declares as this
-    /// type does not silently deserialize to <see langword="null"/>.
-    /// </para>
+    /// Kept for one release so code naming it still compiles and a <c>[SerializeReference]</c> field
+    /// a project declares as this type does not silently deserialize to <see langword="null"/>.
     /// </remarks>
     [Obsolete("Named converter aliases only existed because Unity before 2023.1 could not serialize a [SerializeReference] field of an open generic type. The package now requires Unity 6000.0, so use IConverter<float, double> directly. This will be removed in the next major version.")]
     public interface IConverterFloatToDouble : IConverter<float, double> { }

--- a/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Runtime/Converters/Specific/Numbers/IConverterFloatToInt.cs
+++ b/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Runtime/Converters/Specific/Numbers/IConverterFloatToInt.cs
@@ -7,15 +7,8 @@ namespace Aspid.MVVM.StarterKit
     /// A converter from <see cref="float"/> to <see cref="int"/>.
     /// </summary>
     /// <remarks>
-    /// A named alias for <see cref="IConverter{TFrom, TTo}"/> closed over these two types. It
-    /// existed because Unity before 2023.1 could not serialize a <c>[SerializeReference]</c> field
-    /// typed as an open generic, so a binder declared the field as this instead.
-    /// <para>
-    /// The package requires Unity 6000.0, so nothing in it declares such a field any more and this
-    /// carries no behaviour of its own. It stays one release so that code naming it keeps compiling
-    /// with a warning, and so that a <c>[SerializeReference]</c> field a project declares as this
-    /// type does not silently deserialize to <see langword="null"/>.
-    /// </para>
+    /// Kept for one release so code naming it still compiles and a <c>[SerializeReference]</c> field
+    /// a project declares as this type does not silently deserialize to <see langword="null"/>.
     /// </remarks>
     [Obsolete("Named converter aliases only existed because Unity before 2023.1 could not serialize a [SerializeReference] field of an open generic type. The package now requires Unity 6000.0, so use IConverter<float, int> directly. This will be removed in the next major version.")]
     public interface IConverterFloatToInt : IConverter<float, int> { }

--- a/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Runtime/Converters/Specific/Numbers/IConverterFloatToInt.cs
+++ b/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Runtime/Converters/Specific/Numbers/IConverterFloatToInt.cs
@@ -1,3 +1,5 @@
+using System;
+
 // ReSharper disable once CheckNamespace
 namespace Aspid.MVVM.StarterKit
 {
@@ -5,10 +7,16 @@ namespace Aspid.MVVM.StarterKit
     /// A converter from <see cref="float"/> to <see cref="int"/>.
     /// </summary>
     /// <remarks>
-    /// A named alias for <see cref="IConverter{TFrom, TTo}"/> closed over these two types.
-    /// It exists because Unity before 2023.1 cannot serialize a <c>[SerializeReference]</c>
-    /// field typed as an open generic, so a binder declares the field as this instead. From
-    /// 2023.1 the generic form is used directly and this is a compatibility shim.
+    /// A named alias for <see cref="IConverter{TFrom, TTo}"/> closed over these two types. It
+    /// existed because Unity before 2023.1 could not serialize a <c>[SerializeReference]</c> field
+    /// typed as an open generic, so a binder declared the field as this instead.
+    /// <para>
+    /// The package requires Unity 6000.0, so nothing in it declares such a field any more and this
+    /// carries no behaviour of its own. It stays one release so that code naming it keeps compiling
+    /// with a warning, and so that a <c>[SerializeReference]</c> field a project declares as this
+    /// type does not silently deserialize to <see langword="null"/>.
+    /// </para>
     /// </remarks>
+    [Obsolete("Named converter aliases only existed because Unity before 2023.1 could not serialize a [SerializeReference] field of an open generic type. The package now requires Unity 6000.0, so use IConverter<float, int> directly. This will be removed in the next major version.")]
     public interface IConverterFloatToInt : IConverter<float, int> { }
 }

--- a/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Runtime/Converters/Specific/Numbers/IConverterFloatToLong.cs
+++ b/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Runtime/Converters/Specific/Numbers/IConverterFloatToLong.cs
@@ -7,15 +7,8 @@ namespace Aspid.MVVM.StarterKit
     /// A converter from <see cref="float"/> to <see cref="long"/>.
     /// </summary>
     /// <remarks>
-    /// A named alias for <see cref="IConverter{TFrom, TTo}"/> closed over these two types. It
-    /// existed because Unity before 2023.1 could not serialize a <c>[SerializeReference]</c> field
-    /// typed as an open generic, so a binder declared the field as this instead.
-    /// <para>
-    /// The package requires Unity 6000.0, so nothing in it declares such a field any more and this
-    /// carries no behaviour of its own. It stays one release so that code naming it keeps compiling
-    /// with a warning, and so that a <c>[SerializeReference]</c> field a project declares as this
-    /// type does not silently deserialize to <see langword="null"/>.
-    /// </para>
+    /// Kept for one release so code naming it still compiles and a <c>[SerializeReference]</c> field
+    /// a project declares as this type does not silently deserialize to <see langword="null"/>.
     /// </remarks>
     [Obsolete("Named converter aliases only existed because Unity before 2023.1 could not serialize a [SerializeReference] field of an open generic type. The package now requires Unity 6000.0, so use IConverter<float, long> directly. This will be removed in the next major version.")]
     public interface IConverterFloatToLong : IConverter<float, long> { }

--- a/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Runtime/Converters/Specific/Numbers/IConverterFloatToLong.cs
+++ b/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Runtime/Converters/Specific/Numbers/IConverterFloatToLong.cs
@@ -1,3 +1,5 @@
+using System;
+
 // ReSharper disable once CheckNamespace
 namespace Aspid.MVVM.StarterKit
 {
@@ -5,10 +7,16 @@ namespace Aspid.MVVM.StarterKit
     /// A converter from <see cref="float"/> to <see cref="long"/>.
     /// </summary>
     /// <remarks>
-    /// A named alias for <see cref="IConverter{TFrom, TTo}"/> closed over these two types.
-    /// It exists because Unity before 2023.1 cannot serialize a <c>[SerializeReference]</c>
-    /// field typed as an open generic, so a binder declares the field as this instead. From
-    /// 2023.1 the generic form is used directly and this is a compatibility shim.
+    /// A named alias for <see cref="IConverter{TFrom, TTo}"/> closed over these two types. It
+    /// existed because Unity before 2023.1 could not serialize a <c>[SerializeReference]</c> field
+    /// typed as an open generic, so a binder declared the field as this instead.
+    /// <para>
+    /// The package requires Unity 6000.0, so nothing in it declares such a field any more and this
+    /// carries no behaviour of its own. It stays one release so that code naming it keeps compiling
+    /// with a warning, and so that a <c>[SerializeReference]</c> field a project declares as this
+    /// type does not silently deserialize to <see langword="null"/>.
+    /// </para>
     /// </remarks>
+    [Obsolete("Named converter aliases only existed because Unity before 2023.1 could not serialize a [SerializeReference] field of an open generic type. The package now requires Unity 6000.0, so use IConverter<float, long> directly. This will be removed in the next major version.")]
     public interface IConverterFloatToLong : IConverter<float, long> { }
 }

--- a/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Runtime/Converters/Specific/Numbers/IConverterInt.cs
+++ b/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Runtime/Converters/Specific/Numbers/IConverterInt.cs
@@ -7,15 +7,8 @@ namespace Aspid.MVVM.StarterKit
     /// A converter from <see cref="int"/> to <see cref="int"/>.
     /// </summary>
     /// <remarks>
-    /// A named alias for <see cref="IConverter{TFrom, TTo}"/> closed over these two types. It
-    /// existed because Unity before 2023.1 could not serialize a <c>[SerializeReference]</c> field
-    /// typed as an open generic, so a binder declared the field as this instead.
-    /// <para>
-    /// The package requires Unity 6000.0, so nothing in it declares such a field any more and this
-    /// carries no behaviour of its own. It stays one release so that code naming it keeps compiling
-    /// with a warning, and so that a <c>[SerializeReference]</c> field a project declares as this
-    /// type does not silently deserialize to <see langword="null"/>.
-    /// </para>
+    /// Kept for one release so code naming it still compiles and a <c>[SerializeReference]</c> field
+    /// a project declares as this type does not silently deserialize to <see langword="null"/>.
     /// </remarks>
     [Obsolete("Named converter aliases only existed because Unity before 2023.1 could not serialize a [SerializeReference] field of an open generic type. The package now requires Unity 6000.0, so use IConverter<int, int> directly. This will be removed in the next major version.")]
     public interface IConverterInt : IConverter<int, int> { }

--- a/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Runtime/Converters/Specific/Numbers/IConverterInt.cs
+++ b/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Runtime/Converters/Specific/Numbers/IConverterInt.cs
@@ -1,3 +1,5 @@
+using System;
+
 // ReSharper disable once CheckNamespace
 namespace Aspid.MVVM.StarterKit
 {
@@ -5,10 +7,16 @@ namespace Aspid.MVVM.StarterKit
     /// A converter from <see cref="int"/> to <see cref="int"/>.
     /// </summary>
     /// <remarks>
-    /// A named alias for <see cref="IConverter{TFrom, TTo}"/> closed over these two types.
-    /// It exists because Unity before 2023.1 cannot serialize a <c>[SerializeReference]</c>
-    /// field typed as an open generic, so a binder declares the field as this instead. From
-    /// 2023.1 the generic form is used directly and this is a compatibility shim.
+    /// A named alias for <see cref="IConverter{TFrom, TTo}"/> closed over these two types. It
+    /// existed because Unity before 2023.1 could not serialize a <c>[SerializeReference]</c> field
+    /// typed as an open generic, so a binder declared the field as this instead.
+    /// <para>
+    /// The package requires Unity 6000.0, so nothing in it declares such a field any more and this
+    /// carries no behaviour of its own. It stays one release so that code naming it keeps compiling
+    /// with a warning, and so that a <c>[SerializeReference]</c> field a project declares as this
+    /// type does not silently deserialize to <see langword="null"/>.
+    /// </para>
     /// </remarks>
+    [Obsolete("Named converter aliases only existed because Unity before 2023.1 could not serialize a [SerializeReference] field of an open generic type. The package now requires Unity 6000.0, so use IConverter<int, int> directly. This will be removed in the next major version.")]
     public interface IConverterInt : IConverter<int, int> { }
 }

--- a/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Runtime/Converters/Specific/Numbers/IConverterIntToDouble.cs
+++ b/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Runtime/Converters/Specific/Numbers/IConverterIntToDouble.cs
@@ -7,15 +7,8 @@ namespace Aspid.MVVM.StarterKit
     /// A converter from <see cref="int"/> to <see cref="double"/>.
     /// </summary>
     /// <remarks>
-    /// A named alias for <see cref="IConverter{TFrom, TTo}"/> closed over these two types. It
-    /// existed because Unity before 2023.1 could not serialize a <c>[SerializeReference]</c> field
-    /// typed as an open generic, so a binder declared the field as this instead.
-    /// <para>
-    /// The package requires Unity 6000.0, so nothing in it declares such a field any more and this
-    /// carries no behaviour of its own. It stays one release so that code naming it keeps compiling
-    /// with a warning, and so that a <c>[SerializeReference]</c> field a project declares as this
-    /// type does not silently deserialize to <see langword="null"/>.
-    /// </para>
+    /// Kept for one release so code naming it still compiles and a <c>[SerializeReference]</c> field
+    /// a project declares as this type does not silently deserialize to <see langword="null"/>.
     /// </remarks>
     [Obsolete("Named converter aliases only existed because Unity before 2023.1 could not serialize a [SerializeReference] field of an open generic type. The package now requires Unity 6000.0, so use IConverter<int, double> directly. This will be removed in the next major version.")]
     public interface IConverterIntToDouble : IConverter<int, double> { }

--- a/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Runtime/Converters/Specific/Numbers/IConverterIntToDouble.cs
+++ b/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Runtime/Converters/Specific/Numbers/IConverterIntToDouble.cs
@@ -1,3 +1,5 @@
+using System;
+
 // ReSharper disable once CheckNamespace
 namespace Aspid.MVVM.StarterKit
 {
@@ -5,10 +7,16 @@ namespace Aspid.MVVM.StarterKit
     /// A converter from <see cref="int"/> to <see cref="double"/>.
     /// </summary>
     /// <remarks>
-    /// A named alias for <see cref="IConverter{TFrom, TTo}"/> closed over these two types.
-    /// It exists because Unity before 2023.1 cannot serialize a <c>[SerializeReference]</c>
-    /// field typed as an open generic, so a binder declares the field as this instead. From
-    /// 2023.1 the generic form is used directly and this is a compatibility shim.
+    /// A named alias for <see cref="IConverter{TFrom, TTo}"/> closed over these two types. It
+    /// existed because Unity before 2023.1 could not serialize a <c>[SerializeReference]</c> field
+    /// typed as an open generic, so a binder declared the field as this instead.
+    /// <para>
+    /// The package requires Unity 6000.0, so nothing in it declares such a field any more and this
+    /// carries no behaviour of its own. It stays one release so that code naming it keeps compiling
+    /// with a warning, and so that a <c>[SerializeReference]</c> field a project declares as this
+    /// type does not silently deserialize to <see langword="null"/>.
+    /// </para>
     /// </remarks>
+    [Obsolete("Named converter aliases only existed because Unity before 2023.1 could not serialize a [SerializeReference] field of an open generic type. The package now requires Unity 6000.0, so use IConverter<int, double> directly. This will be removed in the next major version.")]
     public interface IConverterIntToDouble : IConverter<int, double> { }
 }

--- a/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Runtime/Converters/Specific/Numbers/IConverterIntToFloat.cs
+++ b/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Runtime/Converters/Specific/Numbers/IConverterIntToFloat.cs
@@ -1,3 +1,5 @@
+using System;
+
 // ReSharper disable once CheckNamespace
 namespace Aspid.MVVM.StarterKit
 {
@@ -5,10 +7,16 @@ namespace Aspid.MVVM.StarterKit
     /// A converter from <see cref="int"/> to <see cref="float"/>.
     /// </summary>
     /// <remarks>
-    /// A named alias for <see cref="IConverter{TFrom, TTo}"/> closed over these two types.
-    /// It exists because Unity before 2023.1 cannot serialize a <c>[SerializeReference]</c>
-    /// field typed as an open generic, so a binder declares the field as this instead. From
-    /// 2023.1 the generic form is used directly and this is a compatibility shim.
+    /// A named alias for <see cref="IConverter{TFrom, TTo}"/> closed over these two types. It
+    /// existed because Unity before 2023.1 could not serialize a <c>[SerializeReference]</c> field
+    /// typed as an open generic, so a binder declared the field as this instead.
+    /// <para>
+    /// The package requires Unity 6000.0, so nothing in it declares such a field any more and this
+    /// carries no behaviour of its own. It stays one release so that code naming it keeps compiling
+    /// with a warning, and so that a <c>[SerializeReference]</c> field a project declares as this
+    /// type does not silently deserialize to <see langword="null"/>.
+    /// </para>
     /// </remarks>
+    [Obsolete("Named converter aliases only existed because Unity before 2023.1 could not serialize a [SerializeReference] field of an open generic type. The package now requires Unity 6000.0, so use IConverter<int, float> directly. This will be removed in the next major version.")]
     public interface IConverterIntToFloat : IConverter<int, float> { }
 }

--- a/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Runtime/Converters/Specific/Numbers/IConverterIntToFloat.cs
+++ b/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Runtime/Converters/Specific/Numbers/IConverterIntToFloat.cs
@@ -7,15 +7,8 @@ namespace Aspid.MVVM.StarterKit
     /// A converter from <see cref="int"/> to <see cref="float"/>.
     /// </summary>
     /// <remarks>
-    /// A named alias for <see cref="IConverter{TFrom, TTo}"/> closed over these two types. It
-    /// existed because Unity before 2023.1 could not serialize a <c>[SerializeReference]</c> field
-    /// typed as an open generic, so a binder declared the field as this instead.
-    /// <para>
-    /// The package requires Unity 6000.0, so nothing in it declares such a field any more and this
-    /// carries no behaviour of its own. It stays one release so that code naming it keeps compiling
-    /// with a warning, and so that a <c>[SerializeReference]</c> field a project declares as this
-    /// type does not silently deserialize to <see langword="null"/>.
-    /// </para>
+    /// Kept for one release so code naming it still compiles and a <c>[SerializeReference]</c> field
+    /// a project declares as this type does not silently deserialize to <see langword="null"/>.
     /// </remarks>
     [Obsolete("Named converter aliases only existed because Unity before 2023.1 could not serialize a [SerializeReference] field of an open generic type. The package now requires Unity 6000.0, so use IConverter<int, float> directly. This will be removed in the next major version.")]
     public interface IConverterIntToFloat : IConverter<int, float> { }

--- a/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Runtime/Converters/Specific/Numbers/IConverterIntToLong.cs
+++ b/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Runtime/Converters/Specific/Numbers/IConverterIntToLong.cs
@@ -7,15 +7,8 @@ namespace Aspid.MVVM.StarterKit
     /// A converter from <see cref="int"/> to <see cref="long"/>.
     /// </summary>
     /// <remarks>
-    /// A named alias for <see cref="IConverter{TFrom, TTo}"/> closed over these two types. It
-    /// existed because Unity before 2023.1 could not serialize a <c>[SerializeReference]</c> field
-    /// typed as an open generic, so a binder declared the field as this instead.
-    /// <para>
-    /// The package requires Unity 6000.0, so nothing in it declares such a field any more and this
-    /// carries no behaviour of its own. It stays one release so that code naming it keeps compiling
-    /// with a warning, and so that a <c>[SerializeReference]</c> field a project declares as this
-    /// type does not silently deserialize to <see langword="null"/>.
-    /// </para>
+    /// Kept for one release so code naming it still compiles and a <c>[SerializeReference]</c> field
+    /// a project declares as this type does not silently deserialize to <see langword="null"/>.
     /// </remarks>
     [Obsolete("Named converter aliases only existed because Unity before 2023.1 could not serialize a [SerializeReference] field of an open generic type. The package now requires Unity 6000.0, so use IConverter<int, long> directly. This will be removed in the next major version.")]
     public interface IConverterIntToLong : IConverter<int, long> { }

--- a/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Runtime/Converters/Specific/Numbers/IConverterIntToLong.cs
+++ b/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Runtime/Converters/Specific/Numbers/IConverterIntToLong.cs
@@ -1,3 +1,5 @@
+using System;
+
 // ReSharper disable once CheckNamespace
 namespace Aspid.MVVM.StarterKit
 {
@@ -5,10 +7,16 @@ namespace Aspid.MVVM.StarterKit
     /// A converter from <see cref="int"/> to <see cref="long"/>.
     /// </summary>
     /// <remarks>
-    /// A named alias for <see cref="IConverter{TFrom, TTo}"/> closed over these two types.
-    /// It exists because Unity before 2023.1 cannot serialize a <c>[SerializeReference]</c>
-    /// field typed as an open generic, so a binder declares the field as this instead. From
-    /// 2023.1 the generic form is used directly and this is a compatibility shim.
+    /// A named alias for <see cref="IConverter{TFrom, TTo}"/> closed over these two types. It
+    /// existed because Unity before 2023.1 could not serialize a <c>[SerializeReference]</c> field
+    /// typed as an open generic, so a binder declared the field as this instead.
+    /// <para>
+    /// The package requires Unity 6000.0, so nothing in it declares such a field any more and this
+    /// carries no behaviour of its own. It stays one release so that code naming it keeps compiling
+    /// with a warning, and so that a <c>[SerializeReference]</c> field a project declares as this
+    /// type does not silently deserialize to <see langword="null"/>.
+    /// </para>
     /// </remarks>
+    [Obsolete("Named converter aliases only existed because Unity before 2023.1 could not serialize a [SerializeReference] field of an open generic type. The package now requires Unity 6000.0, so use IConverter<int, long> directly. This will be removed in the next major version.")]
     public interface IConverterIntToLong : IConverter<int, long> { }
 }

--- a/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Runtime/Converters/Specific/Numbers/IConverterLong.cs
+++ b/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Runtime/Converters/Specific/Numbers/IConverterLong.cs
@@ -7,15 +7,8 @@ namespace Aspid.MVVM.StarterKit
     /// A converter from <see cref="long"/> to <see cref="long"/>.
     /// </summary>
     /// <remarks>
-    /// A named alias for <see cref="IConverter{TFrom, TTo}"/> closed over these two types. It
-    /// existed because Unity before 2023.1 could not serialize a <c>[SerializeReference]</c> field
-    /// typed as an open generic, so a binder declared the field as this instead.
-    /// <para>
-    /// The package requires Unity 6000.0, so nothing in it declares such a field any more and this
-    /// carries no behaviour of its own. It stays one release so that code naming it keeps compiling
-    /// with a warning, and so that a <c>[SerializeReference]</c> field a project declares as this
-    /// type does not silently deserialize to <see langword="null"/>.
-    /// </para>
+    /// Kept for one release so code naming it still compiles and a <c>[SerializeReference]</c> field
+    /// a project declares as this type does not silently deserialize to <see langword="null"/>.
     /// </remarks>
     [Obsolete("Named converter aliases only existed because Unity before 2023.1 could not serialize a [SerializeReference] field of an open generic type. The package now requires Unity 6000.0, so use IConverter<long, long> directly. This will be removed in the next major version.")]
     public interface IConverterLong : IConverter<long, long> { }

--- a/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Runtime/Converters/Specific/Numbers/IConverterLong.cs
+++ b/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Runtime/Converters/Specific/Numbers/IConverterLong.cs
@@ -1,3 +1,5 @@
+using System;
+
 // ReSharper disable once CheckNamespace
 namespace Aspid.MVVM.StarterKit
 {
@@ -5,10 +7,16 @@ namespace Aspid.MVVM.StarterKit
     /// A converter from <see cref="long"/> to <see cref="long"/>.
     /// </summary>
     /// <remarks>
-    /// A named alias for <see cref="IConverter{TFrom, TTo}"/> closed over these two types.
-    /// It exists because Unity before 2023.1 cannot serialize a <c>[SerializeReference]</c>
-    /// field typed as an open generic, so a binder declares the field as this instead. From
-    /// 2023.1 the generic form is used directly and this is a compatibility shim.
+    /// A named alias for <see cref="IConverter{TFrom, TTo}"/> closed over these two types. It
+    /// existed because Unity before 2023.1 could not serialize a <c>[SerializeReference]</c> field
+    /// typed as an open generic, so a binder declared the field as this instead.
+    /// <para>
+    /// The package requires Unity 6000.0, so nothing in it declares such a field any more and this
+    /// carries no behaviour of its own. It stays one release so that code naming it keeps compiling
+    /// with a warning, and so that a <c>[SerializeReference]</c> field a project declares as this
+    /// type does not silently deserialize to <see langword="null"/>.
+    /// </para>
     /// </remarks>
+    [Obsolete("Named converter aliases only existed because Unity before 2023.1 could not serialize a [SerializeReference] field of an open generic type. The package now requires Unity 6000.0, so use IConverter<long, long> directly. This will be removed in the next major version.")]
     public interface IConverterLong : IConverter<long, long> { }
 }

--- a/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Runtime/Converters/Specific/Numbers/IConverterLongToDouble.cs
+++ b/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Runtime/Converters/Specific/Numbers/IConverterLongToDouble.cs
@@ -1,3 +1,5 @@
+using System;
+
 // ReSharper disable once CheckNamespace
 namespace Aspid.MVVM.StarterKit
 {
@@ -5,10 +7,16 @@ namespace Aspid.MVVM.StarterKit
     /// A converter from <see cref="long"/> to <see cref="double"/>.
     /// </summary>
     /// <remarks>
-    /// A named alias for <see cref="IConverter{TFrom, TTo}"/> closed over these two types.
-    /// It exists because Unity before 2023.1 cannot serialize a <c>[SerializeReference]</c>
-    /// field typed as an open generic, so a binder declares the field as this instead. From
-    /// 2023.1 the generic form is used directly and this is a compatibility shim.
+    /// A named alias for <see cref="IConverter{TFrom, TTo}"/> closed over these two types. It
+    /// existed because Unity before 2023.1 could not serialize a <c>[SerializeReference]</c> field
+    /// typed as an open generic, so a binder declared the field as this instead.
+    /// <para>
+    /// The package requires Unity 6000.0, so nothing in it declares such a field any more and this
+    /// carries no behaviour of its own. It stays one release so that code naming it keeps compiling
+    /// with a warning, and so that a <c>[SerializeReference]</c> field a project declares as this
+    /// type does not silently deserialize to <see langword="null"/>.
+    /// </para>
     /// </remarks>
+    [Obsolete("Named converter aliases only existed because Unity before 2023.1 could not serialize a [SerializeReference] field of an open generic type. The package now requires Unity 6000.0, so use IConverter<long, double> directly. This will be removed in the next major version.")]
     public interface IConverterLongToDouble : IConverter<long, double> { }
 }

--- a/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Runtime/Converters/Specific/Numbers/IConverterLongToDouble.cs
+++ b/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Runtime/Converters/Specific/Numbers/IConverterLongToDouble.cs
@@ -7,15 +7,8 @@ namespace Aspid.MVVM.StarterKit
     /// A converter from <see cref="long"/> to <see cref="double"/>.
     /// </summary>
     /// <remarks>
-    /// A named alias for <see cref="IConverter{TFrom, TTo}"/> closed over these two types. It
-    /// existed because Unity before 2023.1 could not serialize a <c>[SerializeReference]</c> field
-    /// typed as an open generic, so a binder declared the field as this instead.
-    /// <para>
-    /// The package requires Unity 6000.0, so nothing in it declares such a field any more and this
-    /// carries no behaviour of its own. It stays one release so that code naming it keeps compiling
-    /// with a warning, and so that a <c>[SerializeReference]</c> field a project declares as this
-    /// type does not silently deserialize to <see langword="null"/>.
-    /// </para>
+    /// Kept for one release so code naming it still compiles and a <c>[SerializeReference]</c> field
+    /// a project declares as this type does not silently deserialize to <see langword="null"/>.
     /// </remarks>
     [Obsolete("Named converter aliases only existed because Unity before 2023.1 could not serialize a [SerializeReference] field of an open generic type. The package now requires Unity 6000.0, so use IConverter<long, double> directly. This will be removed in the next major version.")]
     public interface IConverterLongToDouble : IConverter<long, double> { }

--- a/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Runtime/Converters/Specific/Numbers/IConverterLongToFloat.cs
+++ b/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Runtime/Converters/Specific/Numbers/IConverterLongToFloat.cs
@@ -1,3 +1,5 @@
+using System;
+
 // ReSharper disable once CheckNamespace
 namespace Aspid.MVVM.StarterKit
 {
@@ -5,10 +7,16 @@ namespace Aspid.MVVM.StarterKit
     /// A converter from <see cref="long"/> to <see cref="float"/>.
     /// </summary>
     /// <remarks>
-    /// A named alias for <see cref="IConverter{TFrom, TTo}"/> closed over these two types.
-    /// It exists because Unity before 2023.1 cannot serialize a <c>[SerializeReference]</c>
-    /// field typed as an open generic, so a binder declares the field as this instead. From
-    /// 2023.1 the generic form is used directly and this is a compatibility shim.
+    /// A named alias for <see cref="IConverter{TFrom, TTo}"/> closed over these two types. It
+    /// existed because Unity before 2023.1 could not serialize a <c>[SerializeReference]</c> field
+    /// typed as an open generic, so a binder declared the field as this instead.
+    /// <para>
+    /// The package requires Unity 6000.0, so nothing in it declares such a field any more and this
+    /// carries no behaviour of its own. It stays one release so that code naming it keeps compiling
+    /// with a warning, and so that a <c>[SerializeReference]</c> field a project declares as this
+    /// type does not silently deserialize to <see langword="null"/>.
+    /// </para>
     /// </remarks>
+    [Obsolete("Named converter aliases only existed because Unity before 2023.1 could not serialize a [SerializeReference] field of an open generic type. The package now requires Unity 6000.0, so use IConverter<long, float> directly. This will be removed in the next major version.")]
     public interface IConverterLongToFloat : IConverter<long, float> { }
 }

--- a/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Runtime/Converters/Specific/Numbers/IConverterLongToFloat.cs
+++ b/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Runtime/Converters/Specific/Numbers/IConverterLongToFloat.cs
@@ -7,15 +7,8 @@ namespace Aspid.MVVM.StarterKit
     /// A converter from <see cref="long"/> to <see cref="float"/>.
     /// </summary>
     /// <remarks>
-    /// A named alias for <see cref="IConverter{TFrom, TTo}"/> closed over these two types. It
-    /// existed because Unity before 2023.1 could not serialize a <c>[SerializeReference]</c> field
-    /// typed as an open generic, so a binder declared the field as this instead.
-    /// <para>
-    /// The package requires Unity 6000.0, so nothing in it declares such a field any more and this
-    /// carries no behaviour of its own. It stays one release so that code naming it keeps compiling
-    /// with a warning, and so that a <c>[SerializeReference]</c> field a project declares as this
-    /// type does not silently deserialize to <see langword="null"/>.
-    /// </para>
+    /// Kept for one release so code naming it still compiles and a <c>[SerializeReference]</c> field
+    /// a project declares as this type does not silently deserialize to <see langword="null"/>.
     /// </remarks>
     [Obsolete("Named converter aliases only existed because Unity before 2023.1 could not serialize a [SerializeReference] field of an open generic type. The package now requires Unity 6000.0, so use IConverter<long, float> directly. This will be removed in the next major version.")]
     public interface IConverterLongToFloat : IConverter<long, float> { }

--- a/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Runtime/Converters/Specific/Numbers/IConverterLongToInt.cs
+++ b/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Runtime/Converters/Specific/Numbers/IConverterLongToInt.cs
@@ -7,15 +7,8 @@ namespace Aspid.MVVM.StarterKit
     /// A converter from <see cref="long"/> to <see cref="int"/>.
     /// </summary>
     /// <remarks>
-    /// A named alias for <see cref="IConverter{TFrom, TTo}"/> closed over these two types. It
-    /// existed because Unity before 2023.1 could not serialize a <c>[SerializeReference]</c> field
-    /// typed as an open generic, so a binder declared the field as this instead.
-    /// <para>
-    /// The package requires Unity 6000.0, so nothing in it declares such a field any more and this
-    /// carries no behaviour of its own. It stays one release so that code naming it keeps compiling
-    /// with a warning, and so that a <c>[SerializeReference]</c> field a project declares as this
-    /// type does not silently deserialize to <see langword="null"/>.
-    /// </para>
+    /// Kept for one release so code naming it still compiles and a <c>[SerializeReference]</c> field
+    /// a project declares as this type does not silently deserialize to <see langword="null"/>.
     /// </remarks>
     [Obsolete("Named converter aliases only existed because Unity before 2023.1 could not serialize a [SerializeReference] field of an open generic type. The package now requires Unity 6000.0, so use IConverter<long, int> directly. This will be removed in the next major version.")]
     public interface IConverterLongToInt : IConverter<long, int> { }

--- a/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Runtime/Converters/Specific/Numbers/IConverterLongToInt.cs
+++ b/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Runtime/Converters/Specific/Numbers/IConverterLongToInt.cs
@@ -1,3 +1,5 @@
+using System;
+
 // ReSharper disable once CheckNamespace
 namespace Aspid.MVVM.StarterKit
 {
@@ -5,10 +7,16 @@ namespace Aspid.MVVM.StarterKit
     /// A converter from <see cref="long"/> to <see cref="int"/>.
     /// </summary>
     /// <remarks>
-    /// A named alias for <see cref="IConverter{TFrom, TTo}"/> closed over these two types.
-    /// It exists because Unity before 2023.1 cannot serialize a <c>[SerializeReference]</c>
-    /// field typed as an open generic, so a binder declares the field as this instead. From
-    /// 2023.1 the generic form is used directly and this is a compatibility shim.
+    /// A named alias for <see cref="IConverter{TFrom, TTo}"/> closed over these two types. It
+    /// existed because Unity before 2023.1 could not serialize a <c>[SerializeReference]</c> field
+    /// typed as an open generic, so a binder declared the field as this instead.
+    /// <para>
+    /// The package requires Unity 6000.0, so nothing in it declares such a field any more and this
+    /// carries no behaviour of its own. It stays one release so that code naming it keeps compiling
+    /// with a warning, and so that a <c>[SerializeReference]</c> field a project declares as this
+    /// type does not silently deserialize to <see langword="null"/>.
+    /// </para>
     /// </remarks>
+    [Obsolete("Named converter aliases only existed because Unity before 2023.1 could not serialize a [SerializeReference] field of an open generic type. The package now requires Unity 6000.0, so use IConverter<long, int> directly. This will be removed in the next major version.")]
     public interface IConverterLongToInt : IConverter<long, int> { }
 }

--- a/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Runtime/Converters/Specific/Numbers/NumberConverterSpecificExtensions.cs
+++ b/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Runtime/Converters/Specific/Numbers/NumberConverterSpecificExtensions.cs
@@ -14,6 +14,7 @@ namespace Aspid.MVVM.StarterKit
     /// Unity 2023.1 declares its field as the named interface rather than the generic one,
     /// so a lambda cannot be assigned to it directly.
     /// </remarks>
+    [Obsolete("Only needed to assign a lambda to a field typed as a named converter alias, which Unity before 2023.1 required. The package now requires Unity 6000.0, so assign the converter directly. This will be removed in the next major version.")]
     public static class NumberConverterSpecificExtensions
     {
         #region Int Methods
@@ -23,6 +24,7 @@ namespace Aspid.MVVM.StarterKit
         /// <param name="converter">The function to wrap.</param>
         /// <returns>A converter of the named interface type.</returns>
         /// <exception cref="System.ArgumentNullException">Thrown when <paramref name="converter"/> is <see langword="null"/>.</exception>
+        [Obsolete("Only needed to assign a lambda to a field typed as a named converter alias, which Unity before 2023.1 required. The package now requires Unity 6000.0, so assign the converter directly. This will be removed in the next major version.")]
         public static IConverterInt ToConvert(this Func<int, int> converter) =>
             new ConverterInt(converter);
         
@@ -32,6 +34,7 @@ namespace Aspid.MVVM.StarterKit
         /// <param name="converter">The converter to wrap.</param>
         /// <returns>A converter of the named interface type.</returns>
         /// <exception cref="System.ArgumentNullException">Thrown when <paramref name="converter"/> is <see langword="null"/>.</exception>
+        [Obsolete("Only needed to assign a lambda to a field typed as a named converter alias, which Unity before 2023.1 required. The package now requires Unity 6000.0, so assign the converter directly. This will be removed in the next major version.")]
         public static IConverterInt ToConvertSpecific(this IConverter<int, int> converter) =>
             new ConverterInt(converter);
         
@@ -41,6 +44,7 @@ namespace Aspid.MVVM.StarterKit
         /// <param name="converter">The function to wrap.</param>
         /// <returns>A converter of the named interface type.</returns>
         /// <exception cref="System.ArgumentNullException">Thrown when <paramref name="converter"/> is <see langword="null"/>.</exception>
+        [Obsolete("Only needed to assign a lambda to a field typed as a named converter alias, which Unity before 2023.1 required. The package now requires Unity 6000.0, so assign the converter directly. This will be removed in the next major version.")]
         public static IConverterIntToLong ToConvert(this Func<int, long> converter) =>
             new ConverterIntToLong(converter);
         
@@ -50,6 +54,7 @@ namespace Aspid.MVVM.StarterKit
         /// <param name="converter">The converter to wrap.</param>
         /// <returns>A converter of the named interface type.</returns>
         /// <exception cref="System.ArgumentNullException">Thrown when <paramref name="converter"/> is <see langword="null"/>.</exception>
+        [Obsolete("Only needed to assign a lambda to a field typed as a named converter alias, which Unity before 2023.1 required. The package now requires Unity 6000.0, so assign the converter directly. This will be removed in the next major version.")]
         public static IConverterIntToLong ToConvertSpecific(this IConverter<int, long> converter) =>
             new ConverterIntToLong(converter);
         
@@ -59,6 +64,7 @@ namespace Aspid.MVVM.StarterKit
         /// <param name="converter">The function to wrap.</param>
         /// <returns>A converter of the named interface type.</returns>
         /// <exception cref="System.ArgumentNullException">Thrown when <paramref name="converter"/> is <see langword="null"/>.</exception>
+        [Obsolete("Only needed to assign a lambda to a field typed as a named converter alias, which Unity before 2023.1 required. The package now requires Unity 6000.0, so assign the converter directly. This will be removed in the next major version.")]
         public static IConverterIntToFloat ToConvert(this Func<int, float> converter) =>
             new ConverterIntToFloat(converter);
         
@@ -68,6 +74,7 @@ namespace Aspid.MVVM.StarterKit
         /// <param name="converter">The converter to wrap.</param>
         /// <returns>A converter of the named interface type.</returns>
         /// <exception cref="System.ArgumentNullException">Thrown when <paramref name="converter"/> is <see langword="null"/>.</exception>
+        [Obsolete("Only needed to assign a lambda to a field typed as a named converter alias, which Unity before 2023.1 required. The package now requires Unity 6000.0, so assign the converter directly. This will be removed in the next major version.")]
         public static IConverterIntToFloat ToConvertSpecific(this IConverter<int, float> converter) =>
             new ConverterIntToFloat(converter);
         
@@ -77,6 +84,7 @@ namespace Aspid.MVVM.StarterKit
         /// <param name="converter">The function to wrap.</param>
         /// <returns>A converter of the named interface type.</returns>
         /// <exception cref="System.ArgumentNullException">Thrown when <paramref name="converter"/> is <see langword="null"/>.</exception>
+        [Obsolete("Only needed to assign a lambda to a field typed as a named converter alias, which Unity before 2023.1 required. The package now requires Unity 6000.0, so assign the converter directly. This will be removed in the next major version.")]
         public static IConverterIntToDouble ToConvert(this Func<int, double> converter) =>
             new ConverterIntToDouble(converter);
         
@@ -86,6 +94,7 @@ namespace Aspid.MVVM.StarterKit
         /// <param name="converter">The converter to wrap.</param>
         /// <returns>A converter of the named interface type.</returns>
         /// <exception cref="System.ArgumentNullException">Thrown when <paramref name="converter"/> is <see langword="null"/>.</exception>
+        [Obsolete("Only needed to assign a lambda to a field typed as a named converter alias, which Unity before 2023.1 required. The package now requires Unity 6000.0, so assign the converter directly. This will be removed in the next major version.")]
         public static IConverterIntToDouble ToConvertSpecific(this IConverter<int, double> converter) =>
             new ConverterIntToDouble(converter);
         #endregion
@@ -97,6 +106,7 @@ namespace Aspid.MVVM.StarterKit
         /// <param name="converter">The function to wrap.</param>
         /// <returns>A converter of the named interface type.</returns>
         /// <exception cref="System.ArgumentNullException">Thrown when <paramref name="converter"/> is <see langword="null"/>.</exception>
+        [Obsolete("Only needed to assign a lambda to a field typed as a named converter alias, which Unity before 2023.1 required. The package now requires Unity 6000.0, so assign the converter directly. This will be removed in the next major version.")]
         public static IConverterLongToInt ToConvert(this Func<long, int> converter) =>
             new ConverterLongToInt(converter);
         
@@ -106,6 +116,7 @@ namespace Aspid.MVVM.StarterKit
         /// <param name="converter">The converter to wrap.</param>
         /// <returns>A converter of the named interface type.</returns>
         /// <exception cref="System.ArgumentNullException">Thrown when <paramref name="converter"/> is <see langword="null"/>.</exception>
+        [Obsolete("Only needed to assign a lambda to a field typed as a named converter alias, which Unity before 2023.1 required. The package now requires Unity 6000.0, so assign the converter directly. This will be removed in the next major version.")]
         public static IConverterLongToInt ToConvertSpecific(this IConverter<long, int> converter) =>
             new ConverterLongToInt(converter);
         
@@ -115,6 +126,7 @@ namespace Aspid.MVVM.StarterKit
         /// <param name="converter">The function to wrap.</param>
         /// <returns>A converter of the named interface type.</returns>
         /// <exception cref="System.ArgumentNullException">Thrown when <paramref name="converter"/> is <see langword="null"/>.</exception>
+        [Obsolete("Only needed to assign a lambda to a field typed as a named converter alias, which Unity before 2023.1 required. The package now requires Unity 6000.0, so assign the converter directly. This will be removed in the next major version.")]
         public static IConverterLong ToConvert(this Func<long, long> converter) =>
             new ConverterLong(converter);
         
@@ -124,6 +136,7 @@ namespace Aspid.MVVM.StarterKit
         /// <param name="converter">The converter to wrap.</param>
         /// <returns>A converter of the named interface type.</returns>
         /// <exception cref="System.ArgumentNullException">Thrown when <paramref name="converter"/> is <see langword="null"/>.</exception>
+        [Obsolete("Only needed to assign a lambda to a field typed as a named converter alias, which Unity before 2023.1 required. The package now requires Unity 6000.0, so assign the converter directly. This will be removed in the next major version.")]
         public static IConverterLong ToConvertSpecific(this IConverter<long, long> converter) =>
             new ConverterLong(converter);
         
@@ -133,6 +146,7 @@ namespace Aspid.MVVM.StarterKit
         /// <param name="converter">The function to wrap.</param>
         /// <returns>A converter of the named interface type.</returns>
         /// <exception cref="System.ArgumentNullException">Thrown when <paramref name="converter"/> is <see langword="null"/>.</exception>
+        [Obsolete("Only needed to assign a lambda to a field typed as a named converter alias, which Unity before 2023.1 required. The package now requires Unity 6000.0, so assign the converter directly. This will be removed in the next major version.")]
         public static IConverterLongToFloat ToConvert(this Func<long, float> converter) =>
             new ConverterLongToFloat(converter);
         
@@ -142,6 +156,7 @@ namespace Aspid.MVVM.StarterKit
         /// <param name="converter">The converter to wrap.</param>
         /// <returns>A converter of the named interface type.</returns>
         /// <exception cref="System.ArgumentNullException">Thrown when <paramref name="converter"/> is <see langword="null"/>.</exception>
+        [Obsolete("Only needed to assign a lambda to a field typed as a named converter alias, which Unity before 2023.1 required. The package now requires Unity 6000.0, so assign the converter directly. This will be removed in the next major version.")]
         public static IConverterLongToFloat ToConvertSpecific(this IConverter<long, float> converter) =>
             new ConverterLongToFloat(converter);
         
@@ -151,6 +166,7 @@ namespace Aspid.MVVM.StarterKit
         /// <param name="converter">The function to wrap.</param>
         /// <returns>A converter of the named interface type.</returns>
         /// <exception cref="System.ArgumentNullException">Thrown when <paramref name="converter"/> is <see langword="null"/>.</exception>
+        [Obsolete("Only needed to assign a lambda to a field typed as a named converter alias, which Unity before 2023.1 required. The package now requires Unity 6000.0, so assign the converter directly. This will be removed in the next major version.")]
         public static IConverterLongToDouble ToConvert(this Func<long, double> converter) =>
             new ConverterLongToDouble(converter);
         
@@ -160,6 +176,7 @@ namespace Aspid.MVVM.StarterKit
         /// <param name="converter">The converter to wrap.</param>
         /// <returns>A converter of the named interface type.</returns>
         /// <exception cref="System.ArgumentNullException">Thrown when <paramref name="converter"/> is <see langword="null"/>.</exception>
+        [Obsolete("Only needed to assign a lambda to a field typed as a named converter alias, which Unity before 2023.1 required. The package now requires Unity 6000.0, so assign the converter directly. This will be removed in the next major version.")]
         public static IConverterLongToDouble ToConvertSpecific(this IConverter<long, double> converter) =>
             new ConverterLongToDouble(converter);
         #endregion
@@ -171,6 +188,7 @@ namespace Aspid.MVVM.StarterKit
         /// <param name="converter">The function to wrap.</param>
         /// <returns>A converter of the named interface type.</returns>
         /// <exception cref="System.ArgumentNullException">Thrown when <paramref name="converter"/> is <see langword="null"/>.</exception>
+        [Obsolete("Only needed to assign a lambda to a field typed as a named converter alias, which Unity before 2023.1 required. The package now requires Unity 6000.0, so assign the converter directly. This will be removed in the next major version.")]
         public static IConverterFloatToInt ToConvert(this Func<float, int> converter) =>
             new ConverterFloatToInt(converter);
         
@@ -180,6 +198,7 @@ namespace Aspid.MVVM.StarterKit
         /// <param name="converter">The converter to wrap.</param>
         /// <returns>A converter of the named interface type.</returns>
         /// <exception cref="System.ArgumentNullException">Thrown when <paramref name="converter"/> is <see langword="null"/>.</exception>
+        [Obsolete("Only needed to assign a lambda to a field typed as a named converter alias, which Unity before 2023.1 required. The package now requires Unity 6000.0, so assign the converter directly. This will be removed in the next major version.")]
         public static IConverterFloatToInt ToConvertSpecific(this IConverter<float, int> converter) =>
             new ConverterFloatToInt(converter);
         
@@ -189,6 +208,7 @@ namespace Aspid.MVVM.StarterKit
         /// <param name="converter">The function to wrap.</param>
         /// <returns>A converter of the named interface type.</returns>
         /// <exception cref="System.ArgumentNullException">Thrown when <paramref name="converter"/> is <see langword="null"/>.</exception>
+        [Obsolete("Only needed to assign a lambda to a field typed as a named converter alias, which Unity before 2023.1 required. The package now requires Unity 6000.0, so assign the converter directly. This will be removed in the next major version.")]
         public static IConverterFloatToLong ToConvert(this Func<float, long> converter) =>
             new ConverterFloatToLong(converter);
         
@@ -198,6 +218,7 @@ namespace Aspid.MVVM.StarterKit
         /// <param name="converter">The converter to wrap.</param>
         /// <returns>A converter of the named interface type.</returns>
         /// <exception cref="System.ArgumentNullException">Thrown when <paramref name="converter"/> is <see langword="null"/>.</exception>
+        [Obsolete("Only needed to assign a lambda to a field typed as a named converter alias, which Unity before 2023.1 required. The package now requires Unity 6000.0, so assign the converter directly. This will be removed in the next major version.")]
         public static IConverterFloatToLong ToConvertSpecific(this IConverter<float, long> converter) =>
             new ConverterFloatToLong(converter);
         
@@ -207,6 +228,7 @@ namespace Aspid.MVVM.StarterKit
         /// <param name="converter">The function to wrap.</param>
         /// <returns>A converter of the named interface type.</returns>
         /// <exception cref="System.ArgumentNullException">Thrown when <paramref name="converter"/> is <see langword="null"/>.</exception>
+        [Obsolete("Only needed to assign a lambda to a field typed as a named converter alias, which Unity before 2023.1 required. The package now requires Unity 6000.0, so assign the converter directly. This will be removed in the next major version.")]
         public static IConverterFloat ToConvert(this Func<float, float> converter) =>
             new ConverterFloat(converter);
         
@@ -216,6 +238,7 @@ namespace Aspid.MVVM.StarterKit
         /// <param name="converter">The converter to wrap.</param>
         /// <returns>A converter of the named interface type.</returns>
         /// <exception cref="System.ArgumentNullException">Thrown when <paramref name="converter"/> is <see langword="null"/>.</exception>
+        [Obsolete("Only needed to assign a lambda to a field typed as a named converter alias, which Unity before 2023.1 required. The package now requires Unity 6000.0, so assign the converter directly. This will be removed in the next major version.")]
         public static IConverterFloat ToConvertSpecific(this IConverter<float, float> converter) =>
             new ConverterFloat(converter);
         
@@ -225,6 +248,7 @@ namespace Aspid.MVVM.StarterKit
         /// <param name="converter">The function to wrap.</param>
         /// <returns>A converter of the named interface type.</returns>
         /// <exception cref="System.ArgumentNullException">Thrown when <paramref name="converter"/> is <see langword="null"/>.</exception>
+        [Obsolete("Only needed to assign a lambda to a field typed as a named converter alias, which Unity before 2023.1 required. The package now requires Unity 6000.0, so assign the converter directly. This will be removed in the next major version.")]
         public static IConverterFloatToDouble ToConvert(this Func<float, double> converter) =>
             new ConverterFloatToDouble(converter);
         
@@ -234,6 +258,7 @@ namespace Aspid.MVVM.StarterKit
         /// <param name="converter">The converter to wrap.</param>
         /// <returns>A converter of the named interface type.</returns>
         /// <exception cref="System.ArgumentNullException">Thrown when <paramref name="converter"/> is <see langword="null"/>.</exception>
+        [Obsolete("Only needed to assign a lambda to a field typed as a named converter alias, which Unity before 2023.1 required. The package now requires Unity 6000.0, so assign the converter directly. This will be removed in the next major version.")]
         public static IConverterFloatToDouble ToConvertSpecific(this IConverter<float, double> converter) =>
             new ConverterFloatToDouble(converter);
         #endregion
@@ -245,6 +270,7 @@ namespace Aspid.MVVM.StarterKit
         /// <param name="converter">The function to wrap.</param>
         /// <returns>A converter of the named interface type.</returns>
         /// <exception cref="System.ArgumentNullException">Thrown when <paramref name="converter"/> is <see langword="null"/>.</exception>
+        [Obsolete("Only needed to assign a lambda to a field typed as a named converter alias, which Unity before 2023.1 required. The package now requires Unity 6000.0, so assign the converter directly. This will be removed in the next major version.")]
         public static IConverterDoubleToInt ToConvert(this Func<double, int> converter) =>
             new ConverterDoubleToInt(converter);
         
@@ -254,6 +280,7 @@ namespace Aspid.MVVM.StarterKit
         /// <param name="converter">The converter to wrap.</param>
         /// <returns>A converter of the named interface type.</returns>
         /// <exception cref="System.ArgumentNullException">Thrown when <paramref name="converter"/> is <see langword="null"/>.</exception>
+        [Obsolete("Only needed to assign a lambda to a field typed as a named converter alias, which Unity before 2023.1 required. The package now requires Unity 6000.0, so assign the converter directly. This will be removed in the next major version.")]
         public static IConverterDoubleToInt ToConvertSpecific(this IConverter<double, int> converter) =>
             new ConverterDoubleToInt(converter);
         
@@ -263,6 +290,7 @@ namespace Aspid.MVVM.StarterKit
         /// <param name="converter">The function to wrap.</param>
         /// <returns>A converter of the named interface type.</returns>
         /// <exception cref="System.ArgumentNullException">Thrown when <paramref name="converter"/> is <see langword="null"/>.</exception>
+        [Obsolete("Only needed to assign a lambda to a field typed as a named converter alias, which Unity before 2023.1 required. The package now requires Unity 6000.0, so assign the converter directly. This will be removed in the next major version.")]
         public static IConverterDoubleToLong ToConvert(this Func<double, long> converter) =>
             new ConverterDoubleToLong(converter);
         
@@ -272,6 +300,7 @@ namespace Aspid.MVVM.StarterKit
         /// <param name="converter">The converter to wrap.</param>
         /// <returns>A converter of the named interface type.</returns>
         /// <exception cref="System.ArgumentNullException">Thrown when <paramref name="converter"/> is <see langword="null"/>.</exception>
+        [Obsolete("Only needed to assign a lambda to a field typed as a named converter alias, which Unity before 2023.1 required. The package now requires Unity 6000.0, so assign the converter directly. This will be removed in the next major version.")]
         public static IConverterDoubleToLong ToConvertSpecific(this IConverter<double, long> converter) =>
             new ConverterDoubleToLong(converter);
         
@@ -281,6 +310,7 @@ namespace Aspid.MVVM.StarterKit
         /// <param name="converter">The function to wrap.</param>
         /// <returns>A converter of the named interface type.</returns>
         /// <exception cref="System.ArgumentNullException">Thrown when <paramref name="converter"/> is <see langword="null"/>.</exception>
+        [Obsolete("Only needed to assign a lambda to a field typed as a named converter alias, which Unity before 2023.1 required. The package now requires Unity 6000.0, so assign the converter directly. This will be removed in the next major version.")]
         public static IConverterDoubleToFloat ToConvert(this Func<double, float> converter) =>
             new ConverterDoubleToFloat(converter);
         
@@ -290,6 +320,7 @@ namespace Aspid.MVVM.StarterKit
         /// <param name="converter">The converter to wrap.</param>
         /// <returns>A converter of the named interface type.</returns>
         /// <exception cref="System.ArgumentNullException">Thrown when <paramref name="converter"/> is <see langword="null"/>.</exception>
+        [Obsolete("Only needed to assign a lambda to a field typed as a named converter alias, which Unity before 2023.1 required. The package now requires Unity 6000.0, so assign the converter directly. This will be removed in the next major version.")]
         public static IConverterDoubleToFloat ToConvertSpecific(this IConverter<double, float> converter) =>
             new ConverterDoubleToFloat(converter);
         
@@ -299,6 +330,7 @@ namespace Aspid.MVVM.StarterKit
         /// <param name="converter">The function to wrap.</param>
         /// <returns>A converter of the named interface type.</returns>
         /// <exception cref="System.ArgumentNullException">Thrown when <paramref name="converter"/> is <see langword="null"/>.</exception>
+        [Obsolete("Only needed to assign a lambda to a field typed as a named converter alias, which Unity before 2023.1 required. The package now requires Unity 6000.0, so assign the converter directly. This will be removed in the next major version.")]
         public static IConverterDouble ToConvert(this Func<double, double> converter) =>
             new ConverterDouble(converter);
         
@@ -308,6 +340,7 @@ namespace Aspid.MVVM.StarterKit
         /// <param name="converter">The converter to wrap.</param>
         /// <returns>A converter of the named interface type.</returns>
         /// <exception cref="System.ArgumentNullException">Thrown when <paramref name="converter"/> is <see langword="null"/>.</exception>
+        [Obsolete("Only needed to assign a lambda to a field typed as a named converter alias, which Unity before 2023.1 required. The package now requires Unity 6000.0, so assign the converter directly. This will be removed in the next major version.")]
         public static IConverterDouble ToConvertSpecific(this IConverter<double, double> converter) =>
             new ConverterDouble(converter);
         #endregion

--- a/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Runtime/Converters/Specific/Strings/IConverterObjectToString.cs
+++ b/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Runtime/Converters/Specific/Strings/IConverterObjectToString.cs
@@ -1,3 +1,5 @@
+using System;
+
 // ReSharper disable once CheckNamespace
 namespace Aspid.MVVM.StarterKit
 {
@@ -5,10 +7,16 @@ namespace Aspid.MVVM.StarterKit
     /// A converter from <see cref="object"/> to <see cref="string"/>.
     /// </summary>
     /// <remarks>
-    /// A named alias for <see cref="IConverter{TFrom, TTo}"/> closed over these two types.
-    /// It exists because Unity before 2023.1 cannot serialize a <c>[SerializeReference]</c>
-    /// field typed as an open generic, so a binder declares the field as this instead. From
-    /// 2023.1 the generic form is used directly and this is a compatibility shim.
+    /// A named alias for <see cref="IConverter{TFrom, TTo}"/> closed over these two types. It
+    /// existed because Unity before 2023.1 could not serialize a <c>[SerializeReference]</c> field
+    /// typed as an open generic, so a binder declared the field as this instead.
+    /// <para>
+    /// The package requires Unity 6000.0, so nothing in it declares such a field any more and this
+    /// carries no behaviour of its own. It stays one release so that code naming it keeps compiling
+    /// with a warning, and so that a <c>[SerializeReference]</c> field a project declares as this
+    /// type does not silently deserialize to <see langword="null"/>.
+    /// </para>
     /// </remarks>
+    [Obsolete("Named converter aliases only existed because Unity before 2023.1 could not serialize a [SerializeReference] field of an open generic type. The package now requires Unity 6000.0, so use IConverter<object?, string?> directly. This will be removed in the next major version.")]
     public interface IConverterObjectToString : IConverter<object?, string?> { }
 }

--- a/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Runtime/Converters/Specific/Strings/IConverterObjectToString.cs
+++ b/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Runtime/Converters/Specific/Strings/IConverterObjectToString.cs
@@ -7,15 +7,8 @@ namespace Aspid.MVVM.StarterKit
     /// A converter from <see cref="object"/> to <see cref="string"/>.
     /// </summary>
     /// <remarks>
-    /// A named alias for <see cref="IConverter{TFrom, TTo}"/> closed over these two types. It
-    /// existed because Unity before 2023.1 could not serialize a <c>[SerializeReference]</c> field
-    /// typed as an open generic, so a binder declared the field as this instead.
-    /// <para>
-    /// The package requires Unity 6000.0, so nothing in it declares such a field any more and this
-    /// carries no behaviour of its own. It stays one release so that code naming it keeps compiling
-    /// with a warning, and so that a <c>[SerializeReference]</c> field a project declares as this
-    /// type does not silently deserialize to <see langword="null"/>.
-    /// </para>
+    /// Kept for one release so code naming it still compiles and a <c>[SerializeReference]</c> field
+    /// a project declares as this type does not silently deserialize to <see langword="null"/>.
     /// </remarks>
     [Obsolete("Named converter aliases only existed because Unity before 2023.1 could not serialize a [SerializeReference] field of an open generic type. The package now requires Unity 6000.0, so use IConverter<object?, string?> directly. This will be removed in the next major version.")]
     public interface IConverterObjectToString : IConverter<object?, string?> { }

--- a/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Runtime/Converters/Specific/Strings/IConverterString.cs
+++ b/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Runtime/Converters/Specific/Strings/IConverterString.cs
@@ -7,15 +7,8 @@ namespace Aspid.MVVM.StarterKit
     /// A converter from <see cref="string"/> to <see cref="string"/>.
     /// </summary>
     /// <remarks>
-    /// A named alias for <see cref="IConverter{TFrom, TTo}"/> closed over these two types. It
-    /// existed because Unity before 2023.1 could not serialize a <c>[SerializeReference]</c> field
-    /// typed as an open generic, so a binder declared the field as this instead.
-    /// <para>
-    /// The package requires Unity 6000.0, so nothing in it declares such a field any more and this
-    /// carries no behaviour of its own. It stays one release so that code naming it keeps compiling
-    /// with a warning, and so that a <c>[SerializeReference]</c> field a project declares as this
-    /// type does not silently deserialize to <see langword="null"/>.
-    /// </para>
+    /// Kept for one release so code naming it still compiles and a <c>[SerializeReference]</c> field
+    /// a project declares as this type does not silently deserialize to <see langword="null"/>.
     /// </remarks>
     [Obsolete("Named converter aliases only existed because Unity before 2023.1 could not serialize a [SerializeReference] field of an open generic type. The package now requires Unity 6000.0, so use IConverter<string?, string?> directly. This will be removed in the next major version.")]
     public interface IConverterString : IConverter<string?, string?> { }

--- a/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Runtime/Converters/Specific/Strings/IConverterString.cs
+++ b/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Runtime/Converters/Specific/Strings/IConverterString.cs
@@ -1,3 +1,5 @@
+using System;
+
 // ReSharper disable once CheckNamespace
 namespace Aspid.MVVM.StarterKit
 {
@@ -5,10 +7,16 @@ namespace Aspid.MVVM.StarterKit
     /// A converter from <see cref="string"/> to <see cref="string"/>.
     /// </summary>
     /// <remarks>
-    /// A named alias for <see cref="IConverter{TFrom, TTo}"/> closed over these two types.
-    /// It exists because Unity before 2023.1 cannot serialize a <c>[SerializeReference]</c>
-    /// field typed as an open generic, so a binder declares the field as this instead. From
-    /// 2023.1 the generic form is used directly and this is a compatibility shim.
+    /// A named alias for <see cref="IConverter{TFrom, TTo}"/> closed over these two types. It
+    /// existed because Unity before 2023.1 could not serialize a <c>[SerializeReference]</c> field
+    /// typed as an open generic, so a binder declared the field as this instead.
+    /// <para>
+    /// The package requires Unity 6000.0, so nothing in it declares such a field any more and this
+    /// carries no behaviour of its own. It stays one release so that code naming it keeps compiling
+    /// with a warning, and so that a <c>[SerializeReference]</c> field a project declares as this
+    /// type does not silently deserialize to <see langword="null"/>.
+    /// </para>
     /// </remarks>
+    [Obsolete("Named converter aliases only existed because Unity before 2023.1 could not serialize a [SerializeReference] field of an open generic type. The package now requires Unity 6000.0, so use IConverter<string?, string?> directly. This will be removed in the next major version.")]
     public interface IConverterString : IConverter<string?, string?> { }
 }

--- a/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Runtime/Converters/Specific/Strings/IConverterTimeSpanToString.cs
+++ b/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Runtime/Converters/Specific/Strings/IConverterTimeSpanToString.cs
@@ -7,10 +7,16 @@ namespace Aspid.MVVM.StarterKit
     /// A converter from <see cref="TimeSpan"/> to <see cref="string"/>.
     /// </summary>
     /// <remarks>
-    /// A named alias for <see cref="IConverter{TFrom, TTo}"/> closed over these two types.
-    /// It exists because Unity before 2023.1 cannot serialize a <c>[SerializeReference]</c>
-    /// field typed as an open generic, so a binder declares the field as this instead. From
-    /// 2023.1 the generic form is used directly and this is a compatibility shim.
+    /// A named alias for <see cref="IConverter{TFrom, TTo}"/> closed over these two types. It
+    /// existed because Unity before 2023.1 could not serialize a <c>[SerializeReference]</c> field
+    /// typed as an open generic, so a binder declared the field as this instead.
+    /// <para>
+    /// The package requires Unity 6000.0, so nothing in it declares such a field any more and this
+    /// carries no behaviour of its own. It stays one release so that code naming it keeps compiling
+    /// with a warning, and so that a <c>[SerializeReference]</c> field a project declares as this
+    /// type does not silently deserialize to <see langword="null"/>.
+    /// </para>
     /// </remarks>
+    [Obsolete("Named converter aliases only existed because Unity before 2023.1 could not serialize a [SerializeReference] field of an open generic type. The package now requires Unity 6000.0, so use IConverter<TimeSpan, string?> directly. This will be removed in the next major version.")]
     public interface IConverterTimeSpanToString : IConverter<TimeSpan, string?> { }
 }

--- a/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Runtime/Converters/Specific/Strings/IConverterTimeSpanToString.cs
+++ b/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Runtime/Converters/Specific/Strings/IConverterTimeSpanToString.cs
@@ -7,15 +7,8 @@ namespace Aspid.MVVM.StarterKit
     /// A converter from <see cref="TimeSpan"/> to <see cref="string"/>.
     /// </summary>
     /// <remarks>
-    /// A named alias for <see cref="IConverter{TFrom, TTo}"/> closed over these two types. It
-    /// existed because Unity before 2023.1 could not serialize a <c>[SerializeReference]</c> field
-    /// typed as an open generic, so a binder declared the field as this instead.
-    /// <para>
-    /// The package requires Unity 6000.0, so nothing in it declares such a field any more and this
-    /// carries no behaviour of its own. It stays one release so that code naming it keeps compiling
-    /// with a warning, and so that a <c>[SerializeReference]</c> field a project declares as this
-    /// type does not silently deserialize to <see langword="null"/>.
-    /// </para>
+    /// Kept for one release so code naming it still compiles and a <c>[SerializeReference]</c> field
+    /// a project declares as this type does not silently deserialize to <see langword="null"/>.
     /// </remarks>
     [Obsolete("Named converter aliases only existed because Unity before 2023.1 could not serialize a [SerializeReference] field of an open generic type. The package now requires Unity 6000.0, so use IConverter<TimeSpan, string?> directly. This will be removed in the next major version.")]
     public interface IConverterTimeSpanToString : IConverter<TimeSpan, string?> { }

--- a/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Runtime/Converters/Specific/Strings/StringConverterSpecificExtensions.cs
+++ b/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Runtime/Converters/Specific/Strings/StringConverterSpecificExtensions.cs
@@ -14,6 +14,7 @@ namespace Aspid.MVVM.StarterKit
     /// Unity 2023.1 declares its field as the named interface rather than the generic one,
     /// so a lambda cannot be assigned to it directly.
     /// </remarks>
+    [Obsolete("Only needed to assign a lambda to a field typed as a named converter alias, which Unity before 2023.1 required. The package now requires Unity 6000.0, so assign the converter directly. This will be removed in the next major version.")]
     public static class StringConverterSpecificExtensions
     {
         /// <summary>
@@ -22,6 +23,7 @@ namespace Aspid.MVVM.StarterKit
         /// <param name="converter">The function to wrap.</param>
         /// <returns>A converter of the named interface type.</returns>
         /// <exception cref="System.ArgumentNullException">Thrown when <paramref name="converter"/> is <see langword="null"/>.</exception>
+        [Obsolete("Only needed to assign a lambda to a field typed as a named converter alias, which Unity before 2023.1 required. The package now requires Unity 6000.0, so assign the converter directly. This will be removed in the next major version.")]
         public static IConverterString ToConvert(this Func<string?, string?> converter) =>
             new ConverterString(converter);
         
@@ -31,6 +33,7 @@ namespace Aspid.MVVM.StarterKit
         /// <param name="converter">The converter to wrap.</param>
         /// <returns>A converter of the named interface type.</returns>
         /// <exception cref="System.ArgumentNullException">Thrown when <paramref name="converter"/> is <see langword="null"/>.</exception>
+        [Obsolete("Only needed to assign a lambda to a field typed as a named converter alias, which Unity before 2023.1 required. The package now requires Unity 6000.0, so assign the converter directly. This will be removed in the next major version.")]
         public static IConverterString ToConvertSpecific(this IConverter<string?, string?> converter) =>
             new ConverterString(converter);
         
@@ -40,6 +43,7 @@ namespace Aspid.MVVM.StarterKit
         /// <param name="converter">The function to wrap.</param>
         /// <returns>A converter of the named interface type.</returns>
         /// <exception cref="System.ArgumentNullException">Thrown when <paramref name="converter"/> is <see langword="null"/>.</exception>
+        [Obsolete("Only needed to assign a lambda to a field typed as a named converter alias, which Unity before 2023.1 required. The package now requires Unity 6000.0, so assign the converter directly. This will be removed in the next major version.")]
         public static IConverterObjectToString ToConvert(this Func<object?, string?> converter) =>
             new ConverterObjectToString(converter);
         
@@ -49,6 +53,7 @@ namespace Aspid.MVVM.StarterKit
         /// <param name="converter">The converter to wrap.</param>
         /// <returns>A converter of the named interface type.</returns>
         /// <exception cref="System.ArgumentNullException">Thrown when <paramref name="converter"/> is <see langword="null"/>.</exception>
+        [Obsolete("Only needed to assign a lambda to a field typed as a named converter alias, which Unity before 2023.1 required. The package now requires Unity 6000.0, so assign the converter directly. This will be removed in the next major version.")]
         public static IConverterObjectToString ToConvertSpecific(this IConverter<object?, string?> converter) =>
             new ConverterObjectToString(converter);
         
@@ -58,6 +63,7 @@ namespace Aspid.MVVM.StarterKit
         /// <param name="converter">The function to wrap.</param>
         /// <returns>A converter of the named interface type.</returns>
         /// <exception cref="System.ArgumentNullException">Thrown when <paramref name="converter"/> is <see langword="null"/>.</exception>
+        [Obsolete("Only needed to assign a lambda to a field typed as a named converter alias, which Unity before 2023.1 required. The package now requires Unity 6000.0, so assign the converter directly. This will be removed in the next major version.")]
         public static IConverterTimeSpanToString ToConvert(this Func<TimeSpan, string?> converter) =>
             new ConverterTimeSpanToString(converter);
         
@@ -67,6 +73,7 @@ namespace Aspid.MVVM.StarterKit
         /// <param name="converter">The converter to wrap.</param>
         /// <returns>A converter of the named interface type.</returns>
         /// <exception cref="System.ArgumentNullException">Thrown when <paramref name="converter"/> is <see langword="null"/>.</exception>
+        [Obsolete("Only needed to assign a lambda to a field typed as a named converter alias, which Unity before 2023.1 required. The package now requires Unity 6000.0, so assign the converter directly. This will be removed in the next major version.")]
         public static IConverterTimeSpanToString ToConvertSpecific(this IConverter<TimeSpan, string?> converter) =>
             new ConverterTimeSpanToString(converter);
         

--- a/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Runtime/Converters/Strings/ConcatStringConverter.cs
+++ b/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Runtime/Converters/Strings/ConcatStringConverter.cs
@@ -2,6 +2,11 @@ using Aspid.FastTools.Types;
 using System;
 using UnityEngine;
 
+// The named converter aliases are [Obsolete]. The converters below keep implementing them for
+// one release so that a [SerializeReference] field a project declares as one still
+// deserializes; the base lists go with the aliases in the next major.
+#pragma warning disable CS0618 // Type or member is obsolete
+
 // ReSharper disable once CheckNamespace
 namespace Aspid.MVVM.StarterKit
 {

--- a/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Runtime/Converters/Strings/DefaultStringConverter.cs
+++ b/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Runtime/Converters/Strings/DefaultStringConverter.cs
@@ -2,6 +2,11 @@ using Aspid.FastTools.Types;
 using System;
 using UnityEngine;
 
+// The named converter aliases are [Obsolete]. The converters below keep implementing them for
+// one release so that a [SerializeReference] field a project declares as one still
+// deserializes; the base lists go with the aliases in the next major.
+#pragma warning disable CS0618 // Type or member is obsolete
+
 // ReSharper disable once CheckNamespace
 namespace Aspid.MVVM.StarterKit
 {

--- a/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Runtime/Converters/Strings/MaskStringConverter.cs
+++ b/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Runtime/Converters/Strings/MaskStringConverter.cs
@@ -2,6 +2,11 @@ using Aspid.FastTools.Types;
 using System;
 using UnityEngine;
 
+// The named converter aliases are [Obsolete]. The converters below keep implementing them for
+// one release so that a [SerializeReference] field a project declares as one still
+// deserializes; the base lists go with the aliases in the next major.
+#pragma warning disable CS0618 // Type or member is obsolete
+
 // ReSharper disable once CheckNamespace
 namespace Aspid.MVVM.StarterKit
 {

--- a/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Runtime/Converters/Strings/ObjectToStringConverter.cs
+++ b/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Runtime/Converters/Strings/ObjectToStringConverter.cs
@@ -1,6 +1,11 @@
 using Aspid.FastTools.Types;
 using System;
 
+// The named converter aliases are [Obsolete]. The converters below keep implementing them for
+// one release so that a [SerializeReference] field a project declares as one still
+// deserializes; the base lists go with the aliases in the next major.
+#pragma warning disable CS0618 // Type or member is obsolete
+
 // ReSharper disable once CheckNamespace
 namespace Aspid.MVVM.StarterKit
 {

--- a/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Runtime/Converters/Strings/PadStringConverter.cs
+++ b/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Runtime/Converters/Strings/PadStringConverter.cs
@@ -2,6 +2,11 @@ using Aspid.FastTools.Types;
 using System;
 using UnityEngine;
 
+// The named converter aliases are [Obsolete]. The converters below keep implementing them for
+// one release so that a [SerializeReference] field a project declares as one still
+// deserializes; the base lists go with the aliases in the next major.
+#pragma warning disable CS0618 // Type or member is obsolete
+
 // ReSharper disable once CheckNamespace
 namespace Aspid.MVVM.StarterKit
 {

--- a/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Runtime/Converters/Strings/ReplaceStringConverter.cs
+++ b/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Runtime/Converters/Strings/ReplaceStringConverter.cs
@@ -2,6 +2,11 @@ using Aspid.FastTools.Types;
 using System;
 using UnityEngine;
 
+// The named converter aliases are [Obsolete]. The converters below keep implementing them for
+// one release so that a [SerializeReference] field a project declares as one still
+// deserializes; the base lists go with the aliases in the next major.
+#pragma warning disable CS0618 // Type or member is obsolete
+
 // ReSharper disable once CheckNamespace
 namespace Aspid.MVVM.StarterKit
 {

--- a/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Runtime/Converters/Strings/StringFormatConverter.cs
+++ b/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Runtime/Converters/Strings/StringFormatConverter.cs
@@ -2,6 +2,11 @@ using Aspid.FastTools.Types;
 using System;
 using UnityEngine;
 
+// The named converter aliases are [Obsolete]. The converters below keep implementing them for
+// one release so that a [SerializeReference] field a project declares as one still
+// deserializes; the base lists go with the aliases in the next major.
+#pragma warning disable CS0618 // Type or member is obsolete
+
 // ReSharper disable once CheckNamespace
 namespace Aspid.MVVM.StarterKit
 {

--- a/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Runtime/Converters/Strings/StringToBoolParseConverter.cs
+++ b/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Runtime/Converters/Strings/StringToBoolParseConverter.cs
@@ -2,6 +2,11 @@ using Aspid.FastTools.Types;
 using System;
 using UnityEngine;
 
+// The named converter aliases are [Obsolete]. The converters below keep implementing them for
+// one release so that a [SerializeReference] field a project declares as one still
+// deserializes; the base lists go with the aliases in the next major.
+#pragma warning disable CS0618 // Type or member is obsolete
+
 // ReSharper disable once CheckNamespace
 namespace Aspid.MVVM.StarterKit
 {

--- a/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Runtime/Converters/Strings/SubstringConverter.cs
+++ b/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Runtime/Converters/Strings/SubstringConverter.cs
@@ -2,6 +2,11 @@ using Aspid.FastTools.Types;
 using System;
 using UnityEngine;
 
+// The named converter aliases are [Obsolete]. The converters below keep implementing them for
+// one release so that a [SerializeReference] field a project declares as one still
+// deserializes; the base lists go with the aliases in the next major.
+#pragma warning disable CS0618 // Type or member is obsolete
+
 // ReSharper disable once CheckNamespace
 namespace Aspid.MVVM.StarterKit
 {

--- a/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Runtime/Converters/Strings/TextCaseConverter.cs
+++ b/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Runtime/Converters/Strings/TextCaseConverter.cs
@@ -3,6 +3,11 @@ using System;
 using UnityEngine;
 using System.Globalization;
 
+// The named converter aliases are [Obsolete]. The converters below keep implementing them for
+// one release so that a [SerializeReference] field a project declares as one still
+// deserializes; the base lists go with the aliases in the next major.
+#pragma warning disable CS0618 // Type or member is obsolete
+
 // ReSharper disable once CheckNamespace
 namespace Aspid.MVVM.StarterKit
 {

--- a/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Runtime/Converters/Strings/TimeSpanToStringConverter.cs
+++ b/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Runtime/Converters/Strings/TimeSpanToStringConverter.cs
@@ -1,6 +1,11 @@
 using Aspid.FastTools.Types;
 using System;
 
+// The named converter aliases are [Obsolete]. The converters below keep implementing them for
+// one release so that a [SerializeReference] field a project declares as one still
+// deserializes; the base lists go with the aliases in the next major.
+#pragma warning disable CS0618 // Type or member is obsolete
+
 // ReSharper disable once CheckNamespace
 namespace Aspid.MVVM.StarterKit
 {

--- a/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Runtime/Converters/Strings/TrimStringConverter.cs
+++ b/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Runtime/Converters/Strings/TrimStringConverter.cs
@@ -2,6 +2,11 @@ using Aspid.FastTools.Types;
 using System;
 using UnityEngine;
 
+// The named converter aliases are [Obsolete]. The converters below keep implementing them for
+// one release so that a [SerializeReference] field a project declares as one still
+// deserializes; the base lists go with the aliases in the next major.
+#pragma warning disable CS0618 // Type or member is obsolete
+
 // ReSharper disable once CheckNamespace
 namespace Aspid.MVVM.StarterKit
 {

--- a/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Runtime/Converters/Strings/TruncateStringConverter.cs
+++ b/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Runtime/Converters/Strings/TruncateStringConverter.cs
@@ -2,6 +2,11 @@ using Aspid.FastTools.Types;
 using System;
 using UnityEngine;
 
+// The named converter aliases are [Obsolete]. The converters below keep implementing them for
+// one release so that a [SerializeReference] field a project declares as one still
+// deserializes; the base lists go with the aliases in the next major.
+#pragma warning disable CS0618 // Type or member is obsolete
+
 // ReSharper disable once CheckNamespace
 namespace Aspid.MVVM.StarterKit
 {

--- a/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Runtime/Converters/Times/TimeSpanFormatConverter.cs
+++ b/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Runtime/Converters/Times/TimeSpanFormatConverter.cs
@@ -2,6 +2,11 @@ using Aspid.FastTools.Types;
 using System;
 using UnityEngine;
 
+// The named converter aliases are [Obsolete]. The converters below keep implementing them for
+// one release so that a [SerializeReference] field a project declares as one still
+// deserializes; the base lists go with the aliases in the next major.
+#pragma warning disable CS0618 // Type or member is obsolete
+
 // ReSharper disable once CheckNamespace
 namespace Aspid.MVVM.StarterKit
 {

--- a/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Unity/Runtime/Converters/Assets/MaterialInstanceConverter.cs
+++ b/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Unity/Runtime/Converters/Assets/MaterialInstanceConverter.cs
@@ -3,6 +3,11 @@ using Aspid.FastTools.Types;
 using System;
 using UnityEngine;
 
+// The named converter aliases are [Obsolete]. The converters below keep implementing them for
+// one release so that a [SerializeReference] field a project declares as one still
+// deserializes; the base lists go with the aliases in the next major.
+#pragma warning disable CS0618 // Type or member is obsolete
+
 // ReSharper disable once CheckNamespace
 namespace Aspid.MVVM.StarterKit
 {

--- a/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Unity/Runtime/Converters/Colors/ColorAlphaConverter.cs
+++ b/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Unity/Runtime/Converters/Colors/ColorAlphaConverter.cs
@@ -3,6 +3,11 @@ using Aspid.FastTools.Types;
 using System;
 using UnityEngine;
 
+// The named converter aliases are [Obsolete]. The converters below keep implementing them for
+// one release so that a [SerializeReference] field a project declares as one still
+// deserializes; the base lists go with the aliases in the next major.
+#pragma warning disable CS0618 // Type or member is obsolete
+
 // ReSharper disable once CheckNamespace
 namespace Aspid.MVVM.StarterKit
 {

--- a/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Unity/Runtime/Converters/Colors/ColorBlockAlphaConverter.cs
+++ b/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Unity/Runtime/Converters/Colors/ColorBlockAlphaConverter.cs
@@ -4,6 +4,11 @@ using System;
 using UnityEngine;
 using UnityEngine.UI;
 
+// The named converter aliases are [Obsolete]. The converters below keep implementing them for
+// one release so that a [SerializeReference] field a project declares as one still
+// deserializes; the base lists go with the aliases in the next major.
+#pragma warning disable CS0618 // Type or member is obsolete
+
 // ReSharper disable once CheckNamespace
 namespace Aspid.MVVM.StarterKit
 {

--- a/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Unity/Runtime/Converters/Colors/ColorBlockFadeDurationConverter.cs
+++ b/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Unity/Runtime/Converters/Colors/ColorBlockFadeDurationConverter.cs
@@ -4,6 +4,11 @@ using System;
 using UnityEngine;
 using UnityEngine.UI;
 
+// The named converter aliases are [Obsolete]. The converters below keep implementing them for
+// one release so that a [SerializeReference] field a project declares as one still
+// deserializes; the base lists go with the aliases in the next major.
+#pragma warning disable CS0618 // Type or member is obsolete
+
 // ReSharper disable once CheckNamespace
 namespace Aspid.MVVM.StarterKit
 {

--- a/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Unity/Runtime/Converters/Colors/ColorBlockTintConverter.cs
+++ b/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Unity/Runtime/Converters/Colors/ColorBlockTintConverter.cs
@@ -4,6 +4,11 @@ using System;
 using UnityEngine;
 using UnityEngine.UI;
 
+// The named converter aliases are [Obsolete]. The converters below keep implementing them for
+// one release so that a [SerializeReference] field a project declares as one still
+// deserializes; the base lists go with the aliases in the next major.
+#pragma warning disable CS0618 // Type or member is obsolete
+
 // ReSharper disable once CheckNamespace
 namespace Aspid.MVVM.StarterKit
 {

--- a/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Unity/Runtime/Converters/Colors/ColorGrayscaleConverter.cs
+++ b/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Unity/Runtime/Converters/Colors/ColorGrayscaleConverter.cs
@@ -3,6 +3,11 @@ using Aspid.FastTools.Types;
 using System;
 using UnityEngine;
 
+// The named converter aliases are [Obsolete]. The converters below keep implementing them for
+// one release so that a [SerializeReference] field a project declares as one still
+// deserializes; the base lists go with the aliases in the next major.
+#pragma warning disable CS0618 // Type or member is obsolete
+
 // ReSharper disable once CheckNamespace
 namespace Aspid.MVVM.StarterKit
 {

--- a/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Unity/Runtime/Converters/Colors/ColorHsvConverter.cs
+++ b/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Unity/Runtime/Converters/Colors/ColorHsvConverter.cs
@@ -3,6 +3,11 @@ using Aspid.FastTools.Types;
 using System;
 using UnityEngine;
 
+// The named converter aliases are [Obsolete]. The converters below keep implementing them for
+// one release so that a [SerializeReference] field a project declares as one still
+// deserializes; the base lists go with the aliases in the next major.
+#pragma warning disable CS0618 // Type or member is obsolete
+
 // ReSharper disable once CheckNamespace
 namespace Aspid.MVVM.StarterKit
 {

--- a/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Unity/Runtime/Converters/Colors/ColorTintConverter.cs
+++ b/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Unity/Runtime/Converters/Colors/ColorTintConverter.cs
@@ -3,6 +3,11 @@ using Aspid.FastTools.Types;
 using System;
 using UnityEngine;
 
+// The named converter aliases are [Obsolete]. The converters below keep implementing them for
+// one release so that a [SerializeReference] field a project declares as one still
+// deserializes; the base lists go with the aliases in the next major.
+#pragma warning disable CS0618 // Type or member is obsolete
+
 // ReSharper disable once CheckNamespace
 namespace Aspid.MVVM.StarterKit
 {

--- a/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Unity/Runtime/Converters/Colors/ParseHtmlStringConverter.cs
+++ b/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Unity/Runtime/Converters/Colors/ParseHtmlStringConverter.cs
@@ -3,6 +3,11 @@ using Aspid.FastTools.Types;
 using System;
 using UnityEngine;
 
+// The named converter aliases are [Obsolete]. The converters below keep implementing them for
+// one release so that a [SerializeReference] field a project declares as one still
+// deserializes; the base lists go with the aliases in the next major.
+#pragma warning disable CS0618 // Type or member is obsolete
+
 // ReSharper disable once CheckNamespace
 namespace Aspid.MVVM.StarterKit
 {

--- a/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Unity/Runtime/Converters/Enums/EnumToDropdownOptionDataConverter.cs
+++ b/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Unity/Runtime/Converters/Enums/EnumToDropdownOptionDataConverter.cs
@@ -6,6 +6,11 @@ using System;
 using UnityEngine;
 using System.Collections.Generic;
 
+// The named converter aliases are [Obsolete]. The converters below keep implementing them for
+// one release so that a [SerializeReference] field a project declares as one still
+// deserializes; the base lists go with the aliases in the next major.
+#pragma warning disable CS0618 // Type or member is obsolete
+
 // ReSharper disable once CheckNamespace
 namespace Aspid.MVVM.StarterKit
 {

--- a/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Unity/Runtime/Converters/Layouts/RectOffsetScaleConverter.cs
+++ b/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Unity/Runtime/Converters/Layouts/RectOffsetScaleConverter.cs
@@ -3,6 +3,11 @@ using Aspid.FastTools.Types;
 using System;
 using UnityEngine;
 
+// The named converter aliases are [Obsolete]. The converters below keep implementing them for
+// one release so that a [SerializeReference] field a project declares as one still
+// deserializes; the base lists go with the aliases in the next major.
+#pragma warning disable CS0618 // Type or member is obsolete
+
 // ReSharper disable once CheckNamespace
 namespace Aspid.MVVM.StarterKit
 {

--- a/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Unity/Runtime/Converters/Localizations/LocalizedStringConverter.cs
+++ b/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Unity/Runtime/Converters/Localizations/LocalizedStringConverter.cs
@@ -5,6 +5,11 @@ using System;
 using UnityEngine;
 using UnityEngine.Localization;
 
+// The named converter aliases are [Obsolete]. The converters below keep implementing them for
+// one release so that a [SerializeReference] field a project declares as one still
+// deserializes; the base lists go with the aliases in the next major.
+#pragma warning disable CS0618 // Type or member is obsolete
+
 // ReSharper disable once CheckNamespace
 namespace Aspid.MVVM.StarterKit
 {

--- a/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Unity/Runtime/Converters/Numbers/AnimationCurveConverter.cs
+++ b/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Unity/Runtime/Converters/Numbers/AnimationCurveConverter.cs
@@ -3,6 +3,11 @@ using Aspid.FastTools.Types;
 using System;
 using UnityEngine;
 
+// The named converter aliases are [Obsolete]. The converters below keep implementing them for
+// one release so that a [SerializeReference] field a project declares as one still
+// deserializes; the base lists go with the aliases in the next major.
+#pragma warning disable CS0618 // Type or member is obsolete
+
 // ReSharper disable once CheckNamespace
 namespace Aspid.MVVM.StarterKit
 {

--- a/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Unity/Runtime/Converters/Rotations/AngleToQuaternionConverter.cs
+++ b/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Unity/Runtime/Converters/Rotations/AngleToQuaternionConverter.cs
@@ -3,6 +3,11 @@ using Aspid.FastTools.Types;
 using System;
 using UnityEngine;
 
+// The named converter aliases are [Obsolete]. The converters below keep implementing them for
+// one release so that a [SerializeReference] field a project declares as one still
+// deserializes; the base lists go with the aliases in the next major.
+#pragma warning disable CS0618 // Type or member is obsolete
+
 // ReSharper disable once CheckNamespace
 namespace Aspid.MVVM.StarterKit
 {

--- a/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Unity/Runtime/Converters/Rotations/AngleWrapConverter.cs
+++ b/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Unity/Runtime/Converters/Rotations/AngleWrapConverter.cs
@@ -3,6 +3,11 @@ using Aspid.FastTools.Types;
 using System;
 using UnityEngine;
 
+// The named converter aliases are [Obsolete]. The converters below keep implementing them for
+// one release so that a [SerializeReference] field a project declares as one still
+// deserializes; the base lists go with the aliases in the next major.
+#pragma warning disable CS0618 // Type or member is obsolete
+
 // ReSharper disable once CheckNamespace
 namespace Aspid.MVVM.StarterKit
 {

--- a/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Unity/Runtime/Converters/Specific/Colors/ConverterColorSpecificExtensions.cs
+++ b/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Unity/Runtime/Converters/Specific/Colors/ConverterColorSpecificExtensions.cs
@@ -16,6 +16,7 @@ namespace Aspid.MVVM.StarterKit
     /// Unity 2023.1 declares its field as the named interface rather than the generic one,
     /// so a lambda cannot be assigned to it directly.
     /// </remarks>
+    [Obsolete("Only needed to assign a lambda to a field typed as a named converter alias, which Unity before 2023.1 required. The package now requires Unity 6000.0, so assign the converter directly. This will be removed in the next major version.")]
     public static class ConverterColorSpecificExtensions
     {
         /// <summary>
@@ -24,6 +25,7 @@ namespace Aspid.MVVM.StarterKit
         /// <param name="converter">The function to wrap.</param>
         /// <returns>A converter of the named interface type.</returns>
         /// <exception cref="System.ArgumentNullException">Thrown when <paramref name="converter"/> is <see langword="null"/>.</exception>
+        [Obsolete("Only needed to assign a lambda to a field typed as a named converter alias, which Unity before 2023.1 required. The package now requires Unity 6000.0, so assign the converter directly. This will be removed in the next major version.")]
         public static IConverterColor ToConvert(this Func<Color, Color> converter) =>
             new ConverterColor(converter);
         
@@ -33,6 +35,7 @@ namespace Aspid.MVVM.StarterKit
         /// <param name="converter">The converter to wrap.</param>
         /// <returns>A converter of the named interface type.</returns>
         /// <exception cref="System.ArgumentNullException">Thrown when <paramref name="converter"/> is <see langword="null"/>.</exception>
+        [Obsolete("Only needed to assign a lambda to a field typed as a named converter alias, which Unity before 2023.1 required. The package now requires Unity 6000.0, so assign the converter directly. This will be removed in the next major version.")]
         public static IConverterColor ToConvertSpecific(this IConverter<Color, Color> converter) =>
             new ConverterColor(converter);
         
@@ -42,6 +45,7 @@ namespace Aspid.MVVM.StarterKit
         /// <param name="converter">The function to wrap.</param>
         /// <returns>A converter of the named interface type.</returns>
         /// <exception cref="System.ArgumentNullException">Thrown when <paramref name="converter"/> is <see langword="null"/>.</exception>
+        [Obsolete("Only needed to assign a lambda to a field typed as a named converter alias, which Unity before 2023.1 required. The package now requires Unity 6000.0, so assign the converter directly. This will be removed in the next major version.")]
         public static IConverterStringToColor ToConvert(this Func<string?, Color> converter) =>
             new ConverterStringToColor(converter);
         
@@ -51,6 +55,7 @@ namespace Aspid.MVVM.StarterKit
         /// <param name="converter">The converter to wrap.</param>
         /// <returns>A converter of the named interface type.</returns>
         /// <exception cref="System.ArgumentNullException">Thrown when <paramref name="converter"/> is <see langword="null"/>.</exception>
+        [Obsolete("Only needed to assign a lambda to a field typed as a named converter alias, which Unity before 2023.1 required. The package now requires Unity 6000.0, so assign the converter directly. This will be removed in the next major version.")]
         public static IConverterStringToColor ToConvertSpecific(this IConverter<string?, Color> converter) =>
             new ConverterStringToColor(converter);
         

--- a/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Unity/Runtime/Converters/Specific/Colors/IConverterColor.cs
+++ b/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Unity/Runtime/Converters/Specific/Colors/IConverterColor.cs
@@ -1,4 +1,5 @@
 #nullable enable
+using System;
 using UnityEngine;
 
 // ReSharper disable once CheckNamespace
@@ -8,10 +9,16 @@ namespace Aspid.MVVM.StarterKit
     /// A converter from <see cref="Color"/> to <see cref="Color"/>.
     /// </summary>
     /// <remarks>
-    /// A named alias for <see cref="IConverter{TFrom, TTo}"/> closed over these two types.
-    /// It exists because Unity before 2023.1 cannot serialize a <c>[SerializeReference]</c>
-    /// field typed as an open generic, so a binder declares the field as this instead. From
-    /// 2023.1 the generic form is used directly and this is a compatibility shim.
+    /// A named alias for <see cref="IConverter{TFrom, TTo}"/> closed over these two types. It
+    /// existed because Unity before 2023.1 could not serialize a <c>[SerializeReference]</c> field
+    /// typed as an open generic, so a binder declared the field as this instead.
+    /// <para>
+    /// The package requires Unity 6000.0, so nothing in it declares such a field any more and this
+    /// carries no behaviour of its own. It stays one release so that code naming it keeps compiling
+    /// with a warning, and so that a <c>[SerializeReference]</c> field a project declares as this
+    /// type does not silently deserialize to <see langword="null"/>.
+    /// </para>
     /// </remarks>
+    [Obsolete("Named converter aliases only existed because Unity before 2023.1 could not serialize a [SerializeReference] field of an open generic type. The package now requires Unity 6000.0, so use IConverter<Color, Color> directly. This will be removed in the next major version.")]
     public interface IConverterColor : IConverter<Color, Color> { }
 }

--- a/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Unity/Runtime/Converters/Specific/Colors/IConverterColor.cs
+++ b/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Unity/Runtime/Converters/Specific/Colors/IConverterColor.cs
@@ -9,15 +9,8 @@ namespace Aspid.MVVM.StarterKit
     /// A converter from <see cref="Color"/> to <see cref="Color"/>.
     /// </summary>
     /// <remarks>
-    /// A named alias for <see cref="IConverter{TFrom, TTo}"/> closed over these two types. It
-    /// existed because Unity before 2023.1 could not serialize a <c>[SerializeReference]</c> field
-    /// typed as an open generic, so a binder declared the field as this instead.
-    /// <para>
-    /// The package requires Unity 6000.0, so nothing in it declares such a field any more and this
-    /// carries no behaviour of its own. It stays one release so that code naming it keeps compiling
-    /// with a warning, and so that a <c>[SerializeReference]</c> field a project declares as this
-    /// type does not silently deserialize to <see langword="null"/>.
-    /// </para>
+    /// Kept for one release so code naming it still compiles and a <c>[SerializeReference]</c> field
+    /// a project declares as this type does not silently deserialize to <see langword="null"/>.
     /// </remarks>
     [Obsolete("Named converter aliases only existed because Unity before 2023.1 could not serialize a [SerializeReference] field of an open generic type. The package now requires Unity 6000.0, so use IConverter<Color, Color> directly. This will be removed in the next major version.")]
     public interface IConverterColor : IConverter<Color, Color> { }

--- a/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Unity/Runtime/Converters/Specific/Colors/IConverterColorBlock.cs
+++ b/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Unity/Runtime/Converters/Specific/Colors/IConverterColorBlock.cs
@@ -9,15 +9,8 @@ namespace Aspid.MVVM.StarterKit
     /// A converter from <see cref="ColorBlock"/> to <see cref="ColorBlock"/>.
     /// </summary>
     /// <remarks>
-    /// A named alias for <see cref="IConverter{TFrom, TTo}"/> closed over these two types. It
-    /// existed because Unity before 2023.1 could not serialize a <c>[SerializeReference]</c> field
-    /// typed as an open generic, so a binder declared the field as this instead.
-    /// <para>
-    /// The package requires Unity 6000.0, so nothing in it declares such a field any more and this
-    /// carries no behaviour of its own. It stays one release so that code naming it keeps compiling
-    /// with a warning, and so that a <c>[SerializeReference]</c> field a project declares as this
-    /// type does not silently deserialize to <see langword="null"/>.
-    /// </para>
+    /// Kept for one release so code naming it still compiles and a <c>[SerializeReference]</c> field
+    /// a project declares as this type does not silently deserialize to <see langword="null"/>.
     /// </remarks>
     [Obsolete("Named converter aliases only existed because Unity before 2023.1 could not serialize a [SerializeReference] field of an open generic type. The package now requires Unity 6000.0, so use IConverter<ColorBlock, ColorBlock> directly. This will be removed in the next major version.")]
     public interface IConverterColorBlock : IConverter<ColorBlock, ColorBlock> { }

--- a/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Unity/Runtime/Converters/Specific/Colors/IConverterColorBlock.cs
+++ b/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Unity/Runtime/Converters/Specific/Colors/IConverterColorBlock.cs
@@ -1,4 +1,5 @@
 #nullable enable
+using System;
 using UnityEngine.UI;
 
 // ReSharper disable once CheckNamespace
@@ -8,10 +9,16 @@ namespace Aspid.MVVM.StarterKit
     /// A converter from <see cref="ColorBlock"/> to <see cref="ColorBlock"/>.
     /// </summary>
     /// <remarks>
-    /// A named alias for <see cref="IConverter{TFrom, TTo}"/> closed over these two types.
-    /// It exists because Unity before 2023.1 cannot serialize a <c>[SerializeReference]</c>
-    /// field typed as an open generic, so a binder declares the field as this instead. From
-    /// 2023.1 the generic form is used directly and this is a compatibility shim.
+    /// A named alias for <see cref="IConverter{TFrom, TTo}"/> closed over these two types. It
+    /// existed because Unity before 2023.1 could not serialize a <c>[SerializeReference]</c> field
+    /// typed as an open generic, so a binder declared the field as this instead.
+    /// <para>
+    /// The package requires Unity 6000.0, so nothing in it declares such a field any more and this
+    /// carries no behaviour of its own. It stays one release so that code naming it keeps compiling
+    /// with a warning, and so that a <c>[SerializeReference]</c> field a project declares as this
+    /// type does not silently deserialize to <see langword="null"/>.
+    /// </para>
     /// </remarks>
+    [Obsolete("Named converter aliases only existed because Unity before 2023.1 could not serialize a [SerializeReference] field of an open generic type. The package now requires Unity 6000.0, so use IConverter<ColorBlock, ColorBlock> directly. This will be removed in the next major version.")]
     public interface IConverterColorBlock : IConverter<ColorBlock, ColorBlock> { }
 }

--- a/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Unity/Runtime/Converters/Specific/Colors/IConverterStringToColor.cs
+++ b/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Unity/Runtime/Converters/Specific/Colors/IConverterStringToColor.cs
@@ -9,15 +9,8 @@ namespace Aspid.MVVM.StarterKit
     /// A converter from <see cref="string"/> to <see cref="Color"/>.
     /// </summary>
     /// <remarks>
-    /// A named alias for <see cref="IConverter{TFrom, TTo}"/> closed over these two types. It
-    /// existed because Unity before 2023.1 could not serialize a <c>[SerializeReference]</c> field
-    /// typed as an open generic, so a binder declared the field as this instead.
-    /// <para>
-    /// The package requires Unity 6000.0, so nothing in it declares such a field any more and this
-    /// carries no behaviour of its own. It stays one release so that code naming it keeps compiling
-    /// with a warning, and so that a <c>[SerializeReference]</c> field a project declares as this
-    /// type does not silently deserialize to <see langword="null"/>.
-    /// </para>
+    /// Kept for one release so code naming it still compiles and a <c>[SerializeReference]</c> field
+    /// a project declares as this type does not silently deserialize to <see langword="null"/>.
     /// </remarks>
     [Obsolete("Named converter aliases only existed because Unity before 2023.1 could not serialize a [SerializeReference] field of an open generic type. The package now requires Unity 6000.0, so use IConverter<string?, Color> directly. This will be removed in the next major version.")]
     public interface IConverterStringToColor : IConverter<string?, Color> { }

--- a/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Unity/Runtime/Converters/Specific/Colors/IConverterStringToColor.cs
+++ b/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Unity/Runtime/Converters/Specific/Colors/IConverterStringToColor.cs
@@ -1,4 +1,5 @@
 #nullable enable
+using System;
 using UnityEngine;
 
 // ReSharper disable once CheckNamespace
@@ -8,10 +9,16 @@ namespace Aspid.MVVM.StarterKit
     /// A converter from <see cref="string"/> to <see cref="Color"/>.
     /// </summary>
     /// <remarks>
-    /// A named alias for <see cref="IConverter{TFrom, TTo}"/> closed over these two types.
-    /// It exists because Unity before 2023.1 cannot serialize a <c>[SerializeReference]</c>
-    /// field typed as an open generic, so a binder declares the field as this instead. From
-    /// 2023.1 the generic form is used directly and this is a compatibility shim.
+    /// A named alias for <see cref="IConverter{TFrom, TTo}"/> closed over these two types. It
+    /// existed because Unity before 2023.1 could not serialize a <c>[SerializeReference]</c> field
+    /// typed as an open generic, so a binder declared the field as this instead.
+    /// <para>
+    /// The package requires Unity 6000.0, so nothing in it declares such a field any more and this
+    /// carries no behaviour of its own. It stays one release so that code naming it keeps compiling
+    /// with a warning, and so that a <c>[SerializeReference]</c> field a project declares as this
+    /// type does not silently deserialize to <see langword="null"/>.
+    /// </para>
     /// </remarks>
+    [Obsolete("Named converter aliases only existed because Unity before 2023.1 could not serialize a [SerializeReference] field of an open generic type. The package now requires Unity 6000.0, so use IConverter<string?, Color> directly. This will be removed in the next major version.")]
     public interface IConverterStringToColor : IConverter<string?, Color> { }
 }

--- a/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Unity/Runtime/Converters/Specific/ConverterSpecificExtensions.cs
+++ b/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Unity/Runtime/Converters/Specific/ConverterSpecificExtensions.cs
@@ -17,6 +17,7 @@ namespace Aspid.MVVM.StarterKit
     /// Unity 2023.1 declares its field as the named interface rather than the generic one,
     /// so a lambda cannot be assigned to it directly.
     /// </remarks>
+    [Obsolete("Only needed to assign a lambda to a field typed as a named converter alias, which Unity before 2023.1 required. The package now requires Unity 6000.0, so assign the converter directly. This will be removed in the next major version.")]
     public static class ConverterSpecificExtensions
     {
         /// <summary>
@@ -25,6 +26,7 @@ namespace Aspid.MVVM.StarterKit
         /// <param name="converter">The function to wrap.</param>
         /// <returns>A converter of the named interface type.</returns>
         /// <exception cref="System.ArgumentNullException">Thrown when <paramref name="converter"/> is <see langword="null"/>.</exception>
+        [Obsolete("Only needed to assign a lambda to a field typed as a named converter alias, which Unity before 2023.1 required. The package now requires Unity 6000.0, so assign the converter directly. This will be removed in the next major version.")]
         public static IConverterMesh ToConvert(this Func<Mesh?, Mesh?> converter) =>
             new ConverterMesh(converter);
         
@@ -34,6 +36,7 @@ namespace Aspid.MVVM.StarterKit
         /// <param name="converter">The converter to wrap.</param>
         /// <returns>A converter of the named interface type.</returns>
         /// <exception cref="System.ArgumentNullException">Thrown when <paramref name="converter"/> is <see langword="null"/>.</exception>
+        [Obsolete("Only needed to assign a lambda to a field typed as a named converter alias, which Unity before 2023.1 required. The package now requires Unity 6000.0, so assign the converter directly. This will be removed in the next major version.")]
         public static IConverterMesh ToConvertSpecific(this IConverter<Mesh?, Mesh?> converter) =>
             new ConverterMesh(converter);
         
@@ -43,6 +46,7 @@ namespace Aspid.MVVM.StarterKit
         /// <param name="converter">The function to wrap.</param>
         /// <returns>A converter of the named interface type.</returns>
         /// <exception cref="System.ArgumentNullException">Thrown when <paramref name="converter"/> is <see langword="null"/>.</exception>
+        [Obsolete("Only needed to assign a lambda to a field typed as a named converter alias, which Unity before 2023.1 required. The package now requires Unity 6000.0, so assign the converter directly. This will be removed in the next major version.")]
         public static IConverterMaterial ToConvert(this Func<Material?, Material?> converter) =>
             new ConverterMaterial(converter);
         
@@ -52,6 +56,7 @@ namespace Aspid.MVVM.StarterKit
         /// <param name="converter">The converter to wrap.</param>
         /// <returns>A converter of the named interface type.</returns>
         /// <exception cref="System.ArgumentNullException">Thrown when <paramref name="converter"/> is <see langword="null"/>.</exception>
+        [Obsolete("Only needed to assign a lambda to a field typed as a named converter alias, which Unity before 2023.1 required. The package now requires Unity 6000.0, so assign the converter directly. This will be removed in the next major version.")]
         public static IConverterMaterial ToConvertSpecific(this IConverter<Material?, Material?> converter) =>
             new ConverterMaterial(converter);
         
@@ -61,6 +66,7 @@ namespace Aspid.MVVM.StarterKit
         /// <param name="converter">The function to wrap.</param>
         /// <returns>A converter of the named interface type.</returns>
         /// <exception cref="System.ArgumentNullException">Thrown when <paramref name="converter"/> is <see langword="null"/>.</exception>
+        [Obsolete("Only needed to assign a lambda to a field typed as a named converter alias, which Unity before 2023.1 required. The package now requires Unity 6000.0, so assign the converter directly. This will be removed in the next major version.")]
         public static IConverterQuaternion ToConvert(this Func<Quaternion, Quaternion> converter) =>
             new ConverterQuaternion(converter);
         
@@ -70,6 +76,7 @@ namespace Aspid.MVVM.StarterKit
         /// <param name="converter">The converter to wrap.</param>
         /// <returns>A converter of the named interface type.</returns>
         /// <exception cref="System.ArgumentNullException">Thrown when <paramref name="converter"/> is <see langword="null"/>.</exception>
+        [Obsolete("Only needed to assign a lambda to a field typed as a named converter alias, which Unity before 2023.1 required. The package now requires Unity 6000.0, so assign the converter directly. This will be removed in the next major version.")]
         public static IConverterQuaternion ToConvertSpecific(this IConverter<Quaternion, Quaternion> converter) =>
             new ConverterQuaternion(converter);
         
@@ -79,6 +86,7 @@ namespace Aspid.MVVM.StarterKit
         /// <param name="converter">The function to wrap.</param>
         /// <returns>A converter of the named interface type.</returns>
         /// <exception cref="System.ArgumentNullException">Thrown when <paramref name="converter"/> is <see langword="null"/>.</exception>
+        [Obsolete("Only needed to assign a lambda to a field typed as a named converter alias, which Unity before 2023.1 required. The package now requires Unity 6000.0, so assign the converter directly. This will be removed in the next major version.")]
         public static IConverterPhysicsMaterial ToConvert(this Func<PhysicsMaterial?, PhysicsMaterial?> converter) =>
             new ConverterPhysicsMaterial(converter);
         
@@ -88,6 +96,7 @@ namespace Aspid.MVVM.StarterKit
         /// <param name="converter">The converter to wrap.</param>
         /// <returns>A converter of the named interface type.</returns>
         /// <exception cref="System.ArgumentNullException">Thrown when <paramref name="converter"/> is <see langword="null"/>.</exception>
+        [Obsolete("Only needed to assign a lambda to a field typed as a named converter alias, which Unity before 2023.1 required. The package now requires Unity 6000.0, so assign the converter directly. This will be removed in the next major version.")]
         public static IConverterPhysicsMaterial ToConvertSpecific(this IConverter<PhysicsMaterial?, PhysicsMaterial?> converter) =>
             new ConverterPhysicsMaterial(converter);
         

--- a/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Unity/Runtime/Converters/Specific/IConverterEnumToDropdownOptionData.cs
+++ b/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Unity/Runtime/Converters/Specific/IConverterEnumToDropdownOptionData.cs
@@ -10,10 +10,16 @@ namespace Aspid.MVVM.StarterKit
     /// A converter from <see cref="Enum"/> to <see cref="OptionData>"/>.
     /// </summary>
     /// <remarks>
-    /// A named alias for <see cref="IConverter{TFrom, TTo}"/> closed over these two types.
-    /// It exists because Unity before 2023.1 cannot serialize a <c>[SerializeReference]</c>
-    /// field typed as an open generic, so a binder declares the field as this instead. From
-    /// 2023.1 the generic form is used directly and this is a compatibility shim.
+    /// A named alias for <see cref="IConverter{TFrom, TTo}"/> closed over these two types. It
+    /// existed because Unity before 2023.1 could not serialize a <c>[SerializeReference]</c> field
+    /// typed as an open generic, so a binder declared the field as this instead.
+    /// <para>
+    /// The package requires Unity 6000.0, so nothing in it declares such a field any more and this
+    /// carries no behaviour of its own. It stays one release so that code naming it keeps compiling
+    /// with a warning, and so that a <c>[SerializeReference]</c> field a project declares as this
+    /// type does not silently deserialize to <see langword="null"/>.
+    /// </para>
     /// </remarks>
+    [Obsolete("Named converter aliases only existed because Unity before 2023.1 could not serialize a [SerializeReference] field of an open generic type. The package now requires Unity 6000.0, so use IConverter<Enum, IEnumerable<TMP_Dropdown.OptionData>> directly. This will be removed in the next major version.")]
     public interface IConverterEnumToDropdownOptionData : IConverter<Enum, IEnumerable<TMP_Dropdown.OptionData>> { }
 }

--- a/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Unity/Runtime/Converters/Specific/IConverterEnumToDropdownOptionData.cs
+++ b/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Unity/Runtime/Converters/Specific/IConverterEnumToDropdownOptionData.cs
@@ -10,15 +10,8 @@ namespace Aspid.MVVM.StarterKit
     /// A converter from <see cref="Enum"/> to <see cref="OptionData>"/>.
     /// </summary>
     /// <remarks>
-    /// A named alias for <see cref="IConverter{TFrom, TTo}"/> closed over these two types. It
-    /// existed because Unity before 2023.1 could not serialize a <c>[SerializeReference]</c> field
-    /// typed as an open generic, so a binder declared the field as this instead.
-    /// <para>
-    /// The package requires Unity 6000.0, so nothing in it declares such a field any more and this
-    /// carries no behaviour of its own. It stays one release so that code naming it keeps compiling
-    /// with a warning, and so that a <c>[SerializeReference]</c> field a project declares as this
-    /// type does not silently deserialize to <see langword="null"/>.
-    /// </para>
+    /// Kept for one release so code naming it still compiles and a <c>[SerializeReference]</c> field
+    /// a project declares as this type does not silently deserialize to <see langword="null"/>.
     /// </remarks>
     [Obsolete("Named converter aliases only existed because Unity before 2023.1 could not serialize a [SerializeReference] field of an open generic type. The package now requires Unity 6000.0, so use IConverter<Enum, IEnumerable<TMP_Dropdown.OptionData>> directly. This will be removed in the next major version.")]
     public interface IConverterEnumToDropdownOptionData : IConverter<Enum, IEnumerable<TMP_Dropdown.OptionData>> { }

--- a/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Unity/Runtime/Converters/Specific/IConverterMaterial.cs
+++ b/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Unity/Runtime/Converters/Specific/IConverterMaterial.cs
@@ -9,15 +9,8 @@ namespace Aspid.MVVM.StarterKit
     /// A converter from <see cref="Material"/> to <see cref="Material"/>.
     /// </summary>
     /// <remarks>
-    /// A named alias for <see cref="IConverter{TFrom, TTo}"/> closed over these two types. It
-    /// existed because Unity before 2023.1 could not serialize a <c>[SerializeReference]</c> field
-    /// typed as an open generic, so a binder declared the field as this instead.
-    /// <para>
-    /// The package requires Unity 6000.0, so nothing in it declares such a field any more and this
-    /// carries no behaviour of its own. It stays one release so that code naming it keeps compiling
-    /// with a warning, and so that a <c>[SerializeReference]</c> field a project declares as this
-    /// type does not silently deserialize to <see langword="null"/>.
-    /// </para>
+    /// Kept for one release so code naming it still compiles and a <c>[SerializeReference]</c> field
+    /// a project declares as this type does not silently deserialize to <see langword="null"/>.
     /// </remarks>
     [Obsolete("Named converter aliases only existed because Unity before 2023.1 could not serialize a [SerializeReference] field of an open generic type. The package now requires Unity 6000.0, so use IConverter<Material?, Material?> directly. This will be removed in the next major version.")]
     public interface IConverterMaterial : IConverter<Material?, Material?> { }

--- a/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Unity/Runtime/Converters/Specific/IConverterMaterial.cs
+++ b/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Unity/Runtime/Converters/Specific/IConverterMaterial.cs
@@ -1,4 +1,5 @@
 #nullable enable
+using System;
 using UnityEngine;
 
 // ReSharper disable once CheckNamespace
@@ -8,10 +9,16 @@ namespace Aspid.MVVM.StarterKit
     /// A converter from <see cref="Material"/> to <see cref="Material"/>.
     /// </summary>
     /// <remarks>
-    /// A named alias for <see cref="IConverter{TFrom, TTo}"/> closed over these two types.
-    /// It exists because Unity before 2023.1 cannot serialize a <c>[SerializeReference]</c>
-    /// field typed as an open generic, so a binder declares the field as this instead. From
-    /// 2023.1 the generic form is used directly and this is a compatibility shim.
+    /// A named alias for <see cref="IConverter{TFrom, TTo}"/> closed over these two types. It
+    /// existed because Unity before 2023.1 could not serialize a <c>[SerializeReference]</c> field
+    /// typed as an open generic, so a binder declared the field as this instead.
+    /// <para>
+    /// The package requires Unity 6000.0, so nothing in it declares such a field any more and this
+    /// carries no behaviour of its own. It stays one release so that code naming it keeps compiling
+    /// with a warning, and so that a <c>[SerializeReference]</c> field a project declares as this
+    /// type does not silently deserialize to <see langword="null"/>.
+    /// </para>
     /// </remarks>
+    [Obsolete("Named converter aliases only existed because Unity before 2023.1 could not serialize a [SerializeReference] field of an open generic type. The package now requires Unity 6000.0, so use IConverter<Material?, Material?> directly. This will be removed in the next major version.")]
     public interface IConverterMaterial : IConverter<Material?, Material?> { }
 }

--- a/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Unity/Runtime/Converters/Specific/IConverterMesh.cs
+++ b/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Unity/Runtime/Converters/Specific/IConverterMesh.cs
@@ -9,15 +9,8 @@ namespace Aspid.MVVM.StarterKit
     /// A converter from <see cref="Mesh"/> to <see cref="Mesh"/>.
     /// </summary>
     /// <remarks>
-    /// A named alias for <see cref="IConverter{TFrom, TTo}"/> closed over these two types. It
-    /// existed because Unity before 2023.1 could not serialize a <c>[SerializeReference]</c> field
-    /// typed as an open generic, so a binder declared the field as this instead.
-    /// <para>
-    /// The package requires Unity 6000.0, so nothing in it declares such a field any more and this
-    /// carries no behaviour of its own. It stays one release so that code naming it keeps compiling
-    /// with a warning, and so that a <c>[SerializeReference]</c> field a project declares as this
-    /// type does not silently deserialize to <see langword="null"/>.
-    /// </para>
+    /// Kept for one release so code naming it still compiles and a <c>[SerializeReference]</c> field
+    /// a project declares as this type does not silently deserialize to <see langword="null"/>.
     /// </remarks>
     [Obsolete("Named converter aliases only existed because Unity before 2023.1 could not serialize a [SerializeReference] field of an open generic type. The package now requires Unity 6000.0, so use IConverter<Mesh?, Mesh?> directly. This will be removed in the next major version.")]
     public interface IConverterMesh : IConverter<Mesh?, Mesh?> { }

--- a/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Unity/Runtime/Converters/Specific/IConverterMesh.cs
+++ b/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Unity/Runtime/Converters/Specific/IConverterMesh.cs
@@ -1,4 +1,5 @@
 #nullable enable
+using System;
 using UnityEngine;
 
 // ReSharper disable once CheckNamespace
@@ -8,10 +9,16 @@ namespace Aspid.MVVM.StarterKit
     /// A converter from <see cref="Mesh"/> to <see cref="Mesh"/>.
     /// </summary>
     /// <remarks>
-    /// A named alias for <see cref="IConverter{TFrom, TTo}"/> closed over these two types.
-    /// It exists because Unity before 2023.1 cannot serialize a <c>[SerializeReference]</c>
-    /// field typed as an open generic, so a binder declares the field as this instead. From
-    /// 2023.1 the generic form is used directly and this is a compatibility shim.
+    /// A named alias for <see cref="IConverter{TFrom, TTo}"/> closed over these two types. It
+    /// existed because Unity before 2023.1 could not serialize a <c>[SerializeReference]</c> field
+    /// typed as an open generic, so a binder declared the field as this instead.
+    /// <para>
+    /// The package requires Unity 6000.0, so nothing in it declares such a field any more and this
+    /// carries no behaviour of its own. It stays one release so that code naming it keeps compiling
+    /// with a warning, and so that a <c>[SerializeReference]</c> field a project declares as this
+    /// type does not silently deserialize to <see langword="null"/>.
+    /// </para>
     /// </remarks>
+    [Obsolete("Named converter aliases only existed because Unity before 2023.1 could not serialize a [SerializeReference] field of an open generic type. The package now requires Unity 6000.0, so use IConverter<Mesh?, Mesh?> directly. This will be removed in the next major version.")]
     public interface IConverterMesh : IConverter<Mesh?, Mesh?> { }
 }

--- a/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Unity/Runtime/Converters/Specific/IConverterPhysicsMaterial.cs
+++ b/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Unity/Runtime/Converters/Specific/IConverterPhysicsMaterial.cs
@@ -1,4 +1,5 @@
 #nullable enable
+using System;
 using PhysicsMaterial = UnityEngine.PhysicsMaterial;
 
 // ReSharper disable once CheckNamespace
@@ -8,10 +9,16 @@ namespace Aspid.MVVM.StarterKit
     /// A converter from <see cref="PhysicsMaterial"/> to <see cref="PhysicsMaterial"/>.
     /// </summary>
     /// <remarks>
-    /// A named alias for <see cref="IConverter{TFrom, TTo}"/> closed over these two types.
-    /// It exists because Unity before 2023.1 cannot serialize a <c>[SerializeReference]</c>
-    /// field typed as an open generic, so a binder declares the field as this instead. From
-    /// 2023.1 the generic form is used directly and this is a compatibility shim.
+    /// A named alias for <see cref="IConverter{TFrom, TTo}"/> closed over these two types. It
+    /// existed because Unity before 2023.1 could not serialize a <c>[SerializeReference]</c> field
+    /// typed as an open generic, so a binder declared the field as this instead.
+    /// <para>
+    /// The package requires Unity 6000.0, so nothing in it declares such a field any more and this
+    /// carries no behaviour of its own. It stays one release so that code naming it keeps compiling
+    /// with a warning, and so that a <c>[SerializeReference]</c> field a project declares as this
+    /// type does not silently deserialize to <see langword="null"/>.
+    /// </para>
     /// </remarks>
+    [Obsolete("Named converter aliases only existed because Unity before 2023.1 could not serialize a [SerializeReference] field of an open generic type. The package now requires Unity 6000.0, so use IConverter<PhysicsMaterial?, PhysicsMaterial?> directly. This will be removed in the next major version.")]
     public interface IConverterPhysicsMaterial : IConverter<PhysicsMaterial?, PhysicsMaterial?> { }
 }

--- a/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Unity/Runtime/Converters/Specific/IConverterPhysicsMaterial.cs
+++ b/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Unity/Runtime/Converters/Specific/IConverterPhysicsMaterial.cs
@@ -9,15 +9,8 @@ namespace Aspid.MVVM.StarterKit
     /// A converter from <see cref="PhysicsMaterial"/> to <see cref="PhysicsMaterial"/>.
     /// </summary>
     /// <remarks>
-    /// A named alias for <see cref="IConverter{TFrom, TTo}"/> closed over these two types. It
-    /// existed because Unity before 2023.1 could not serialize a <c>[SerializeReference]</c> field
-    /// typed as an open generic, so a binder declared the field as this instead.
-    /// <para>
-    /// The package requires Unity 6000.0, so nothing in it declares such a field any more and this
-    /// carries no behaviour of its own. It stays one release so that code naming it keeps compiling
-    /// with a warning, and so that a <c>[SerializeReference]</c> field a project declares as this
-    /// type does not silently deserialize to <see langword="null"/>.
-    /// </para>
+    /// Kept for one release so code naming it still compiles and a <c>[SerializeReference]</c> field
+    /// a project declares as this type does not silently deserialize to <see langword="null"/>.
     /// </remarks>
     [Obsolete("Named converter aliases only existed because Unity before 2023.1 could not serialize a [SerializeReference] field of an open generic type. The package now requires Unity 6000.0, so use IConverter<PhysicsMaterial?, PhysicsMaterial?> directly. This will be removed in the next major version.")]
     public interface IConverterPhysicsMaterial : IConverter<PhysicsMaterial?, PhysicsMaterial?> { }

--- a/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Unity/Runtime/Converters/Specific/IConverterQuaternion.cs
+++ b/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Unity/Runtime/Converters/Specific/IConverterQuaternion.cs
@@ -9,15 +9,8 @@ namespace Aspid.MVVM.StarterKit
     /// A converter from <see cref="Quaternion"/> to <see cref="Quaternion"/>.
     /// </summary>
     /// <remarks>
-    /// A named alias for <see cref="IConverter{TFrom, TTo}"/> closed over these two types. It
-    /// existed because Unity before 2023.1 could not serialize a <c>[SerializeReference]</c> field
-    /// typed as an open generic, so a binder declared the field as this instead.
-    /// <para>
-    /// The package requires Unity 6000.0, so nothing in it declares such a field any more and this
-    /// carries no behaviour of its own. It stays one release so that code naming it keeps compiling
-    /// with a warning, and so that a <c>[SerializeReference]</c> field a project declares as this
-    /// type does not silently deserialize to <see langword="null"/>.
-    /// </para>
+    /// Kept for one release so code naming it still compiles and a <c>[SerializeReference]</c> field
+    /// a project declares as this type does not silently deserialize to <see langword="null"/>.
     /// </remarks>
     [Obsolete("Named converter aliases only existed because Unity before 2023.1 could not serialize a [SerializeReference] field of an open generic type. The package now requires Unity 6000.0, so use IConverter<Quaternion, Quaternion> directly. This will be removed in the next major version.")]
     public interface IConverterQuaternion : IConverter<Quaternion, Quaternion> { }

--- a/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Unity/Runtime/Converters/Specific/IConverterQuaternion.cs
+++ b/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Unity/Runtime/Converters/Specific/IConverterQuaternion.cs
@@ -1,4 +1,5 @@
 #nullable enable
+using System;
 using UnityEngine;
 
 // ReSharper disable once CheckNamespace
@@ -8,10 +9,16 @@ namespace Aspid.MVVM.StarterKit
     /// A converter from <see cref="Quaternion"/> to <see cref="Quaternion"/>.
     /// </summary>
     /// <remarks>
-    /// A named alias for <see cref="IConverter{TFrom, TTo}"/> closed over these two types.
-    /// It exists because Unity before 2023.1 cannot serialize a <c>[SerializeReference]</c>
-    /// field typed as an open generic, so a binder declares the field as this instead. From
-    /// 2023.1 the generic form is used directly and this is a compatibility shim.
+    /// A named alias for <see cref="IConverter{TFrom, TTo}"/> closed over these two types. It
+    /// existed because Unity before 2023.1 could not serialize a <c>[SerializeReference]</c> field
+    /// typed as an open generic, so a binder declared the field as this instead.
+    /// <para>
+    /// The package requires Unity 6000.0, so nothing in it declares such a field any more and this
+    /// carries no behaviour of its own. It stays one release so that code naming it keeps compiling
+    /// with a warning, and so that a <c>[SerializeReference]</c> field a project declares as this
+    /// type does not silently deserialize to <see langword="null"/>.
+    /// </para>
     /// </remarks>
+    [Obsolete("Named converter aliases only existed because Unity before 2023.1 could not serialize a [SerializeReference] field of an open generic type. The package now requires Unity 6000.0, so use IConverter<Quaternion, Quaternion> directly. This will be removed in the next major version.")]
     public interface IConverterQuaternion : IConverter<Quaternion, Quaternion> { }
 }

--- a/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Unity/Runtime/Converters/Specific/IConverterRectOffset.cs
+++ b/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Unity/Runtime/Converters/Specific/IConverterRectOffset.cs
@@ -9,15 +9,8 @@ namespace Aspid.MVVM.StarterKit
     /// A converter from <see cref="RectOffset"/> to <see cref="RectOffset"/>.
     /// </summary>
     /// <remarks>
-    /// A named alias for <see cref="IConverter{TFrom, TTo}"/> closed over these two types. It
-    /// existed because Unity before 2023.1 could not serialize a <c>[SerializeReference]</c> field
-    /// typed as an open generic, so a binder declared the field as this instead.
-    /// <para>
-    /// The package requires Unity 6000.0, so nothing in it declares such a field any more and this
-    /// carries no behaviour of its own. It stays one release so that code naming it keeps compiling
-    /// with a warning, and so that a <c>[SerializeReference]</c> field a project declares as this
-    /// type does not silently deserialize to <see langword="null"/>.
-    /// </para>
+    /// Kept for one release so code naming it still compiles and a <c>[SerializeReference]</c> field
+    /// a project declares as this type does not silently deserialize to <see langword="null"/>.
     /// </remarks>
     [Obsolete("Named converter aliases only existed because Unity before 2023.1 could not serialize a [SerializeReference] field of an open generic type. The package now requires Unity 6000.0, so use IConverter<RectOffset, RectOffset> directly. This will be removed in the next major version.")]
     public interface IConverterRectOffset : IConverter<RectOffset, RectOffset> { }

--- a/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Unity/Runtime/Converters/Specific/IConverterRectOffset.cs
+++ b/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Unity/Runtime/Converters/Specific/IConverterRectOffset.cs
@@ -1,4 +1,5 @@
 #nullable enable
+using System;
 using UnityEngine;
 
 // ReSharper disable once CheckNamespace
@@ -8,10 +9,16 @@ namespace Aspid.MVVM.StarterKit
     /// A converter from <see cref="RectOffset"/> to <see cref="RectOffset"/>.
     /// </summary>
     /// <remarks>
-    /// A named alias for <see cref="IConverter{TFrom, TTo}"/> closed over these two types.
-    /// It exists because Unity before 2023.1 cannot serialize a <c>[SerializeReference]</c>
-    /// field typed as an open generic, so a binder declares the field as this instead. From
-    /// 2023.1 the generic form is used directly and this is a compatibility shim.
+    /// A named alias for <see cref="IConverter{TFrom, TTo}"/> closed over these two types. It
+    /// existed because Unity before 2023.1 could not serialize a <c>[SerializeReference]</c> field
+    /// typed as an open generic, so a binder declared the field as this instead.
+    /// <para>
+    /// The package requires Unity 6000.0, so nothing in it declares such a field any more and this
+    /// carries no behaviour of its own. It stays one release so that code naming it keeps compiling
+    /// with a warning, and so that a <c>[SerializeReference]</c> field a project declares as this
+    /// type does not silently deserialize to <see langword="null"/>.
+    /// </para>
     /// </remarks>
+    [Obsolete("Named converter aliases only existed because Unity before 2023.1 could not serialize a [SerializeReference] field of an open generic type. The package now requires Unity 6000.0, so use IConverter<RectOffset, RectOffset> directly. This will be removed in the next major version.")]
     public interface IConverterRectOffset : IConverter<RectOffset, RectOffset> { }
 }

--- a/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Unity/Runtime/Converters/Specific/IConverterTexture.cs
+++ b/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Unity/Runtime/Converters/Specific/IConverterTexture.cs
@@ -1,4 +1,5 @@
 #nullable enable
+using System;
 using UnityEngine;
 
 // ReSharper disable once CheckNamespace
@@ -8,10 +9,16 @@ namespace Aspid.MVVM.StarterKit
     /// A converter from <see cref="Texture"/> to <see cref="Texture"/>.
     /// </summary>
     /// <remarks>
-    /// A named alias for <see cref="IConverter{TFrom, TTo}"/> closed over these two types.
-    /// It exists because Unity before 2023.1 cannot serialize a <c>[SerializeReference]</c>
-    /// field typed as an open generic, so a binder declares the field as this instead. From
-    /// 2023.1 the generic form is used directly and this is a compatibility shim.
+    /// A named alias for <see cref="IConverter{TFrom, TTo}"/> closed over these two types. It
+    /// existed because Unity before 2023.1 could not serialize a <c>[SerializeReference]</c> field
+    /// typed as an open generic, so a binder declared the field as this instead.
+    /// <para>
+    /// The package requires Unity 6000.0, so nothing in it declares such a field any more and this
+    /// carries no behaviour of its own. It stays one release so that code naming it keeps compiling
+    /// with a warning, and so that a <c>[SerializeReference]</c> field a project declares as this
+    /// type does not silently deserialize to <see langword="null"/>.
+    /// </para>
     /// </remarks>
+    [Obsolete("Named converter aliases only existed because Unity before 2023.1 could not serialize a [SerializeReference] field of an open generic type. The package now requires Unity 6000.0, so use IConverter<Texture, Texture> directly. This will be removed in the next major version.")]
     public interface IConverterTexture : IConverter<Texture, Texture> { }
 }

--- a/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Unity/Runtime/Converters/Specific/IConverterTexture.cs
+++ b/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Unity/Runtime/Converters/Specific/IConverterTexture.cs
@@ -9,15 +9,8 @@ namespace Aspid.MVVM.StarterKit
     /// A converter from <see cref="Texture"/> to <see cref="Texture"/>.
     /// </summary>
     /// <remarks>
-    /// A named alias for <see cref="IConverter{TFrom, TTo}"/> closed over these two types. It
-    /// existed because Unity before 2023.1 could not serialize a <c>[SerializeReference]</c> field
-    /// typed as an open generic, so a binder declared the field as this instead.
-    /// <para>
-    /// The package requires Unity 6000.0, so nothing in it declares such a field any more and this
-    /// carries no behaviour of its own. It stays one release so that code naming it keeps compiling
-    /// with a warning, and so that a <c>[SerializeReference]</c> field a project declares as this
-    /// type does not silently deserialize to <see langword="null"/>.
-    /// </para>
+    /// Kept for one release so code naming it still compiles and a <c>[SerializeReference]</c> field
+    /// a project declares as this type does not silently deserialize to <see langword="null"/>.
     /// </remarks>
     [Obsolete("Named converter aliases only existed because Unity before 2023.1 could not serialize a [SerializeReference] field of an open generic type. The package now requires Unity 6000.0, so use IConverter<Texture, Texture> directly. This will be removed in the next major version.")]
     public interface IConverterTexture : IConverter<Texture, Texture> { }

--- a/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Unity/Runtime/Converters/Specific/IConverterTexture2D.cs
+++ b/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Unity/Runtime/Converters/Specific/IConverterTexture2D.cs
@@ -1,4 +1,5 @@
 #nullable enable
+using System;
 using UnityEngine;
 
 // ReSharper disable once CheckNamespace
@@ -8,10 +9,16 @@ namespace Aspid.MVVM.StarterKit
     /// A converter from <see cref="Texture2D"/> to <see cref="Texture2D"/>.
     /// </summary>
     /// <remarks>
-    /// A named alias for <see cref="IConverter{TFrom, TTo}"/> closed over these two types.
-    /// It exists because Unity before 2023.1 cannot serialize a <c>[SerializeReference]</c>
-    /// field typed as an open generic, so a binder declares the field as this instead. From
-    /// 2023.1 the generic form is used directly and this is a compatibility shim.
+    /// A named alias for <see cref="IConverter{TFrom, TTo}"/> closed over these two types. It
+    /// existed because Unity before 2023.1 could not serialize a <c>[SerializeReference]</c> field
+    /// typed as an open generic, so a binder declared the field as this instead.
+    /// <para>
+    /// The package requires Unity 6000.0, so nothing in it declares such a field any more and this
+    /// carries no behaviour of its own. It stays one release so that code naming it keeps compiling
+    /// with a warning, and so that a <c>[SerializeReference]</c> field a project declares as this
+    /// type does not silently deserialize to <see langword="null"/>.
+    /// </para>
     /// </remarks>
+    [Obsolete("Named converter aliases only existed because Unity before 2023.1 could not serialize a [SerializeReference] field of an open generic type. The package now requires Unity 6000.0, so use IConverter<Texture2D, Texture2D> directly. This will be removed in the next major version.")]
     public interface IConverterTexture2D : IConverter<Texture2D, Texture2D> { }
 }

--- a/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Unity/Runtime/Converters/Specific/IConverterTexture2D.cs
+++ b/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Unity/Runtime/Converters/Specific/IConverterTexture2D.cs
@@ -9,15 +9,8 @@ namespace Aspid.MVVM.StarterKit
     /// A converter from <see cref="Texture2D"/> to <see cref="Texture2D"/>.
     /// </summary>
     /// <remarks>
-    /// A named alias for <see cref="IConverter{TFrom, TTo}"/> closed over these two types. It
-    /// existed because Unity before 2023.1 could not serialize a <c>[SerializeReference]</c> field
-    /// typed as an open generic, so a binder declared the field as this instead.
-    /// <para>
-    /// The package requires Unity 6000.0, so nothing in it declares such a field any more and this
-    /// carries no behaviour of its own. It stays one release so that code naming it keeps compiling
-    /// with a warning, and so that a <c>[SerializeReference]</c> field a project declares as this
-    /// type does not silently deserialize to <see langword="null"/>.
-    /// </para>
+    /// Kept for one release so code naming it still compiles and a <c>[SerializeReference]</c> field
+    /// a project declares as this type does not silently deserialize to <see langword="null"/>.
     /// </remarks>
     [Obsolete("Named converter aliases only existed because Unity before 2023.1 could not serialize a [SerializeReference] field of an open generic type. The package now requires Unity 6000.0, so use IConverter<Texture2D, Texture2D> directly. This will be removed in the next major version.")]
     public interface IConverterTexture2D : IConverter<Texture2D, Texture2D> { }

--- a/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Unity/Runtime/Converters/Specific/Vectors/IConverterVector2.cs
+++ b/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Unity/Runtime/Converters/Specific/Vectors/IConverterVector2.cs
@@ -9,15 +9,8 @@ namespace Aspid.MVVM.StarterKit
     /// A converter from <see cref="Vector2"/> to <see cref="Vector2"/>.
     /// </summary>
     /// <remarks>
-    /// A named alias for <see cref="IConverter{TFrom, TTo}"/> closed over these two types. It
-    /// existed because Unity before 2023.1 could not serialize a <c>[SerializeReference]</c> field
-    /// typed as an open generic, so a binder declared the field as this instead.
-    /// <para>
-    /// The package requires Unity 6000.0, so nothing in it declares such a field any more and this
-    /// carries no behaviour of its own. It stays one release so that code naming it keeps compiling
-    /// with a warning, and so that a <c>[SerializeReference]</c> field a project declares as this
-    /// type does not silently deserialize to <see langword="null"/>.
-    /// </para>
+    /// Kept for one release so code naming it still compiles and a <c>[SerializeReference]</c> field
+    /// a project declares as this type does not silently deserialize to <see langword="null"/>.
     /// </remarks>
     [Obsolete("Named converter aliases only existed because Unity before 2023.1 could not serialize a [SerializeReference] field of an open generic type. The package now requires Unity 6000.0, so use IConverter<Vector2, Vector2> directly. This will be removed in the next major version.")]
     public interface IConverterVector2 : IConverter<Vector2, Vector2> { }

--- a/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Unity/Runtime/Converters/Specific/Vectors/IConverterVector2.cs
+++ b/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Unity/Runtime/Converters/Specific/Vectors/IConverterVector2.cs
@@ -1,4 +1,5 @@
 #nullable enable
+using System;
 using UnityEngine;
 
 // ReSharper disable once CheckNamespace
@@ -8,10 +9,16 @@ namespace Aspid.MVVM.StarterKit
     /// A converter from <see cref="Vector2"/> to <see cref="Vector2"/>.
     /// </summary>
     /// <remarks>
-    /// A named alias for <see cref="IConverter{TFrom, TTo}"/> closed over these two types.
-    /// It exists because Unity before 2023.1 cannot serialize a <c>[SerializeReference]</c>
-    /// field typed as an open generic, so a binder declares the field as this instead. From
-    /// 2023.1 the generic form is used directly and this is a compatibility shim.
+    /// A named alias for <see cref="IConverter{TFrom, TTo}"/> closed over these two types. It
+    /// existed because Unity before 2023.1 could not serialize a <c>[SerializeReference]</c> field
+    /// typed as an open generic, so a binder declared the field as this instead.
+    /// <para>
+    /// The package requires Unity 6000.0, so nothing in it declares such a field any more and this
+    /// carries no behaviour of its own. It stays one release so that code naming it keeps compiling
+    /// with a warning, and so that a <c>[SerializeReference]</c> field a project declares as this
+    /// type does not silently deserialize to <see langword="null"/>.
+    /// </para>
     /// </remarks>
+    [Obsolete("Named converter aliases only existed because Unity before 2023.1 could not serialize a [SerializeReference] field of an open generic type. The package now requires Unity 6000.0, so use IConverter<Vector2, Vector2> directly. This will be removed in the next major version.")]
     public interface IConverterVector2 : IConverter<Vector2, Vector2> { }
 }

--- a/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Unity/Runtime/Converters/Specific/Vectors/IConverterVector2ToVector3.cs
+++ b/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Unity/Runtime/Converters/Specific/Vectors/IConverterVector2ToVector3.cs
@@ -9,15 +9,8 @@ namespace Aspid.MVVM.StarterKit
     /// A converter from <see cref="Vector2"/> to <see cref="Vector3"/>.
     /// </summary>
     /// <remarks>
-    /// A named alias for <see cref="IConverter{TFrom, TTo}"/> closed over these two types. It
-    /// existed because Unity before 2023.1 could not serialize a <c>[SerializeReference]</c> field
-    /// typed as an open generic, so a binder declared the field as this instead.
-    /// <para>
-    /// The package requires Unity 6000.0, so nothing in it declares such a field any more and this
-    /// carries no behaviour of its own. It stays one release so that code naming it keeps compiling
-    /// with a warning, and so that a <c>[SerializeReference]</c> field a project declares as this
-    /// type does not silently deserialize to <see langword="null"/>.
-    /// </para>
+    /// Kept for one release so code naming it still compiles and a <c>[SerializeReference]</c> field
+    /// a project declares as this type does not silently deserialize to <see langword="null"/>.
     /// </remarks>
     [Obsolete("Named converter aliases only existed because Unity before 2023.1 could not serialize a [SerializeReference] field of an open generic type. The package now requires Unity 6000.0, so use IConverter<Vector2, Vector3> directly. This will be removed in the next major version.")]
     public interface IConverterVector2ToVector3 : IConverter<Vector2, Vector3> { }

--- a/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Unity/Runtime/Converters/Specific/Vectors/IConverterVector2ToVector3.cs
+++ b/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Unity/Runtime/Converters/Specific/Vectors/IConverterVector2ToVector3.cs
@@ -1,4 +1,5 @@
 #nullable enable
+using System;
 using UnityEngine;
 
 // ReSharper disable once CheckNamespace
@@ -8,10 +9,16 @@ namespace Aspid.MVVM.StarterKit
     /// A converter from <see cref="Vector2"/> to <see cref="Vector3"/>.
     /// </summary>
     /// <remarks>
-    /// A named alias for <see cref="IConverter{TFrom, TTo}"/> closed over these two types.
-    /// It exists because Unity before 2023.1 cannot serialize a <c>[SerializeReference]</c>
-    /// field typed as an open generic, so a binder declares the field as this instead. From
-    /// 2023.1 the generic form is used directly and this is a compatibility shim.
+    /// A named alias for <see cref="IConverter{TFrom, TTo}"/> closed over these two types. It
+    /// existed because Unity before 2023.1 could not serialize a <c>[SerializeReference]</c> field
+    /// typed as an open generic, so a binder declared the field as this instead.
+    /// <para>
+    /// The package requires Unity 6000.0, so nothing in it declares such a field any more and this
+    /// carries no behaviour of its own. It stays one release so that code naming it keeps compiling
+    /// with a warning, and so that a <c>[SerializeReference]</c> field a project declares as this
+    /// type does not silently deserialize to <see langword="null"/>.
+    /// </para>
     /// </remarks>
+    [Obsolete("Named converter aliases only existed because Unity before 2023.1 could not serialize a [SerializeReference] field of an open generic type. The package now requires Unity 6000.0, so use IConverter<Vector2, Vector3> directly. This will be removed in the next major version.")]
     public interface IConverterVector2ToVector3 : IConverter<Vector2, Vector3> { }
 }

--- a/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Unity/Runtime/Converters/Specific/Vectors/IConverterVector3.cs
+++ b/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Unity/Runtime/Converters/Specific/Vectors/IConverterVector3.cs
@@ -1,4 +1,5 @@
 #nullable enable
+using System;
 using UnityEngine;
 
 // ReSharper disable once CheckNamespace
@@ -8,10 +9,16 @@ namespace Aspid.MVVM.StarterKit
     /// A converter from <see cref="Vector3"/> to <see cref="Vector3"/>.
     /// </summary>
     /// <remarks>
-    /// A named alias for <see cref="IConverter{TFrom, TTo}"/> closed over these two types.
-    /// It exists because Unity before 2023.1 cannot serialize a <c>[SerializeReference]</c>
-    /// field typed as an open generic, so a binder declares the field as this instead. From
-    /// 2023.1 the generic form is used directly and this is a compatibility shim.
+    /// A named alias for <see cref="IConverter{TFrom, TTo}"/> closed over these two types. It
+    /// existed because Unity before 2023.1 could not serialize a <c>[SerializeReference]</c> field
+    /// typed as an open generic, so a binder declared the field as this instead.
+    /// <para>
+    /// The package requires Unity 6000.0, so nothing in it declares such a field any more and this
+    /// carries no behaviour of its own. It stays one release so that code naming it keeps compiling
+    /// with a warning, and so that a <c>[SerializeReference]</c> field a project declares as this
+    /// type does not silently deserialize to <see langword="null"/>.
+    /// </para>
     /// </remarks>
+    [Obsolete("Named converter aliases only existed because Unity before 2023.1 could not serialize a [SerializeReference] field of an open generic type. The package now requires Unity 6000.0, so use IConverter<Vector3, Vector3> directly. This will be removed in the next major version.")]
     public interface IConverterVector3 : IConverter<Vector3, Vector3> { }
 }

--- a/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Unity/Runtime/Converters/Specific/Vectors/IConverterVector3.cs
+++ b/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Unity/Runtime/Converters/Specific/Vectors/IConverterVector3.cs
@@ -9,15 +9,8 @@ namespace Aspid.MVVM.StarterKit
     /// A converter from <see cref="Vector3"/> to <see cref="Vector3"/>.
     /// </summary>
     /// <remarks>
-    /// A named alias for <see cref="IConverter{TFrom, TTo}"/> closed over these two types. It
-    /// existed because Unity before 2023.1 could not serialize a <c>[SerializeReference]</c> field
-    /// typed as an open generic, so a binder declared the field as this instead.
-    /// <para>
-    /// The package requires Unity 6000.0, so nothing in it declares such a field any more and this
-    /// carries no behaviour of its own. It stays one release so that code naming it keeps compiling
-    /// with a warning, and so that a <c>[SerializeReference]</c> field a project declares as this
-    /// type does not silently deserialize to <see langword="null"/>.
-    /// </para>
+    /// Kept for one release so code naming it still compiles and a <c>[SerializeReference]</c> field
+    /// a project declares as this type does not silently deserialize to <see langword="null"/>.
     /// </remarks>
     [Obsolete("Named converter aliases only existed because Unity before 2023.1 could not serialize a [SerializeReference] field of an open generic type. The package now requires Unity 6000.0, so use IConverter<Vector3, Vector3> directly. This will be removed in the next major version.")]
     public interface IConverterVector3 : IConverter<Vector3, Vector3> { }

--- a/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Unity/Runtime/Converters/Specific/Vectors/IConverterVector3ToVector2.cs
+++ b/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Unity/Runtime/Converters/Specific/Vectors/IConverterVector3ToVector2.cs
@@ -1,4 +1,5 @@
 #nullable enable
+using System;
 using UnityEngine;
 
 // ReSharper disable once CheckNamespace
@@ -8,10 +9,16 @@ namespace Aspid.MVVM.StarterKit
     /// A converter from <see cref="Vector3"/> to <see cref="Vector2"/>.
     /// </summary>
     /// <remarks>
-    /// A named alias for <see cref="IConverter{TFrom, TTo}"/> closed over these two types.
-    /// It exists because Unity before 2023.1 cannot serialize a <c>[SerializeReference]</c>
-    /// field typed as an open generic, so a binder declares the field as this instead. From
-    /// 2023.1 the generic form is used directly and this is a compatibility shim.
+    /// A named alias for <see cref="IConverter{TFrom, TTo}"/> closed over these two types. It
+    /// existed because Unity before 2023.1 could not serialize a <c>[SerializeReference]</c> field
+    /// typed as an open generic, so a binder declared the field as this instead.
+    /// <para>
+    /// The package requires Unity 6000.0, so nothing in it declares such a field any more and this
+    /// carries no behaviour of its own. It stays one release so that code naming it keeps compiling
+    /// with a warning, and so that a <c>[SerializeReference]</c> field a project declares as this
+    /// type does not silently deserialize to <see langword="null"/>.
+    /// </para>
     /// </remarks>
+    [Obsolete("Named converter aliases only existed because Unity before 2023.1 could not serialize a [SerializeReference] field of an open generic type. The package now requires Unity 6000.0, so use IConverter<Vector3, Vector2> directly. This will be removed in the next major version.")]
     public interface IConverterVector3ToVector2 : IConverter<Vector3, Vector2> { }
 }

--- a/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Unity/Runtime/Converters/Specific/Vectors/IConverterVector3ToVector2.cs
+++ b/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Unity/Runtime/Converters/Specific/Vectors/IConverterVector3ToVector2.cs
@@ -9,15 +9,8 @@ namespace Aspid.MVVM.StarterKit
     /// A converter from <see cref="Vector3"/> to <see cref="Vector2"/>.
     /// </summary>
     /// <remarks>
-    /// A named alias for <see cref="IConverter{TFrom, TTo}"/> closed over these two types. It
-    /// existed because Unity before 2023.1 could not serialize a <c>[SerializeReference]</c> field
-    /// typed as an open generic, so a binder declared the field as this instead.
-    /// <para>
-    /// The package requires Unity 6000.0, so nothing in it declares such a field any more and this
-    /// carries no behaviour of its own. It stays one release so that code naming it keeps compiling
-    /// with a warning, and so that a <c>[SerializeReference]</c> field a project declares as this
-    /// type does not silently deserialize to <see langword="null"/>.
-    /// </para>
+    /// Kept for one release so code naming it still compiles and a <c>[SerializeReference]</c> field
+    /// a project declares as this type does not silently deserialize to <see langword="null"/>.
     /// </remarks>
     [Obsolete("Named converter aliases only existed because Unity before 2023.1 could not serialize a [SerializeReference] field of an open generic type. The package now requires Unity 6000.0, so use IConverter<Vector3, Vector2> directly. This will be removed in the next major version.")]
     public interface IConverterVector3ToVector2 : IConverter<Vector3, Vector2> { }

--- a/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Unity/Runtime/Converters/Specific/Vectors/VectorConverterSpecificExtensions.cs
+++ b/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Unity/Runtime/Converters/Specific/Vectors/VectorConverterSpecificExtensions.cs
@@ -16,6 +16,7 @@ namespace Aspid.MVVM.StarterKit
     /// Unity 2023.1 declares its field as the named interface rather than the generic one,
     /// so a lambda cannot be assigned to it directly.
     /// </remarks>
+    [Obsolete("Only needed to assign a lambda to a field typed as a named converter alias, which Unity before 2023.1 required. The package now requires Unity 6000.0, so assign the converter directly. This will be removed in the next major version.")]
     public static class VectorConverterSpecificExtensions
     {
         /// <summary>
@@ -24,6 +25,7 @@ namespace Aspid.MVVM.StarterKit
         /// <param name="converter">The function to wrap.</param>
         /// <returns>A converter of the named interface type.</returns>
         /// <exception cref="System.ArgumentNullException">Thrown when <paramref name="converter"/> is <see langword="null"/>.</exception>
+        [Obsolete("Only needed to assign a lambda to a field typed as a named converter alias, which Unity before 2023.1 required. The package now requires Unity 6000.0, so assign the converter directly. This will be removed in the next major version.")]
         public static IConverterVector2 ToConvert(this Func<Vector2, Vector2> converter) =>
             new ConverterVector2(converter);
         
@@ -33,6 +35,7 @@ namespace Aspid.MVVM.StarterKit
         /// <param name="converter">The converter to wrap.</param>
         /// <returns>A converter of the named interface type.</returns>
         /// <exception cref="System.ArgumentNullException">Thrown when <paramref name="converter"/> is <see langword="null"/>.</exception>
+        [Obsolete("Only needed to assign a lambda to a field typed as a named converter alias, which Unity before 2023.1 required. The package now requires Unity 6000.0, so assign the converter directly. This will be removed in the next major version.")]
         public static IConverterVector2 ToConvertSpecific(this IConverter<Vector2, Vector2> converter) =>
             new ConverterVector2(converter);
         
@@ -42,6 +45,7 @@ namespace Aspid.MVVM.StarterKit
         /// <param name="converter">The function to wrap.</param>
         /// <returns>A converter of the named interface type.</returns>
         /// <exception cref="System.ArgumentNullException">Thrown when <paramref name="converter"/> is <see langword="null"/>.</exception>
+        [Obsolete("Only needed to assign a lambda to a field typed as a named converter alias, which Unity before 2023.1 required. The package now requires Unity 6000.0, so assign the converter directly. This will be removed in the next major version.")]
         public static IConverterVector2ToVector3 ToConvert(this Func<Vector2, Vector3> converter) =>
             new ConverterVector2ToVector3(converter);
         
@@ -51,6 +55,7 @@ namespace Aspid.MVVM.StarterKit
         /// <param name="converter">The converter to wrap.</param>
         /// <returns>A converter of the named interface type.</returns>
         /// <exception cref="System.ArgumentNullException">Thrown when <paramref name="converter"/> is <see langword="null"/>.</exception>
+        [Obsolete("Only needed to assign a lambda to a field typed as a named converter alias, which Unity before 2023.1 required. The package now requires Unity 6000.0, so assign the converter directly. This will be removed in the next major version.")]
         public static IConverterVector2ToVector3 ToConvertSpecific(this IConverter<Vector2, Vector3> converter) =>
             new ConverterVector2ToVector3(converter);
         
@@ -60,6 +65,7 @@ namespace Aspid.MVVM.StarterKit
         /// <param name="converter">The function to wrap.</param>
         /// <returns>A converter of the named interface type.</returns>
         /// <exception cref="System.ArgumentNullException">Thrown when <paramref name="converter"/> is <see langword="null"/>.</exception>
+        [Obsolete("Only needed to assign a lambda to a field typed as a named converter alias, which Unity before 2023.1 required. The package now requires Unity 6000.0, so assign the converter directly. This will be removed in the next major version.")]
         public static IConverterVector3 ToConvert(this Func<Vector3, Vector3> converter) =>
             new ConverterVector3(converter);
         
@@ -69,6 +75,7 @@ namespace Aspid.MVVM.StarterKit
         /// <param name="converter">The converter to wrap.</param>
         /// <returns>A converter of the named interface type.</returns>
         /// <exception cref="System.ArgumentNullException">Thrown when <paramref name="converter"/> is <see langword="null"/>.</exception>
+        [Obsolete("Only needed to assign a lambda to a field typed as a named converter alias, which Unity before 2023.1 required. The package now requires Unity 6000.0, so assign the converter directly. This will be removed in the next major version.")]
         public static IConverterVector3 ToConvertSpecific(this IConverter<Vector3, Vector3> converter) =>
             new ConverterVector3(converter);
         
@@ -78,6 +85,7 @@ namespace Aspid.MVVM.StarterKit
         /// <param name="converter">The function to wrap.</param>
         /// <returns>A converter of the named interface type.</returns>
         /// <exception cref="System.ArgumentNullException">Thrown when <paramref name="converter"/> is <see langword="null"/>.</exception>
+        [Obsolete("Only needed to assign a lambda to a field typed as a named converter alias, which Unity before 2023.1 required. The package now requires Unity 6000.0, so assign the converter directly. This will be removed in the next major version.")]
         public static IConverterVector3ToVector2 ToConvert(this Func<Vector3, Vector2> converter) =>
             new ConverterVector3ToVector2(converter);
         
@@ -87,6 +95,7 @@ namespace Aspid.MVVM.StarterKit
         /// <param name="converter">The converter to wrap.</param>
         /// <returns>A converter of the named interface type.</returns>
         /// <exception cref="System.ArgumentNullException">Thrown when <paramref name="converter"/> is <see langword="null"/>.</exception>
+        [Obsolete("Only needed to assign a lambda to a field typed as a named converter alias, which Unity before 2023.1 required. The package now requires Unity 6000.0, so assign the converter directly. This will be removed in the next major version.")]
         public static IConverterVector3ToVector2 ToConvertSpecific(this IConverter<Vector3, Vector2> converter) =>
             new ConverterVector3ToVector2(converter);
         

--- a/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Unity/Runtime/Converters/Strings/RichTextColorConverter.cs
+++ b/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Unity/Runtime/Converters/Strings/RichTextColorConverter.cs
@@ -3,6 +3,11 @@ using Aspid.FastTools.Types;
 using System;
 using UnityEngine;
 
+// The named converter aliases are [Obsolete]. The converters below keep implementing them for
+// one release so that a [SerializeReference] field a project declares as one still
+// deserializes; the base lists go with the aliases in the next major.
+#pragma warning disable CS0618 // Type or member is obsolete
+
 // ReSharper disable once CheckNamespace
 namespace Aspid.MVVM.StarterKit
 {

--- a/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Unity/Runtime/Converters/Strings/RichTextNoParseConverter.cs
+++ b/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Unity/Runtime/Converters/Strings/RichTextNoParseConverter.cs
@@ -3,6 +3,11 @@ using Aspid.FastTools.Types;
 using System;
 using UnityEngine;
 
+// The named converter aliases are [Obsolete]. The converters below keep implementing them for
+// one release so that a [SerializeReference] field a project declares as one still
+// deserializes; the base lists go with the aliases in the next major.
+#pragma warning disable CS0618 // Type or member is obsolete
+
 // ReSharper disable once CheckNamespace
 namespace Aspid.MVVM.StarterKit
 {

--- a/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Unity/Runtime/Converters/Strings/RichTextSizeConverter.cs
+++ b/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Unity/Runtime/Converters/Strings/RichTextSizeConverter.cs
@@ -3,6 +3,11 @@ using Aspid.FastTools.Types;
 using System;
 using UnityEngine;
 
+// The named converter aliases are [Obsolete]. The converters below keep implementing them for
+// one release so that a [SerializeReference] field a project declares as one still
+// deserializes; the base lists go with the aliases in the next major.
+#pragma warning disable CS0618 // Type or member is obsolete
+
 // ReSharper disable once CheckNamespace
 namespace Aspid.MVVM.StarterKit
 {

--- a/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Unity/Runtime/Converters/Strings/RichTextStyleConverter.cs
+++ b/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Unity/Runtime/Converters/Strings/RichTextStyleConverter.cs
@@ -3,6 +3,11 @@ using Aspid.FastTools.Types;
 using System;
 using UnityEngine;
 
+// The named converter aliases are [Obsolete]. The converters below keep implementing them for
+// one release so that a [SerializeReference] field a project declares as one still
+// deserializes; the base lists go with the aliases in the next major.
+#pragma warning disable CS0618 // Type or member is obsolete
+
 // ReSharper disable once CheckNamespace
 namespace Aspid.MVVM.StarterKit
 {

--- a/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Unity/Runtime/Converters/Vectors/Vector2SubstitutionConverter.cs
+++ b/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Unity/Runtime/Converters/Vectors/Vector2SubstitutionConverter.cs
@@ -3,6 +3,11 @@ using Aspid.FastTools.Types;
 using System;
 using UnityEngine;
 
+// The named converter aliases are [Obsolete]. The converters below keep implementing them for
+// one release so that a [SerializeReference] field a project declares as one still
+// deserializes; the base lists go with the aliases in the next major.
+#pragma warning disable CS0618 // Type or member is obsolete
+
 // ReSharper disable InconsistentNaming
 // ReSharper disable once CheckNamespace
 namespace Aspid.MVVM.StarterKit

--- a/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Unity/Runtime/Converters/Vectors/Vector2ToVector3Converter.cs
+++ b/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Unity/Runtime/Converters/Vectors/Vector2ToVector3Converter.cs
@@ -3,6 +3,11 @@ using Aspid.FastTools.Types;
 using System;
 using UnityEngine;
 
+// The named converter aliases are [Obsolete]. The converters below keep implementing them for
+// one release so that a [SerializeReference] field a project declares as one still
+// deserializes; the base lists go with the aliases in the next major.
+#pragma warning disable CS0618 // Type or member is obsolete
+
 // ReSharper disable once CheckNamespace
 namespace Aspid.MVVM.StarterKit
 {

--- a/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Unity/Runtime/Converters/Vectors/Vector3ArithmeticConverter.cs
+++ b/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Unity/Runtime/Converters/Vectors/Vector3ArithmeticConverter.cs
@@ -3,6 +3,11 @@ using Aspid.FastTools.Types;
 using System;
 using UnityEngine;
 
+// The named converter aliases are [Obsolete]. The converters below keep implementing them for
+// one release so that a [SerializeReference] field a project declares as one still
+// deserializes; the base lists go with the aliases in the next major.
+#pragma warning disable CS0618 // Type or member is obsolete
+
 // ReSharper disable once CheckNamespace
 namespace Aspid.MVVM.StarterKit
 {

--- a/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Unity/Runtime/Converters/Vectors/Vector3CombineConverter.cs
+++ b/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Unity/Runtime/Converters/Vectors/Vector3CombineConverter.cs
@@ -3,6 +3,11 @@ using System;
 using UnityEngine;
 using Converter = Aspid.MVVM.StarterKit.IConverter<UnityEngine.Vector3, UnityEngine.Vector3>;
 
+// The named converter aliases are [Obsolete]. The converters below keep implementing them for
+// one release so that a [SerializeReference] field a project declares as one still
+// deserializes; the base lists go with the aliases in the next major.
+#pragma warning disable CS0618 // Type or member is obsolete
+
 // ReSharper disable once CheckNamespace
 namespace Aspid.MVVM.StarterKit
 {

--- a/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Unity/Runtime/Converters/Vectors/Vector3SubstitutionConverter.cs
+++ b/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Unity/Runtime/Converters/Vectors/Vector3SubstitutionConverter.cs
@@ -3,6 +3,11 @@ using Aspid.FastTools.Types;
 using System;
 using UnityEngine;
 
+// The named converter aliases are [Obsolete]. The converters below keep implementing them for
+// one release so that a [SerializeReference] field a project declares as one still
+// deserializes; the base lists go with the aliases in the next major.
+#pragma warning disable CS0618 // Type or member is obsolete
+
 // ReSharper disable InconsistentNaming
 // ReSharper disable once CheckNamespace
 namespace Aspid.MVVM.StarterKit

--- a/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Unity/Runtime/Converters/Vectors/Vector3ToVector2Converter.cs
+++ b/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Unity/Runtime/Converters/Vectors/Vector3ToVector2Converter.cs
@@ -3,6 +3,11 @@ using Aspid.FastTools.Types;
 using System;
 using UnityEngine;
 
+// The named converter aliases are [Obsolete]. The converters below keep implementing them for
+// one release so that a [SerializeReference] field a project declares as one still
+// deserializes; the base lists go with the aliases in the next major.
+#pragma warning disable CS0618 // Type or member is obsolete
+
 // ReSharper disable InconsistentNaming
 // ReSharper disable once CheckNamespace
 namespace Aspid.MVVM.StarterKit

--- a/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Unity/Runtime/Converters/Vectors/VectorClampMagnitudeConverter.cs
+++ b/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Unity/Runtime/Converters/Vectors/VectorClampMagnitudeConverter.cs
@@ -3,6 +3,11 @@ using Aspid.FastTools.Types;
 using System;
 using UnityEngine;
 
+// The named converter aliases are [Obsolete]. The converters below keep implementing them for
+// one release so that a [SerializeReference] field a project declares as one still
+// deserializes; the base lists go with the aliases in the next major.
+#pragma warning disable CS0618 // Type or member is obsolete
+
 // ReSharper disable once CheckNamespace
 namespace Aspid.MVVM.StarterKit
 {

--- a/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Unity/Runtime/Converters/Vectors/VectorNormalizeConverter.cs
+++ b/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Unity/Runtime/Converters/Vectors/VectorNormalizeConverter.cs
@@ -3,6 +3,11 @@ using Aspid.FastTools.Types;
 using System;
 using UnityEngine;
 
+// The named converter aliases are [Obsolete]. The converters below keep implementing them for
+// one release so that a [SerializeReference] field a project declares as one still
+// deserializes; the base lists go with the aliases in the next major.
+#pragma warning disable CS0618 // Type or member is obsolete
+
 // ReSharper disable once CheckNamespace
 namespace Aspid.MVVM.StarterKit
 {

--- a/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Unity/Runtime/Converters/Vectors/VectorRoundConverter.cs
+++ b/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Unity/Runtime/Converters/Vectors/VectorRoundConverter.cs
@@ -3,6 +3,11 @@ using Aspid.FastTools.Types;
 using System;
 using UnityEngine;
 
+// The named converter aliases are [Obsolete]. The converters below keep implementing them for
+// one release so that a [SerializeReference] field a project declares as one still
+// deserializes; the base lists go with the aliases in the next major.
+#pragma warning disable CS0618 // Type or member is obsolete
+
 // ReSharper disable once CheckNamespace
 namespace Aspid.MVVM.StarterKit
 {

--- a/Aspid.MVVM/Packages/tech.aspid.mvvm/Tests/Editor/Binders/DebugLogBinderTests.cs
+++ b/Aspid.MVVM/Packages/tech.aspid.mvvm/Tests/Editor/Binders/DebugLogBinderTests.cs
@@ -2,6 +2,10 @@ using UnityEngine;
 using NUnit.Framework;
 using UnityEngine.TestTools;
 
+// These fixtures name the [Obsolete] converter aliases on purpose — guarding the deprecated
+// surface is the point.
+#pragma warning disable CS0618 // Type or member is obsolete
+
 namespace Aspid.MVVM.StarterKit.Tests
 {
     /// <summary>

--- a/Aspid.MVVM/Packages/tech.aspid.mvvm/Tests/Editor/Converters/ConverterAssetTests.cs
+++ b/Aspid.MVVM/Packages/tech.aspid.mvvm/Tests/Editor/Converters/ConverterAssetTests.cs
@@ -4,6 +4,10 @@ using NUnit.Framework;
 using UnityEngine.TestTools;
 using System.Text.RegularExpressions;
 
+// These fixtures name the [Obsolete] converter aliases on purpose — guarding the deprecated
+// surface is the point.
+#pragma warning disable CS0618 // Type or member is obsolete
+
 namespace Aspid.MVVM.StarterKit.Tests
 {
     /// <summary>

--- a/Aspid.MVVM/Packages/tech.aspid.mvvm/Tests/Editor/Converters/ConverterDeprecationTests.cs
+++ b/Aspid.MVVM/Packages/tech.aspid.mvvm/Tests/Editor/Converters/ConverterDeprecationTests.cs
@@ -1,0 +1,93 @@
+using System;
+using System.Linq;
+using NUnit.Framework;
+using System.Reflection;
+using System.Collections.Generic;
+
+namespace Aspid.MVVM.StarterKit.Tests
+{
+    /// <summary>
+    /// The named converter aliases and their wrappers are on their way out, and must say so.
+    /// </summary>
+    /// <remarks>
+    /// Forty <c>IConverterXToY</c> interfaces and seventy <c>ToConvert</c> wrappers exist for one
+    /// reason: Unity before 2023.1 could not serialize a <c>[SerializeReference]</c> field of an open
+    /// generic type. The package requires Unity 6000.0, so that reason is gone, but the surface has to
+    /// outlive it by a release — a field a project declares as one of these would otherwise
+    /// deserialize to <see langword="null"/> without a word.
+    /// <para>
+    /// The risk this guards is a new alias being added out of habit, or an existing one losing its
+    /// attribute in a merge. Either would restart the clock on a deprecation that is meant to end.
+    /// </para>
+    /// </remarks>
+    [TestFixture]
+    internal sealed class ConverterDeprecationTests
+    {
+        [Test]
+        public void EveryNamedConverterAliasIsObsolete()
+        {
+            var live = NamedAliases()
+                .Where(type => !type.IsDefined(typeof(ObsoleteAttribute), inherit: false))
+                .ToArray();
+
+            Assert.IsEmpty(
+                live,
+                "These named converter aliases are not marked [Obsolete], so nothing tells a project "
+                + "to move off them before they are removed:"
+                + Environment.NewLine
+                + string.Join(Environment.NewLine, live.Select(type => "  - " + type.Name)));
+        }
+
+        [Test]
+        public void EveryConverterWrapperIsObsolete()
+        {
+            var live = Wrappers()
+                .Where(method => !method.IsDefined(typeof(ObsoleteAttribute), inherit: false))
+                .Where(method => !method.DeclaringType!.IsDefined(typeof(ObsoleteAttribute), inherit: false))
+                .ToArray();
+
+            Assert.IsEmpty(
+                live,
+                "These converter wrappers are not marked [Obsolete]:"
+                + Environment.NewLine
+                + string.Join(
+                    Environment.NewLine,
+                    live.Select(method => $"  - {method.DeclaringType!.Name}.{method.Name}")));
+        }
+
+        // Both checks above pass vacuously if the scan stops finding the surface it guards. The
+        // counts are the ones the deprecation was written against; they may only fall.
+        [Test]
+        public void TheScanSeesTheSurfaceItGuards()
+        {
+            Assert.That(NamedAliases().Count(), Is.EqualTo(40), "named converter aliases");
+            Assert.That(Wrappers().Count(), Is.EqualTo(70), "ToConvert / ToConvertSpecific wrappers");
+        }
+
+        private static IEnumerable<Type> Assemblies() => new[]
+            {
+                typeof(IConverter).Assembly,
+                typeof(SpriteToTextureConverter).Assembly,
+            }
+            .Distinct()
+            .SelectMany(assembly => assembly.GetTypes());
+
+        // An alias carries no members of its own and closes IConverter<,> over two concrete types.
+        // That is exactly what separates it from IConverter itself and from ITwoWayConverter.
+        private static IEnumerable<Type> NamedAliases() => Assemblies()
+            .Where(type => type.IsInterface)
+            .Where(type => type != typeof(IConverter))
+            .Where(type => typeof(IConverter).IsAssignableFrom(type))
+            .Where(type => !type.IsGenericType)
+            .Where(type => type.GetMembers(BindingFlags.Public | BindingFlags.Instance | BindingFlags.DeclaredOnly).Length == 0);
+
+        // ConverterExtensions.ToConvert<TFrom, TTo> shares the name but is the replacement, not the
+        // legacy: it wraps a lambda as IConverter<TFrom, TTo> and outlives every alias here. The
+        // wrappers being deprecated are all non-generic, one per named alias.
+        private static IEnumerable<MethodInfo> Wrappers() => Assemblies()
+            .Where(type => type.IsSealed && type.IsAbstract) // static class
+            .SelectMany(type => type.GetMethods(BindingFlags.Public | BindingFlags.Static | BindingFlags.DeclaredOnly))
+            .Where(method => method.Name is "ToConvert" or "ToConvertSpecific")
+            .Where(method => !method.IsGenericMethodDefinition);
+    }
+}

--- a/Aspid.MVVM/Packages/tech.aspid.mvvm/Tests/Editor/Converters/ConverterDeprecationTests.cs
+++ b/Aspid.MVVM/Packages/tech.aspid.mvvm/Tests/Editor/Converters/ConverterDeprecationTests.cs
@@ -10,15 +10,10 @@ namespace Aspid.MVVM.StarterKit.Tests
     /// The named converter aliases and their wrappers are on their way out, and must say so.
     /// </summary>
     /// <remarks>
-    /// Forty <c>IConverterXToY</c> interfaces and seventy <c>ToConvert</c> wrappers exist for one
-    /// reason: Unity before 2023.1 could not serialize a <c>[SerializeReference]</c> field of an open
-    /// generic type. The package requires Unity 6000.0, so that reason is gone, but the surface has to
-    /// outlive it by a release — a field a project declares as one of these would otherwise
-    /// deserialize to <see langword="null"/> without a word.
-    /// <para>
-    /// The risk this guards is a new alias being added out of habit, or an existing one losing its
-    /// attribute in a merge. Either would restart the clock on a deprecation that is meant to end.
-    /// </para>
+    /// The aliases must outlive their reason by a release: a field a project declares as one of them
+    /// would otherwise deserialize to <see langword="null"/> without a word. This guards against a new
+    /// alias added out of habit, or an existing one losing its attribute in a merge — either restarts
+    /// the clock on a deprecation that is meant to end.
     /// </remarks>
     [TestFixture]
     internal sealed class ConverterDeprecationTests

--- a/Aspid.MVVM/Packages/tech.aspid.mvvm/Tests/Editor/Converters/ConverterDeprecationTests.cs.meta
+++ b/Aspid.MVVM/Packages/tech.aspid.mvvm/Tests/Editor/Converters/ConverterDeprecationTests.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 21a690ce7f7104da684a964865704976

--- a/Aspid.MVVM/Packages/tech.aspid.mvvm/Tests/Editor/Converters/ConverterFieldCoverageTests.cs
+++ b/Aspid.MVVM/Packages/tech.aspid.mvvm/Tests/Editor/Converters/ConverterFieldCoverageTests.cs
@@ -7,6 +7,10 @@ using System.Reflection;
 using Aspid.FastTools.Types;
 using System.Collections.Generic;
 
+// These fixtures name the [Obsolete] converter aliases on purpose — guarding the deprecated
+// surface is the point.
+#pragma warning disable CS0618 // Type or member is obsolete
+
 namespace Aspid.MVVM.StarterKit.Tests
 {
     /// <summary>

--- a/Aspid.MVVM/Packages/tech.aspid.mvvm/Tests/Editor/Converters/ConverterInspectorContractTests.cs
+++ b/Aspid.MVVM/Packages/tech.aspid.mvvm/Tests/Editor/Converters/ConverterInspectorContractTests.cs
@@ -6,6 +6,10 @@ using NUnit.Framework;
 using System.Reflection;
 using System.Collections.Generic;
 
+// These fixtures name the [Obsolete] converter aliases on purpose — guarding the deprecated
+// surface is the point.
+#pragma warning disable CS0618 // Type or member is obsolete
+
 namespace Aspid.MVVM.StarterKit.Tests
 {
     /// <summary>

--- a/Aspid.MVVM/Packages/tech.aspid.mvvm/Tests/Editor/Converters/ConverterPickerContractTests.cs
+++ b/Aspid.MVVM/Packages/tech.aspid.mvvm/Tests/Editor/Converters/ConverterPickerContractTests.cs
@@ -6,6 +6,10 @@ using NUnit.Framework;
 using Aspid.FastTools.Types;
 using System.Collections.Generic;
 
+// These fixtures name the [Obsolete] converter aliases on purpose — guarding the deprecated
+// surface is the point.
+#pragma warning disable CS0618 // Type or member is obsolete
+
 namespace Aspid.MVVM.StarterKit.Tests
 {
     /// <summary>

--- a/Aspid.MVVM/Packages/tech.aspid.mvvm/Tests/Editor/Converters/Vectors/Vector3CombineConverterTests.cs
+++ b/Aspid.MVVM/Packages/tech.aspid.mvvm/Tests/Editor/Converters/Vectors/Vector3CombineConverterTests.cs
@@ -4,6 +4,10 @@ using UnityEngine.TestTools;
 using System.Text.RegularExpressions;
 using Mode = Aspid.MVVM.StarterKit.Vector3CombineConverter.Mode;
 
+// These fixtures name the [Obsolete] converter aliases on purpose — guarding the deprecated
+// surface is the point.
+#pragma warning disable CS0618 // Type or member is obsolete
+
 namespace Aspid.MVVM.StarterKit.Tests
 {
     /// <summary>


### PR DESCRIPTION
⚠️ The 40 `IConverterXToY` interfaces and the 70 `ToConvert` / `ToConvertSpecific` wrappers are now `[Obsolete]` — the previous PR removed the last field that needed them.

## Summary

- ⚠️ **40 named aliases** deprecated, each message naming the `IConverter<TFrom, TTo>` that replaces it.
- ⚠️ **70 wrappers and their 6 host classes** deprecated; they existed only so a lambda could be assigned to an alias-typed field.
- 🔧 **Not deleted, and still implemented** — the package's own converters keep the aliases behind one `#pragma warning disable CS0618` per file, with a comment saying why.
- 📝 `ConverterExtensions.ToConvert<TFrom, TTo>` is the replacement and stays.
- ✅ A test asserts every alias and wrapper carries the attribute, with a count guard so it cannot pass by finding nothing.

## Notes for review

- ⚠️ **Deprecate rather than delete**: dropping an alias from a base list makes Unity null a `[SerializeReference] IConverterFloat` field on load — no exception, no console entry — and a compiler warning is the only channel that says so, one release ahead.
- 📝 The 35 pragmas are the to-do list: when the aliases go, `grep CS0618` is the checklist.
- ✅ 1040 EditMode tests, 1038 passed, 0 failed, 2 skipped. No new compiler warnings.

<details>
<summary>🇷🇺 Описание на русском</summary>

⚠️ 40 интерфейсов `IConverterXToY` и 70 обёрток `ToConvert` / `ToConvertSpecific` помечены `[Obsolete]` — предыдущий PR убрал последнее поле, которому они были нужны.

## Итог

- ⚠️ **40 именованных псевдонимов** объявлены устаревшими, в сообщении каждого назван заменяющий `IConverter<TFrom, TTo>`.
- ⚠️ **70 обёрток и 6 содержащих их классов** объявлены устаревшими; они существовали только затем, чтобы лямбду можно было присвоить полю с типом-псевдонимом.
- 🔧 **Не удалены и по-прежнему реализуются** — конвертеры пакета сохраняют псевдонимы за одной `#pragma warning disable CS0618` на файл, с комментарием зачем.
- 📝 `ConverterExtensions.ToConvert<TFrom, TTo>` — это замена, и он остаётся.
- ✅ Тест проверяет наличие атрибута у каждого псевдонима и обёртки, плюс контроль количества, чтобы проверка не прошла «найдя ничего».

## Заметки для ревью

- ⚠️ **Депрекация, а не удаление**: убрав псевдоним из базового списка, получим поле `[SerializeReference] IConverterFloat`, обнулённое Unity при загрузке — без исключения и без записи в консоли, — а предупреждение компилятора единственное скажет об этом за релиз вперёд.
- 📝 35 прагм — это и есть список задач: когда псевдонимы уйдут, `grep CS0618` будет чек-листом.
- ✅ 1040 EditMode-теста, 1038 прошло, 0 упало, 2 пропущено. Новых предупреждений компилятора нет.

</details>

