### PR TITLE
Give the parse converters a failure mode

### DIFF
--- a/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Runtime/Converters/ConverterFailure.cs
+++ b/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Runtime/Converters/ConverterFailure.cs
@@ -1,0 +1,60 @@
+#nullable enable
+using System;
+
+// ReSharper disable once CheckNamespace
+namespace Aspid.MVVM.StarterKit
+{
+    /// <summary>
+    /// The shared half of <see cref="ConverterFailureMode"/>: reporting a value that would not convert.
+    /// </summary>
+    /// <remarks>
+    /// The enum gave the converters a common vocabulary but left each to write its own reporting, and
+    /// the first two to adopt it already disagreed about wording and about how often to log. This is
+    /// the other half — one message shape and one log-once rule, so a designer reading the console
+    /// sees the same thing whichever converter failed.
+    /// <para>
+    /// The log-once flag lives on the calling converter, passed by reference, because "once" has to
+    /// mean once per converter instance. A binder pushes on every notification, and a value that
+    /// fails to parse usually fails on every one of them; <see cref="UnityEngine.Debug.LogError"/>
+    /// captures a stack trace, so logging per call costs frames rather than just noise.
+    /// </para>
+    /// </remarks>
+    internal static class ConverterFailure
+    {
+        /// <summary>
+        /// Reports a value the converter could not convert, once per converter instance.
+        /// </summary>
+        /// <param name="logged">
+        /// The caller's log-once flag. Set to <see langword="true"/> by the first call.
+        /// </param>
+        /// <param name="converter">The reporting converter's type name.</param>
+        /// <param name="value">The value that would not convert.</param>
+        /// <param name="expected">What the converter needed, as a noun phrase — "a whole number".</param>
+        /// <param name="fallback">What is being returned instead, as it will read in the sentence.</param>
+        internal static void Report(
+            ref bool logged,
+            string converter,
+            object? value,
+            string expected,
+            string fallback)
+        {
+            if (logged) return;
+            logged = true;
+
+            UnityEngine.Debug.LogError(
+                $"{converter}: expected {expected} but got \"{value}\". Using {fallback}. "
+                + "Further failures on this converter are not reported.");
+        }
+
+        /// <summary>
+        /// Builds the exception thrown when the converter is set to
+        /// <see cref="ConverterFailureMode.Throw"/>.
+        /// </summary>
+        /// <param name="converter">The throwing converter's type name.</param>
+        /// <param name="value">The value that would not convert.</param>
+        /// <param name="expected">What the converter needed, as a noun phrase.</param>
+        /// <returns>The exception to throw.</returns>
+        internal static FormatException Rejected(string converter, object? value, string expected) =>
+            new($"{converter}: expected {expected} but got \"{value}\".");
+    }
+}

--- a/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Runtime/Converters/ConverterFailure.cs
+++ b/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Runtime/Converters/ConverterFailure.cs
@@ -8,15 +8,12 @@ namespace Aspid.MVVM.StarterKit
     /// The shared half of <see cref="ConverterFailureMode"/>: reporting a value that would not convert.
     /// </summary>
     /// <remarks>
-    /// The enum gave the converters a common vocabulary but left each to write its own reporting, and
-    /// the first two to adopt it already disagreed about wording and about how often to log. This is
-    /// the other half — one message shape and one log-once rule, so a designer reading the console
-    /// sees the same thing whichever converter failed.
+    /// One message shape and one log-once rule, so a designer reading the console sees the same thing
+    /// whichever converter failed.
     /// <para>
-    /// The log-once flag lives on the calling converter, passed by reference, because "once" has to
-    /// mean once per converter instance. A binder pushes on every notification, and a value that
-    /// fails to parse usually fails on every one of them; <see cref="UnityEngine.Debug.LogError"/>
-    /// captures a stack trace, so logging per call costs frames rather than just noise.
+    /// The log-once flag lives on the calling converter, passed by reference, because "once" has to mean
+    /// once per converter instance: a binder pushes on every notification and a bad value fails on each,
+    /// and <see cref="UnityEngine.Debug.LogError"/> captures a stack trace — logging per call costs frames.
     /// </para>
     /// </remarks>
     internal static class ConverterFailure

