### PR TITLE
Give ArithmeticNumberConverter a public Apply

### DIFF
--- a/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Runtime/Converters/Bools/BoolInvertConverter.cs
+++ b/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Runtime/Converters/Bools/BoolInvertConverter.cs
@@ -8,16 +8,10 @@ namespace Aspid.MVVM.StarterKit
     /// Negates a boolean.
     /// </summary>
     /// <remarks>
-    /// The View often wants the opposite of what the ViewModel exposes — a panel shown while
-    /// <c>IsLoading</c> is false, a button enabled while <c>IsBusy</c> is false — and adding a second
-    /// property for the negation puts View concerns in the ViewModel.
-    /// <para>
-    /// Thirteen binders carry an <c>_isInvert</c> checkbox for the same reason, and it is not
-    /// redundant with this: those binders derive from the two-parameter
-    /// <see cref="TargetBinder{TTarget, TProperty}"/>, which has no converter field, so the checkbox
-    /// is the only inversion they can offer. Reach for this converter when the binder does have a
-    /// converter slot, or when inversion is one step of a longer chain.
-    /// </para>
+    /// Not redundant with the <c>_isInvert</c> checkbox thirteen binders carry: those derive from the
+    /// two-parameter <see cref="TargetBinder{TTarget, TProperty}"/>, which has no converter field, so
+    /// the checkbox is the only inversion they can offer. Reach for this converter when the binder does
+    /// have a converter slot, or when inversion is one step of a longer chain.
     /// </remarks>
     [Serializable]
     [TypeSelectorDisplay(Group = "Aspid/Bool", Name = "Bool Invert", Tooltip = "Negates a boolean")]

--- a/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Runtime/Converters/Bools/BoolInvertConverter.cs
+++ b/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Runtime/Converters/Bools/BoolInvertConverter.cs
@@ -10,8 +10,14 @@ namespace Aspid.MVVM.StarterKit
     /// <remarks>
     /// The View often wants the opposite of what the ViewModel exposes — a panel shown while
     /// <c>IsLoading</c> is false, a button enabled while <c>IsBusy</c> is false — and adding a second
-    /// property for the negation puts View concerns in the ViewModel. Three binders carry their own
-    /// <c>_isInvert</c> flag for the same reason; this is the same thing, available to all of them.
+    /// property for the negation puts View concerns in the ViewModel.
+    /// <para>
+    /// Thirteen binders carry an <c>_isInvert</c> checkbox for the same reason, and it is not
+    /// redundant with this: those binders derive from the two-parameter
+    /// <see cref="TargetBinder{TTarget, TProperty}"/>, which has no converter field, so the checkbox
+    /// is the only inversion they can offer. Reach for this converter when the binder does have a
+    /// converter slot, or when inversion is one step of a longer chain.
+    /// </para>
     /// </remarks>
     [Serializable]
     [TypeSelectorDisplay(Group = "Aspid/Bool", Name = "Bool Invert", Tooltip = "Negates a boolean")]

--- a/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Runtime/Converters/Numbers/ArithmeticNumberConverter.cs
+++ b/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Runtime/Converters/Numbers/ArithmeticNumberConverter.cs
@@ -22,7 +22,7 @@ namespace Aspid.MVVM.StarterKit
     /// </remarks>
     [Serializable]
     [TypeSelectorDisplay(Group = "Aspid/Number", Name = "Arithmetic Number", Tooltip = "Converts numeric values by applying arithmetic operations with a coefficient")]
-    public class ArithmeticNumberConverter :
+    public sealed class ArithmeticNumberConverter :
         IConverterDouble, IConverterIntToDouble, IConverterLongToDouble, IConverterFloatToDouble,
         IConverterFloat, IConverterIntToFloat, IConverterLongToFloat, IConverterDoubleToFloat,
         IConverterInt, IConverterLongToInt, IConverterFloatToInt, IConverterDoubleToInt,
@@ -47,48 +47,62 @@ namespace Aspid.MVVM.StarterKit
         
         #region Return int
         int IConverter<int, int>.Convert(int value) =>
-            (int)((IConverter<double, double>)this).Convert(value);
+            (int)Apply(value);
         
         int IConverter<long, int>.Convert(long value) =>
-            (int)((IConverter<double, double>)this).Convert(value);
+            (int)Apply(value);
         
         int IConverter<float, int>.Convert(float value) =>
-            (int)((IConverter<double, double>)this).Convert(value);
+            (int)Apply(value);
         
         int IConverter<double, int>.Convert(double value) =>
-            (int)((IConverter<double, double>)this).Convert(value);
+            (int)Apply(value);
         #endregion
         
         #region Return long
         long IConverter<long, long>.Convert(long value) => 
-            (long)((IConverter<double, double>)this).Convert(value);
+            (long)Apply(value);
         
         long IConverter<int, long>.Convert(int value) => 
-            (long)((IConverter<double, double>)this).Convert(value);
+            (long)Apply(value);
         
         long IConverter<float, long>.Convert(float value) => 
-            (long)((IConverter<double, double>)this).Convert(value);
+            (long)Apply(value);
 
         long IConverter<double, long>.Convert(double value) => 
-            (long)((IConverter<double, double>)this).Convert(value);
+            (long)Apply(value);
         #endregion
 
         #region Return float
         float IConverter<float, float>.Convert(float value) => 
-            (float)((IConverter<double, double>)this).Convert(value);
+            (float)Apply(value);
         
         float IConverter<int, float>.Convert(int value) => 
