### PR TITLE
Stop four binders forward-converting on the way back

### DIFF
--- a/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Unity/Runtime/Binders/GameObjects/Tag/GameObjectTagBinder.cs
+++ b/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Unity/Runtime/Binders/GameObjects/Tag/GameObjectTagBinder.cs
@@ -48,10 +48,29 @@ namespace Aspid.MVVM.StarterKit
         protected override void OnBound()
         {
             if (Mode is BindMode.OneWayToSource)
-                ValueChanged?.Invoke(GetConvertedValue(Target.tag));
+                ValueChanged?.Invoke(GetConvertedBackValue(Target.tag));
         }
         
         private string GetConvertedValue(string value) =>
             _converter?.Convert(value) ?? value;
+
+        /// <summary>
+        /// Converts a value on its way back to the ViewModel.
+        /// </summary>
+        /// <param name="value">The value read from the target.</param>
+        /// <returns>
+        /// The value as the ViewModel expects it: undone by the converter when it offers
+        /// <see cref="ITwoWayConverter{TFrom, TTo}"/>, and unchanged when it does not.
+        /// </returns>
+        /// <remarks>
+        /// The forward converter must not be applied here. This binder pushes the target's current
+        /// value to the ViewModel, so running it through <c>Convert</c> a second time hands the
+        /// ViewModel a value that has been converted twice — visibly wrong for anything that is not
+        /// its own inverse.
+        /// </remarks>
+        private string GetConvertedBackValue(string value) =>
+            _converter is ITwoWayConverter<string?, string?> twoWay
+                ? twoWay.ConvertBack(value) ?? value
+                : value;
     }
 }

--- a/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Unity/Runtime/Binders/GameObjects/Tag/Mono/GameObjectTagMonoBinder.cs
+++ b/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Unity/Runtime/Binders/GameObjects/Tag/Mono/GameObjectTagMonoBinder.cs
@@ -36,10 +36,29 @@ namespace Aspid.MVVM.StarterKit
         protected override void OnBound()
         {
             if (Mode is BindMode.OneWayToSource)
-                ValueChanged?.Invoke(GetConvertedValue(gameObject.tag));
+                ValueChanged?.Invoke(GetConvertedBackValue(gameObject.tag));
         }
         
         private string GetConvertedValue(string value) =>
             _converter?.Convert(value) ?? value;
+
+        /// <summary>
+        /// Converts a value on its way back to the ViewModel.
+        /// </summary>
+        /// <param name="value">The value read from the target.</param>
+        /// <returns>
+        /// The value as the ViewModel expects it: undone by the converter when it offers
+        /// <see cref="ITwoWayConverter{TFrom, TTo}"/>, and unchanged when it does not.
+        /// </returns>
+        /// <remarks>
+        /// The forward converter must not be applied here. This binder pushes the target's current
+        /// value to the ViewModel, so running it through <c>Convert</c> a second time hands the
+        /// ViewModel a value that has been converted twice — visibly wrong for anything that is not
+        /// its own inverse.
+        /// </remarks>
+        private string GetConvertedBackValue(string value) =>
+            _converter is ITwoWayConverter<string?, string?> twoWay
+                ? twoWay.ConvertBack(value) ?? value
+                : value;
     }
 }

--- a/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Unity/Runtime/Binders/Objects/Mono/ObjectNameMonoBinder.cs
+++ b/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Unity/Runtime/Binders/Objects/Mono/ObjectNameMonoBinder.cs
@@ -50,10 +50,29 @@ namespace Aspid.MVVM.StarterKit
         protected override void OnBound()
         {
             if (Mode is BindMode.OneWayToSource)
-                ValueChanged?.Invoke(GetConvertedValue(_object.name));
+                ValueChanged?.Invoke(GetConvertedBackValue(_object.name));
         }
         
         private string GetConvertedValue(string value) =>
             _converter?.Convert(value) ?? value ?? string.Empty;
+
+        /// <summary>
+        /// Converts a value on its way back to the ViewModel.
+        /// </summary>
+        /// <param name="value">The value read from the target.</param>
+        /// <returns>
+        /// The value as the ViewModel expects it: undone by the converter when it offers
+        /// <see cref="ITwoWayConverter{TFrom, TTo}"/>, and unchanged when it does not.
+        /// </returns>
+        /// <remarks>
+        /// The forward converter must not be applied here. This binder pushes the target's current
+        /// value to the ViewModel, so running it through <c>Convert</c> a second time hands the
+        /// ViewModel a value that has been converted twice — visibly wrong for anything that is not
+        /// its own inverse.
+        /// </remarks>
+        private string GetConvertedBackValue(string value) =>
+            _converter is ITwoWayConverter<string?, string?> twoWay
+                ? twoWay.ConvertBack(value) ?? value
+                : value;
     }
 }