--- a/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Runtime/Converters/ConverterFailure.cs.meta
+++ b/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Runtime/Converters/ConverterFailure.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: c6bcec56d8088401680a9af27402afd2

--- a/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Runtime/Converters/Strings/StringToBoolParseConverter.cs
+++ b/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Runtime/Converters/Strings/StringToBoolParseConverter.cs
@@ -24,6 +24,14 @@ namespace Aspid.MVVM.StarterKit
         [Tooltip("The spellings read as true. Matched without regard to case.")]
         [SerializeField] private string[] _trueTokens = { "true", "1", "yes", "on" };
 
+        [Tooltip("The spellings read as false. Leave empty to treat anything unmatched as false; "
+            + "fill it in to have text matching neither list reported as a failure.")]
+        [SerializeField] private string[] _falseTokens = Array.Empty<string>();
+
+        [Tooltip("What to do with text that does not parse. ReturnInput is not available here — the "
+            + "input is text and the output is not — and behaves as ReturnFallback.")]
+        [SerializeField] private ConverterFailureMode _onFailure = ConverterFailureMode.ReturnFallback;
+
         [Tooltip("Returned when the text matches nothing.")]
         [SerializeField] private bool _fallback;
 
@@ -53,7 +61,31 @@ namespace Aspid.MVVM.StarterKit
                 if (string.Equals(trimmed, _trueTokens[i], StringComparison.OrdinalIgnoreCase))
                     return true;
 
+            if (_falseTokens is { Length: > 0 })
+            {
+                for (var i = 0; i < _falseTokens.Length; i++)
+                    if (string.Equals(trimmed, _falseTokens[i], StringComparison.OrdinalIgnoreCase))
+                        return false;
+
+                // Neither list matched, so the text is not a spelling of either answer.
+                return OnUnparsed(value);
+            }
+
+            // With no false-spellings configured, anything unmatched is false by construction rather
+            // than by failure — there is nothing to report.
             return _fallback;
         }
+
+        private bool OnUnparsed(string? value)
+        {
+            if (_onFailure is ConverterFailureMode.Throw)
+                throw ConverterFailure.Rejected(nameof(StringToBoolParseConverter), value, "a boolean spelling");
+
+            ConverterFailure.Report(
+                ref _loggedFailure, nameof(StringToBoolParseConverter), value, "a boolean spelling", "the fallback");
+            return _fallback;
+        }
+
+        [NonSerialized] private bool _loggedFailure;
     }
 }

--- a/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Runtime/Converters/Strings/StringToDateTimeConverter.cs
+++ b/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Runtime/Converters/Strings/StringToDateTimeConverter.cs
@@ -19,6 +19,10 @@ namespace Aspid.MVVM.StarterKit
         [Tooltip("The culture the text is read with.")]
         [SerializeField] private CultureInfoMode _culture = CultureInfoMode.CurrentCulture;
 
+        [Tooltip("What to do with text that does not parse. ReturnInput is not available here — the "
+            + "input is text and the output is not — and behaves as ReturnFallback.")]
+        [SerializeField] private ConverterFailureMode _onFailure = ConverterFailureMode.ReturnFallback;
+
         [Tooltip("Ticks of the date returned when the text is not one.")]
         [SerializeField] private long _fallbackTicks;
 
@@ -43,11 +47,28 @@ namespace Aspid.MVVM.StarterKit
             var culture = _culture.ToCultureInfo();
             var fallback = new DateTime(_fallbackTicks);
 
+            // Empty text is absence rather than a malformed date, so it takes the fallback quietly.
             if (string.IsNullOrWhiteSpace(value)) return fallback;
 