-            (float)((IConverter<double, double>)this).Convert(value);
+            (float)Apply(value);
         
         float IConverter<long, float>.Convert(long value) => 
-            (float)((IConverter<double, double>)this).Convert(value);
+            (float)Apply(value);
         
         float IConverter<double, float>.Convert(double value) => 
-            (float)((IConverter<double, double>)this).Convert(value);
+            (float)Apply(value);
         #endregion
 
         #region Return double
-        double IConverter<double, double>.Convert(double value) => _operation switch
+        double IConverter<double, double>.Convert(double value) => Apply(value);
+
+        /// <summary>
+        /// Applies the configured arithmetic to the specified number.
+        /// </summary>
+        /// <param name="value">The number to transform.</param>
+        /// <returns>The result, in <see cref="double"/> whatever the caller's own numeric type.</returns>
+        /// <remarks>
+        /// Every overload of <c>Convert</c> lands here and casts the result. It is public because the
+        /// alternative — reaching the arithmetic through
+        /// <c>((IConverter&lt;double, double&gt;)converter).Convert(x)</c> — is a cast a reader has to
+        /// decode, and this class did it fifteen times against itself.
+        /// </remarks>
+        /// <exception cref="ArgumentOutOfRangeException">Thrown when the configured operation is not a declared value.</exception>
+        public double Apply(double value) => _operation switch
         {
             NumberOperation.Plus => value + _coefficient,
             NumberOperation.Minus => value - _coefficient,
@@ -102,13 +116,13 @@ namespace Aspid.MVVM.StarterKit
         };
 
         double IConverter<int, double>.Convert(int value) =>
-            ((IConverter<double, double>)this).Convert(value);
-        
+            Apply(value);
+
         double IConverter<float, double>.Convert(float value) =>
-            ((IConverter<double, double>)this).Convert(value);
-        
+            Apply(value);
+
         double IConverter<long, double>.Convert(long value) =>
-            ((IConverter<double, double>)this).Convert(value);
+            Apply(value);
         #endregion
 
         #region Convert back
@@ -124,7 +138,20 @@ namespace Aspid.MVVM.StarterKit
         long ITwoWayConverter<long, long>.ConvertBack(long value) => 
             (long)Undo(value);
 
-        private double Undo(double value) => _operation switch
+        /// <summary>
+        /// Reverses <see cref="Apply"/>.
+        /// </summary>
+        /// <param name="value">The number to transform back.</param>
+        /// <returns>
+        /// The number the forward pass was given, or <paramref name="value"/> unchanged where the
+        /// operation cannot be undone.
+        /// </returns>
+        /// <remarks>
+        /// <see cref="NumberOperation.Modulo"/> discards which multiple the value came from, and a
+        /// zero coefficient makes multiplication and division identities; both return the input.
+        /// </remarks>
+        /// <exception cref="ArgumentOutOfRangeException">Thrown when the configured operation is not a declared value.</exception>
+        public double Undo(double value) => _operation switch
         {
             NumberOperation.Plus => value - _coefficient,
             NumberOperation.Minus => value + _coefficient,


### PR DESCRIPTION
♻️ `ArithmeticNumberConverter` reached its own arithmetic by casting itself to one of its interfaces, fifteen times.

## Summary

- ♻️ **`Apply(double)` and `Undo(double)` are public** — the sixteen `Convert` overloads no longer go through `(int)((IConverter<double, double>)this).Convert(value)`.
- 🔧 The class is `sealed`: it has no subclass, and its explicit interface implementations were never overridable.
- 📝 `BoolInvertConverter` now documents where it does and does not replace the `_isInvert` checkbox.

## Notes for review

- ⚠️ **Audit item 5.6 is rejected**: 13 of the binders carrying `_isInvert` derive from the two-parameter `TargetBinder<TTarget, TProperty>`, which has no converter field, so deprecating the checkbox removes the feature rather than relocating it.
- ⚠️ The second half of 5.6 fails too: a binder's converter is constrained to `IConverter<TProperty, TProperty>`, and `BoolToValueConverter<T>` is cross-type, so it cannot replace the `Switcher*Binder` family.
- ✅ 1048 EditMode tests, 1046 passed, 0 failed, 2 skipped.

<details>
<summary>🇷🇺 Описание на русском</summary>

♻️ `ArithmeticNumberConverter` добирался до собственной арифметики, приводя себя к одному из своих интерфейсов — пятнадцать раз.

## Итог

- ♻️ **`Apply(double)` и `Undo(double)` стали публичными** — шестнадцать перегрузок `Convert` больше не ходят через `(int)((IConverter<double, double>)this).Convert(value)`.
- 🔧 Класс помечен `sealed`: наследников нет, а явные реализации интерфейсов и так нельзя переопределить.
- 📝 `BoolInvertConverter` теперь документирует, где он заменяет флажок `_isInvert`, а где нет.

## Заметки для ревью

- ⚠️ **Пункт аудита 5.6 отклонён**: 13 биндеров с `_isInvert` наследуются от двухпараметрического `TargetBinder<TTarget, TProperty>`, у которого нет поля конвертера, поэтому депрекация флажка убирает функцию, а не переносит её.
- ⚠️ Вторая половина 5.6 тоже не работает: конвертер биндера ограничен `IConverter<TProperty, TProperty>`, а `BoolToValueConverter<T>` кросс-типовой, так что заменить семейство `Switcher*Binder` он не может.
- ✅ 1048 EditMode-тестов, 1046 прошло, 0 упало, 2 пропущено.

</details>