--- a/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Unity/Runtime/Binders/Objects/ObjectNameBinder.cs
+++ b/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Unity/Runtime/Binders/Objects/ObjectNameBinder.cs
@@ -65,10 +65,29 @@ namespace Aspid.MVVM.StarterKit
         protected override void OnBound()
         {
             if (Mode is BindMode.OneWayToSource)
-                ValueChanged?.Invoke(GetConvertedValue(Target.name));
+                ValueChanged?.Invoke(GetConvertedBackValue(Target.name));
         }
         
         private string GetConvertedValue(string value) =>
             _converter?.Convert(value) ?? value ?? string.Empty;
+
+        /// <summary>
+        /// Converts a value on its way back to the ViewModel.
+        /// </summary>
+        /// <param name="value">The value read from the target.</param>
+        /// <returns>
+        /// The value as the ViewModel expects it: undone by the converter when it offers
+        /// <see cref="ITwoWayConverter{TFrom, TTo}"/>, and unchanged when it does not.
+        /// </returns>
+        /// <remarks>
+        /// The forward converter must not be applied here. This binder pushes the target's current
+        /// value to the ViewModel, so running it through <c>Convert</c> a second time hands the
+        /// ViewModel a value that has been converted twice — visibly wrong for anything that is not
+        /// its own inverse.
+        /// </remarks>
+        private string GetConvertedBackValue(string value) =>
+            _converter is ITwoWayConverter<string?, string?> twoWay
+                ? twoWay.ConvertBack(value) ?? value
+                : value;
     }
 }

--- a/Aspid.MVVM/Packages/tech.aspid.mvvm/Tests/Editor/Binders/ReverseConversionTests.cs
+++ b/Aspid.MVVM/Packages/tech.aspid.mvvm/Tests/Editor/Binders/ReverseConversionTests.cs
@@ -1,0 +1,97 @@
+using System;
+using UnityEngine;
+using NUnit.Framework;
+
+namespace Aspid.MVVM.StarterKit.Tests
+{
+    /// <summary>
+    /// A binder must never run the forward converter on a value going back to the ViewModel.
+    /// </summary>
+    /// <remarks>
+    /// The base <see cref="TargetBinder{TTarget, TProperty, TConverter}"/> was fixed to route the
+    /// reverse direction through <see cref="ITwoWayConverter{TFrom, TTo}"/>, but four binders carry
+    /// their own private converter field and never inherited that: <c>GameObjectTagBinder</c>,
+    /// <c>GameObjectTagMonoBinder</c>, <c>ObjectNameBinder</c> and <c>ObjectNameMonoBinder</c> each
+    /// pushed <c>GetConvertedValue(target)</c> to the ViewModel on bind.
+    /// <para>
+    /// The bug hides behind the converters people test with. Inversion and negation are their own
+    /// inverse, so applying the forward conversion twice looks correct; a converter that appends a
+    /// suffix shows it immediately. That is why the converter here is deliberately not an involution.
+    /// </para>
+    /// </remarks>
+    [TestFixture]
+    internal sealed class ReverseConversionTests
+    {
+        [Test]
+        public void GameObjectTagBinder_OneWayToSource_SendsTheValueBackUndone()
+        {
+            var go = new GameObject("probe") { tag = "Player" };
+            try
+            {
+                string? received = null;
+                var member = new OneWayToSourceBindableMember<string>(value => received = value);
+                var binder = new GameObjectTagBinder(go, new SuffixConverter(), BindMode.OneWayToSource);
+
+                binder.Bind(member);
+
+                Assert.AreEqual("Player", received, "the tag should arrive as the ViewModel would hold it");
+            }
+            finally { UnityEngine.Object.DestroyImmediate(go); }
+        }
+
+        [Test]
+        public void GameObjectTagBinder_OneWayToSource_WithAOneWayConverter_SendsTheRawValue()
+        {
+            var go = new GameObject("probe") { tag = "Player" };
+            try
+            {
+                string? received = null;
+                var member = new OneWayToSourceBindableMember<string>(value => received = value);
+                var binder = new GameObjectTagBinder(go, new OneWaySuffixConverter(), BindMode.OneWayToSource);
+
+                binder.Bind(member);
+
+                Assert.AreEqual(
+                    "Player",
+                    received,
+                    "a one-way converter cannot be undone, so the raw value is the only honest answer — "
+                    + "and it must not be the forward-converted one");
+            }
+            finally { UnityEngine.Object.DestroyImmediate(go); }
+        }
+
+        [Test]
+        public void ObjectNameBinder_OneWayToSource_SendsTheValueBackUndone()
+        {
+            var go = new GameObject("Hero");
+            try
+            {
+                string? received = null;
+                var member = new OneWayToSourceBindableMember<string>(value => received = value);
+                var binder = new ObjectNameBinder(go, new SuffixConverter(), BindMode.OneWayToSource);
+
+                binder.Bind(member);
+
+                Assert.AreEqual("Hero", received);
+            }
+            finally { UnityEngine.Object.DestroyImmediate(go); }
+        }
+
+        // Appending is not its own inverse, so a doubled forward pass is visible. An inverting or
+        // negating converter would let the bug through.
+        private sealed class SuffixConverter : ITwoWayConverter<string?, string?>
+        {
+            public string? Convert(string? value) => value + "!";
+
+            public string? ConvertBack(string? value) =>
+                value is not null && value.EndsWith("!", StringComparison.Ordinal)
+                    ? value[..^1]
+                    : value;
+        }
+
+        private sealed class OneWaySuffixConverter : IConverter<string?, string?>
+        {
+            public string? Convert(string? value) => value + "!";
+        }
+    }
+}