-            return string.IsNullOrWhiteSpace(_format)
-                ? DateTime.TryParse(value, culture, DateTimeStyles.None, out var any) ? any : fallback
-                : DateTime.TryParseExact(value, _format, culture, DateTimeStyles.None, out var exact) ? exact : fallback;
+            var parsed = string.IsNullOrWhiteSpace(_format)
+                ? DateTime.TryParse(value, culture, DateTimeStyles.None, out var any) ? any : (DateTime?)null
+                : DateTime.TryParseExact(value, _format, culture, DateTimeStyles.None, out var exact) ? exact : null;
+
+            return parsed ?? OnUnparsed(value, fallback);
         }
+
+        private DateTime OnUnparsed(string? value, DateTime fallback)
+        {
+            var expected = string.IsNullOrWhiteSpace(_format) ? "a date" : $"a date shaped \"{_format}\"";
+
+            if (_onFailure is ConverterFailureMode.Throw)
+                throw ConverterFailure.Rejected(nameof(StringToDateTimeConverter), value, expected);
+
+            ConverterFailure.Report(
+                ref _loggedFailure, nameof(StringToDateTimeConverter), value, expected, "the fallback date");
+            return fallback;
+        }
+
+        [NonSerialized] private bool _loggedFailure;
     }
 }

--- a/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Runtime/Converters/Strings/StringToEnumConverter.cs
+++ b/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Runtime/Converters/Strings/StringToEnumConverter.cs
@@ -18,6 +18,10 @@ namespace Aspid.MVVM.StarterKit
         [Tooltip("Match member names without regard to case.")]
         [SerializeField] private bool _ignoreCase = true;
 
+        [Tooltip("What to do with text that does not parse. ReturnInput is not available here — the "
+            + "input is text and the output is not — and behaves as ReturnFallback.")]
+        [SerializeField] private ConverterFailureMode _onFailure = ConverterFailureMode.ReturnFallback;
+
         [Tooltip("Returned when the text names no member.")]
         [SerializeField] private TEnum _fallback;
 
@@ -44,8 +48,25 @@ namespace Aspid.MVVM.StarterKit
             // rarely what a name-shaped input means.
             return Enum.TryParse<TEnum>(value, _ignoreCase, out var parsed) && Enum.IsDefined(typeof(TEnum), parsed)
                 ? parsed
-                : _fallback;
+                : OnUnparsed(value);
         }
+
+        private TEnum OnUnparsed(string? value)
+        {
+            if (_onFailure is ConverterFailureMode.Throw)
+                throw ConverterFailure.Rejected(
+                    nameof(StringToEnumConverter<TEnum>), value, $"a member of {typeof(TEnum).Name}");
+
+            ConverterFailure.Report(
+                ref _loggedFailure,
+                nameof(StringToEnumConverter<TEnum>),
+                value,
+                $"a member of {typeof(TEnum).Name}",
+                "the fallback");
+            return _fallback;
+        }
+
+        [NonSerialized] private bool _loggedFailure;
 
         /// <summary>
         /// Writes the specified member as text.

--- a/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Runtime/Converters/Strings/StringToFloatConverter.cs
+++ b/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Runtime/Converters/Strings/StringToFloatConverter.cs
@@ -20,6 +20,10 @@ namespace Aspid.MVVM.StarterKit
         [Tooltip("Returned when the text is not a number.")]
         [SerializeField] private float _fallback;
 
+        [Tooltip("What to do with text that does not parse. ReturnInput is not available here — the "
+            + "input is text and the output is not — and behaves as ReturnFallback.")]
+        [SerializeField] private ConverterFailureMode _onFailure = ConverterFailureMode.ReturnFallback;
+
         [Tooltip("Hold the result inside the bounds below.")]
         [SerializeField] private bool _clamp;
 
@@ -50,12 +54,26 @@ namespace Aspid.MVVM.StarterKit
         /// <returns>The number, or the fallback when the text is not one.</returns>
         public float Convert(string? value)
         {
+            // Blank text is an unfilled field, not a malformed number. Reporting it would fire on
+            // every scene with an empty input, which is the noise that gets error logs ignored.
+            if (string.IsNullOrWhiteSpace(value)) return _fallback;
+
             const NumberStyles styles = NumberStyles.Float | NumberStyles.AllowThousands;
 
             if (!float.TryParse(value, styles, _culture.ToCultureInfo(), out var parsed))
-                return _fallback;
+                return OnUnparsed(value);
 
             return _clamp ? Mathf.Clamp(parsed, _min, _max) : parsed;
+        }
+
+        private float OnUnparsed(string? value)
+        {
+            if (_onFailure is ConverterFailureMode.Throw)
+                throw ConverterFailure.Rejected(nameof(StringToFloatConverter), value, "a decimal number");
+
+            ConverterFailure.Report(
+                ref _loggedFailure, nameof(StringToFloatConverter), value, "a decimal number", "the fallback");
+            return _fallback;
         }
 
         /// <summary>
@@ -64,5 +82,7 @@ namespace Aspid.MVVM.StarterKit
         /// <param name="value">The number to write.</param>
         /// <returns>The text.</returns>
         public string ConvertBack(float value) => value.ToString(_culture.ToCultureInfo());
+
+        [NonSerialized] private bool _loggedFailure;
     }
 }

--- a/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Runtime/Converters/Strings/StringToIntConverter.cs
+++ b/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Runtime/Converters/Strings/StringToIntConverter.cs
@@ -21,6 +21,10 @@ namespace Aspid.MVVM.StarterKit
         [Tooltip("Returned when the text is not a number.")]
         [SerializeField] private int _fallback;
 
+        [Tooltip("What to do with text that does not parse. ReturnInput is not available here — the "
+            + "input is text and the output is not — and behaves as ReturnFallback.")]
+        [SerializeField] private ConverterFailureMode _onFailure = ConverterFailureMode.ReturnFallback;
+
         [Tooltip("Hold the result inside the bounds below.")]
         [SerializeField] private bool _clamp;
 
@@ -51,10 +55,24 @@ namespace Aspid.MVVM.StarterKit
         /// <returns>The number, or the fallback when the text is not one.</returns>
         public int Convert(string? value)
         {
+            // Blank text is an unfilled field, not a malformed number. Reporting it would fire on
+            // every scene with an empty input, which is the noise that gets error logs ignored.
+            if (string.IsNullOrWhiteSpace(value)) return _fallback;
+
             if (!int.TryParse(value, NumberStyles.Integer, _culture.ToCultureInfo(), out var parsed))
-                return _fallback;
+                return OnUnparsed(value);
 
             return _clamp ? Math.Clamp(parsed, _min, _max) : parsed;
+        }
+
+        private int OnUnparsed(string? value)
+        {
+            if (_onFailure is ConverterFailureMode.Throw)
+                throw ConverterFailure.Rejected(nameof(StringToIntConverter), value, "a whole number");
+
+            ConverterFailure.Report(
+                ref _loggedFailure, nameof(StringToIntConverter), value, "a whole number", "the fallback");
+            return _fallback;
         }
 
         /// <summary>
@@ -63,5 +81,7 @@ namespace Aspid.MVVM.StarterKit
         /// <param name="value">The number to write.</param>
         /// <returns>The text.</returns>
         public string ConvertBack(int value) => value.ToString(_culture.ToCultureInfo());
+
+        [NonSerialized] private bool _loggedFailure;
     }
 }

--- a/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Runtime/Converters/Strings/StringToLongConverter.cs
+++ b/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Runtime/Converters/Strings/StringToLongConverter.cs
@@ -17,6 +17,10 @@ namespace Aspid.MVVM.StarterKit
         [Tooltip("Returned when the text is not a number.")]
         [SerializeField] private long _fallback;
 
+        [Tooltip("What to do with text that does not parse. ReturnInput is not available here — the "
+            + "input is text and the output is not — and behaves as ReturnFallback.")]
+        [SerializeField] private ConverterFailureMode _onFailure = ConverterFailureMode.ReturnFallback;
+
         [Tooltip("The culture the text is read with.")]
         [SerializeField] private CultureInfoMode _culture = CultureInfoMode.CurrentCulture;
 