--- a/Aspid.MVVM/Packages/tech.aspid.mvvm/Tests/Editor/Binders/ReverseConversionTests.cs
+++ b/Aspid.MVVM/Packages/tech.aspid.mvvm/Tests/Editor/Binders/ReverseConversionTests.cs
@@ -8,15 +8,11 @@ namespace Aspid.MVVM.StarterKit.Tests
     /// A binder must never run the forward converter on a value going back to the ViewModel.
     /// </summary>
     /// <remarks>
-    /// The base <see cref="TargetBinder{TTarget, TProperty, TConverter}"/> was fixed to route the
-    /// reverse direction through <see cref="ITwoWayConverter{TFrom, TTo}"/>, but four binders carry
-    /// their own private converter field and never inherited that: <c>GameObjectTagBinder</c>,
-    /// <c>GameObjectTagMonoBinder</c>, <c>ObjectNameBinder</c> and <c>ObjectNameMonoBinder</c> each
-    /// pushed <c>GetConvertedValue(target)</c> to the ViewModel on bind.
+    /// Four binders carry their own private converter field and never inherited the base fix that routes
+    /// the reverse direction through <see cref="ITwoWayConverter{TFrom, TTo}"/>.
     /// <para>
-    /// The bug hides behind the converters people test with. Inversion and negation are their own
-    /// inverse, so applying the forward conversion twice looks correct; a converter that appends a
-    /// suffix shows it immediately. That is why the converter here is deliberately not an involution.
+    /// The bug hides behind the converters people test with: inversion is its own inverse, so applying
+    /// the forward conversion twice looks correct. The converter here is deliberately not an involution.
     /// </para>
     /// </remarks>
     [TestFixture]

--- a/Aspid.MVVM/Packages/tech.aspid.mvvm/Tests/Editor/Binders/ReverseConversionTests.cs.meta
+++ b/Aspid.MVVM/Packages/tech.aspid.mvvm/Tests/Editor/Binders/ReverseConversionTests.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 84498ad18f41648119d46bac22084611


### PR DESCRIPTION
🐛 Four binders still ran the **forward** converter on values travelling **back** to the ViewModel.

## Summary

- 🐛 `GameObjectTagBinder`, `GameObjectTagMonoBinder`, `ObjectNameBinder` and `ObjectNameMonoBinder` pushed `GetConvertedValue(target)` to the ViewModel on bind.
- ✅ They now use `ConvertBack` when the converter is an `ITwoWayConverter` and send the raw value otherwise — the rule the base `TargetBinder` already follows.
- ✅ Three tests, mutation-checked: undoing the fix on one binder fails exactly that binder's two tests.

## Notes for review

- ⚠️ An earlier PR in this stack claimed this defect fixed — that fix landed in `TargetBinder` / `ComponentMonoBinder`, and these four keep their own `_converter` field, so it never reached them.
- 📝 The test converter appends a suffix rather than inverting: inversion is its own inverse, so a `BoolInvertConverter` test passes with the bug present — which is how it survived the first fix.
- 📝 Seven binders (`InputField*`, `Slider*`, `RendererMaterials*`, `TwoWayValue`) still send the raw value back; incomplete rather than wrong, and left for its own PR.

✅ 1051 EditMode tests, 1049 passed, 0 failed, 2 skipped (batch mode).

<details>
<summary>🇷🇺 Описание на русском</summary>

🐛 Четыре биндера применяли **прямой** конвертер к значениям, идущим **обратно** во ViewModel.

## Итог

- 🐛 `GameObjectTagBinder`, `GameObjectTagMonoBinder`, `ObjectNameBinder` и `ObjectNameMonoBinder` при биндинге отправляли во ViewModel `GetConvertedValue(target)`.
- ✅ Теперь они используют `ConvertBack`, если конвертер — `ITwoWayConverter`, и отдают сырое значение иначе — то же правило, что и в базовом `TargetBinder`.
- ✅ Три теста, проверенных мутацией: откат фикса на одном биндере валит ровно его два теста.

## Заметки для ревью

- ⚠️ Предыдущий PR стека объявлял этот дефект исправленным — но фикс приехал в `TargetBinder` / `ComponentMonoBinder`, а у этих четырёх собственное поле `_converter`, до которого он не дошёл.
- 📝 Тестовый конвертер добавляет суффикс, а не инвертирует: инверсия сама себе обратна, поэтому тест на `BoolInvertConverter` проходит и с дефектом — именно так он пережил первый фикс.
- 📝 Ещё семь биндеров (`InputField*`, `Slider*`, `RendererMaterials*`, `TwoWayValue`) по-прежнему отдают сырое значение; это неполнота, а не ошибка, и вынесено в отдельный PR.

✅ 1051 EditMode-теста, 1049 прошёл, 0 упало, 2 пропущено (batch mode).

</details>