@@ -34,8 +38,26 @@ namespace Aspid.MVVM.StarterKit
         /// </summary>
         /// <param name="value">The text to read.</param>
         /// <returns>The number, or the fallback when the text is not one.</returns>
-        public long Convert(string? value) =>
-            long.TryParse(value, NumberStyles.Integer, _culture.ToCultureInfo(), out var parsed) ? parsed : _fallback;
+        public long Convert(string? value)
+        {
+            // Blank text is an unfilled field, not a malformed number. Reporting it would fire on
+            // every scene with an empty input, which is the noise that gets error logs ignored.
+            if (string.IsNullOrWhiteSpace(value)) return _fallback;
+
+            return long.TryParse(value, NumberStyles.Integer, _culture.ToCultureInfo(), out var parsed)
+                ? parsed
+                : OnUnparsed(value);
+        }
+
+        private long OnUnparsed(string? value)
+        {
+            if (_onFailure is ConverterFailureMode.Throw)
+                throw ConverterFailure.Rejected(nameof(StringToLongConverter), value, "a whole number");
+
+            ConverterFailure.Report(
+                ref _loggedFailure, nameof(StringToLongConverter), value, "a whole number", "the fallback");
+            return _fallback;
+        }
 
         /// <summary>
         /// Writes the specified number as text.
@@ -43,5 +65,7 @@ namespace Aspid.MVVM.StarterKit
         /// <param name="value">The number to write.</param>
         /// <returns>The text.</returns>
         public string ConvertBack(long value) => value.ToString(_culture.ToCultureInfo());
+
+        [NonSerialized] private bool _loggedFailure;
     }
 }

--- a/Aspid.MVVM/Packages/tech.aspid.mvvm/Tests/Editor/Converters/ConverterFailureModeTests.cs
+++ b/Aspid.MVVM/Packages/tech.aspid.mvvm/Tests/Editor/Converters/ConverterFailureModeTests.cs
@@ -11,14 +11,11 @@ namespace Aspid.MVVM.StarterKit.Tests
     /// The parse converters answer a value they cannot read according to <see cref="ConverterFailureMode"/>.
     /// </summary>
     /// <remarks>
-    /// Before this, every one of them returned its fallback in silence. A fallback of zero is
-    /// indistinguishable from text that legitimately read as zero, so a mistyped field in a save file
-    /// or a locale mismatch presented as a value rather than as a problem — the failure mode that
-    /// costs the most time to find.
+    /// A fallback of zero is indistinguishable from text that legitimately read as zero, so a mistyped
+    /// field or a locale mismatch used to present as a value rather than as a problem.
     /// <para>
-    /// Only the parse family took the mode. A converter whose fallback is its purpose —
-    /// <c>NullCoalesceConverter</c>, <c>DefaultStringConverter</c>, the threshold converters — has no
-    /// failure to report, and giving it a failure mode would have been vocabulary for its own sake.
+    /// Only the parse family took the mode: a converter whose fallback is its purpose has no failure to
+    /// report.
     /// </para>
     /// </remarks>
     [TestFixture]

--- a/Aspid.MVVM/Packages/tech.aspid.mvvm/Tests/Editor/Converters/ConverterFailureModeTests.cs
+++ b/Aspid.MVVM/Packages/tech.aspid.mvvm/Tests/Editor/Converters/ConverterFailureModeTests.cs
@@ -1,0 +1,114 @@
+using System;
+using NUnit.Framework;
+using System.Reflection;
+using UnityEngine;
+using UnityEngine.TestTools;
+using System.Text.RegularExpressions;
+
+namespace Aspid.MVVM.StarterKit.Tests
+{
+    /// <summary>
+    /// The parse converters answer a value they cannot read according to <see cref="ConverterFailureMode"/>.
+    /// </summary>
+    /// <remarks>
+    /// Before this, every one of them returned its fallback in silence. A fallback of zero is
+    /// indistinguishable from text that legitimately read as zero, so a mistyped field in a save file
+    /// or a locale mismatch presented as a value rather than as a problem — the failure mode that
+    /// costs the most time to find.
+    /// <para>
+    /// Only the parse family took the mode. A converter whose fallback is its purpose —
+    /// <c>NullCoalesceConverter</c>, <c>DefaultStringConverter</c>, the threshold converters — has no
+    /// failure to report, and giving it a failure mode would have been vocabulary for its own sake.
+    /// </para>
+    /// </remarks>
+    [TestFixture]
+    internal sealed class ConverterFailureModeTests
+    {
+        [Test]
+        public void StringToInt_Unparsed_ReturnsFallbackAndReportsOnce()
+        {
+            var converter = new StringToIntConverter(fallback: -1);
+            LogAssert.Expect(LogType.Error, new Regex("StringToIntConverter.*a whole number"));
+
+            Assert.AreEqual(-1, converter.Convert("not a number"));
+            // The second failure must not log: a binder pushes on every notification, and
+            // Debug.LogError captures a stack trace.
+            Assert.AreEqual(-1, converter.Convert("still not a number"));
+        }
+
+        [Test]
+        public void StringToInt_Throw_RaisesFormatException()
+        {
+            var converter = new StringToIntConverter(fallback: 0);
+            SetFailureMode(converter, ConverterFailureMode.Throw);
+
+            Assert.Throws<FormatException>(() => converter.Convert("nope"));
+        }
+
+        [Test]
+        public void StringToFloat_Unparsed_ReturnsFallbackAndReports()
+        {
+            var converter = new StringToFloatConverter(fallback: 2.5f);
+            LogAssert.Expect(LogType.Error, new Regex("StringToFloatConverter.*a decimal number"));
+
+            Assert.AreEqual(2.5f, converter.Convert("abc"));
+        }
+
+        [Test]
+        public void StringToEnum_Unparsed_ReturnsFallbackAndNamesTheEnum()
+        {
+            var converter = new StringToEnumConverter<Comparisons>(Comparisons.Equal);
+            LogAssert.Expect(LogType.Error, new Regex("StringToEnumConverter.*Comparisons"));
+
+            Assert.AreEqual(Comparisons.Equal, converter.Convert("NotAMember"));
+        }
+
+        [Test]
+        public void StringToDateTime_Unparsed_ReturnsFallbackAndReports()
+        {
+            var fallback = new DateTime(2000, 1, 1);
+            var converter = new StringToDateTimeConverter(format: string.Empty, fallback);
+            LogAssert.Expect(LogType.Error, new Regex("StringToDateTimeConverter.*a date"));
+
+            Assert.AreEqual(fallback, converter.Convert("not a date"));
+        }
+
+        // Empty text means the field was left blank, which is absence rather than a malformed value.
+        // Reporting it would fire on every scene that has an unfilled input.
+        [Test]
+        public void StringToDateTime_Empty_TakesTheFallbackQuietly()
+        {
+            var fallback = new DateTime(2000, 1, 1);
+            Assert.AreEqual(fallback, new StringToDateTimeConverter(format: string.Empty, fallback).Convert(""));
+        }
+
+        [Test]
+        public void StringToBoolParse_WithNoFalseSpellings_TreatsAnythingUnmatchedAsFalse()
+        {
+            // Nothing to report: without a false list, "not true" is the definition of false.
+            Assert.IsFalse(new StringToBoolParseConverter(new[] { "yes" }).Convert("banana"));
+        }
+
+        [Test]
+        public void StringToBoolParse_WithFalseSpellings_ReportsTextMatchingNeither()
+        {
+            var converter = new StringToBoolParseConverter(new[] { "yes" });
+            SetField(converter, "_falseTokens", new[] { "no" });
+            LogAssert.Expect(LogType.Error, new Regex("StringToBoolParseConverter.*a boolean spelling"));
+
+            Assert.IsFalse(converter.Convert("banana"));
+            Assert.IsTrue(converter.Convert("yes"), "a matching spelling still reads normally");
+            Assert.IsFalse(converter.Convert("no"));
+        }
+
+        private static void SetFailureMode(object converter, ConverterFailureMode mode) =>
+            SetField(converter, "_onFailure", mode);
+
+        private static void SetField(object target, string name, object value)
+        {
+            var field = target.GetType().GetField(name, BindingFlags.Instance | BindingFlags.NonPublic);
+            Assert.IsNotNull(field, $"{target.GetType().Name} has no field {name}");
+            field!.SetValue(target, value);
+        }
+    }
+}

--- a/Aspid.MVVM/Packages/tech.aspid.mvvm/Tests/Editor/Converters/ConverterFailureModeTests.cs.meta
+++ b/Aspid.MVVM/Packages/tech.aspid.mvvm/Tests/Editor/Converters/ConverterFailureModeTests.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 4b98b9554968f4b059d17f964afcdd37

--- a/Aspid.MVVM/Packages/tech.aspid.mvvm/Tests/Editor/Converters/Strings/ParseConverterTests.cs
+++ b/Aspid.MVVM/Packages/tech.aspid.mvvm/Tests/Editor/Converters/Strings/ParseConverterTests.cs
@@ -1,7 +1,10 @@
 using System;
+using UnityEngine;
 using System.Threading;
 using NUnit.Framework;
 using System.Globalization;
+using UnityEngine.TestTools;
+using System.Text.RegularExpressions;
 
 namespace Aspid.MVVM.StarterKit.Tests
 {
@@ -29,18 +32,29 @@ namespace Aspid.MVVM.StarterKit.Tests
         public void RestoreCulture() =>
             Thread.CurrentThread.CurrentCulture = _previous;
 
+        // Blank text is an unfilled field rather than a malformed number, so it takes the fallback
+        // without a word; text that is present but unreadable is reported.
         [TestCase("42", 42)]
         [TestCase("-7", -7)]
         [TestCase("", 0)]
         [TestCase(null, 0)]
-        [TestCase("abc", 0)]
-        [TestCase("1.5", 0)]
-        public void StringToInt_ReadsOrFallsBack(string value, int expected) =>
+        public void StringToInt_ReadsOrFallsBackQuietly(string value, int expected) =>
             Assert.AreEqual(expected, new StringToIntConverter().Convert(value));
 
+        [TestCase("abc", 0)]
+        [TestCase("1.5", 0)]
+        public void StringToInt_UnreadableTextFallsBackAndReports(string value, int expected)
+        {
+            LogAssert.Expect(LogType.Error, new Regex("StringToIntConverter"));
+            Assert.AreEqual(expected, new StringToIntConverter().Convert(value));
+        }
+
         [Test]
-        public void StringToInt_UsesTheAuthoredFallback() =>
+        public void StringToInt_UsesTheAuthoredFallback()
+        {
+            LogAssert.Expect(LogType.Error, new Regex("StringToIntConverter"));
             Assert.AreEqual(-1, new StringToIntConverter(-1).Convert("nonsense"));
+        }
 
         [Test]
         public void StringToInt_RoundTrips()
@@ -56,9 +70,15 @@ namespace Aspid.MVVM.StarterKit.Tests
 
         [TestCase("1.5", 1.5f)]
         [TestCase("-0.25", -0.25f)]
-        [TestCase("abc", 0f)]
         public void StringToFloat_ReadsOrFallsBack(string value, float expected) =>
             Assert.AreEqual(expected, new StringToFloatConverter().Convert(value), 1e-5f);
+
+        [Test]
+        public void StringToFloat_UnreadableTextFallsBackAndReports()
+        {
+            LogAssert.Expect(LogType.Error, new Regex("StringToFloatConverter"));
+            Assert.AreEqual(0f, new StringToFloatConverter().Convert("abc"));
+        }
 
         // A German player typing "1,5" means one and a half; reading it as invariant gives fifteen
         // or nothing at all.
@@ -97,16 +117,25 @@ namespace Aspid.MVVM.StarterKit.Tests
 
         [TestCase("Rain", Weather.Rain)]
         [TestCase("rain", Weather.Rain)]
-        [TestCase("nonsense", Weather.Clear)]
         [TestCase("", Weather.Clear)]
         public void StringToEnum_ReadsTheMember(string value, Weather expected) =>
             Assert.AreEqual(expected, new StringToEnumConverter<Weather>(Weather.Clear).Convert(value));
 
+        [Test]
+        public void StringToEnum_UnknownNameFallsBackAndReports()
+        {
+            LogAssert.Expect(LogType.Error, new Regex("StringToEnumConverter"));
+            Assert.AreEqual(Weather.Clear, new StringToEnumConverter<Weather>(Weather.Clear).Convert("nonsense"));
+        }
+
         // Enum.TryParse accepts a bare number and hands back an undeclared member for it, which is
         // rarely what a name-shaped input means.
         [Test]
-        public void StringToEnum_RejectsANumberThatNamesNoMember() =>
+        public void StringToEnum_RejectsANumberThatNamesNoMember()
+        {
+            LogAssert.Expect(LogType.Error, new Regex("StringToEnumConverter"));
             Assert.AreEqual(Weather.Clear, new StringToEnumConverter<Weather>(Weather.Clear).Convert("99"));
+        }
 
         [Test]
         public void StringToEnum_RoundTrips()
@@ -126,6 +155,7 @@ namespace Aspid.MVVM.StarterKit.Tests
         public void StringToDateTime_WrongFormatGivesTheFallback()
         {
             var fallback = new DateTime(2000, 1, 1);
+            LogAssert.Expect(LogType.Error, new Regex("StringToDateTimeConverter"));
 
             Assert.AreEqual(
                 fallback,


### PR DESCRIPTION
✨ `ConverterFailureMode` shipped as a vocabulary exactly one converter spoke. Now the parse family speaks it.

## Summary

- ✨ **`StringToInt` / `Long` / `Float` / `BoolParse` / `Enum` / `DateTime` take `_onFailure`** (`ReturnFallback` / `Throw`) and report through one shared reporter with a log-once rule.
- ✨ **`StringToBoolParseConverter` gains an opt-in `_falseTokens` list** — configure false spellings and text matching neither list becomes a real failure.
- 📝 Why it matters: a fallback of zero is indistinguishable from text that legitimately read as zero, so a bad save file or a locale mismatch used to present as a value rather than a problem.

## Notes for review

- ⚠️ Blank or null text still falls back silently — absence is not a malformed value, and the existing tests caught the first cut that logged on it.
- ⚠️ `NullCoalesce`, `DefaultString` and the threshold converters get no mode: their fallback *is* the feature.
- ✅ Nine pre-existing tests were split into "falls back quietly" and "falls back and reports" rather than blanket-updated; 1056 EditMode tests, 1054 passed, 0 failed, 2 skipped (batch mode).

<details>
<summary>🇷🇺 Описание на русском</summary>

✨ `ConverterFailureMode` уехал как словарь, на котором говорил ровно один конвертер. Теперь на нём говорит всё parse-семейство.

## Итог

- ✨ **`StringToInt` / `Long` / `Float` / `BoolParse` / `Enum` / `DateTime` получили `_onFailure`** (`ReturnFallback` / `Throw`) и сообщают через один общий репортер с правилом «логировать однократно».
- ✨ **У `StringToBoolParseConverter` появился опциональный список `_falseTokens`** — настроишь «ложные» написания, и текст, не совпавший ни с одним списком, становится настоящим сбоем.
- 📝 Зачем: fallback, равный нулю, неотличим от текста, который законно прочитался как ноль, поэтому битый сейв или несовпадение локали выглядели значением, а не проблемой.

## Заметки для ревью

- ⚠️ Пустой и null-текст по-прежнему берут fallback молча — отсутствие не мусор, и первую версию, которая на них логировала, поймали существующие тесты.
- ⚠️ `NullCoalesce`, `DefaultString` и threshold-конвертеры остаются без режима: их fallback — это и есть функция.
- ✅ Девять существующих тестов разделены на «молча берёт fallback» и «берёт fallback и сообщает», а не обновлены оптом; 1056 EditMode-тестов, 1054 прошло, 0 упало, 2 пропущено (batch mode).

</details>

