### PR TITLE
Build the colour, vector, collection and parsing catalogue

### DIFF
--- a/Aspid.MVVM/Packages/tech.aspid.mvvm/Documentation/08-converters.md
+++ b/Aspid.MVVM/Packages/tech.aspid.mvvm/Documentation/08-converters.md
@@ -92,7 +92,7 @@ public interface ITwoWayConverter<TFrom, TTo> : IConverter<TFrom, TTo>
 
 ## Каталог
 
-В пакете 163 конвертера. В Inspector они разложены по группам — группа видна в выпадающем списке
+В пакете 210 конвертеров. В Inspector они разложены по группам — группа видна в выпадающем списке
 поля `Converter`.
 
 ### Aspid/Bool (8)
@@ -101,12 +101,9 @@ public interface ITwoWayConverter<TFrom, TTo> : IConverter<TFrom, TTo>
 `ObjectNullToBoolConverter`, `StringEmptyToBoolConverter`, `StringMatchToBoolConverter`,
 `UnityObjectNullToBoolConverter`
 
-`UnityObjectNullToBoolConverter` — не то же самое, что `ObjectNullToBoolConverter`: он использует
-перегруженный `==` Unity и потому видит уничтоженный объект, для которого `is null` вернёт `false`.
-
-`StringEmptyToBoolConverter` полем `StringEmptiness` выбирает, что считать отсутствующей строкой:
-`NullOrEmpty` (по умолчанию), `Null` — пустая строка считается заполненной, `NullOrWhiteSpace` —
-строка из пробелов считается пустой. Последнее и означает «пользователь что-нибудь ввёл?».
+> `StringEmptyToBoolConverter` полем `StringEmptiness` выбирает, что считать отсутствующей строкой:
+> `NullOrEmpty` (по умолчанию), `Null` — пустая строка считается заполненной, `NullOrWhiteSpace` —
+> строка из пробелов считается пустой. Последнее и означает «пользователь что-нибудь ввёл?».
 
 ### Aspid/Number (21)
 
@@ -115,37 +112,36 @@ public interface ITwoWayConverter<TFrom, TTo> : IConverter<TFrom, TTo>
 `EasingConverter`, `InverseLerpConverter`, `LerpNumberConverter`, `ModuloNumberConverter`,
 `NormalizedToPercentConverter`, `NumericCastConverter`, `PercentToNormalizedConverter`,
 `PowerNumberConverter`, `RemapNumberConverter`, `RoundNumberConverter`, `SmoothStepConverter`,
-`SnapToStepConverter`, `SumConstantThenScaleConverter`, `UnaryMathConverter`, `WrapNumberConverter`
+`SnapToStepConverter`, `SumConstantThenScaleConverter`, `UnaryMathConverter`,
+`WrapNumberConverter`
 
 > `NumericCastConverter` — единственный способ сузить число управляемо. Без него `long.MaxValue`,
 > попавший в int-биндер, молча уходит в отрицательное; `OverflowMode.Saturate` прижимает к границе,
 > `Checked` бросает.
 
-### Aspid/String (41)
+### Aspid/String (46)
 
-Форматирование чисел: `AbbreviatedNumberConverter` (`1234` → `1.2K`), `ByteSizeConverter`,
-`CurrencyConverter`, `DecimalFormatConverter`, `NumberFormatConverter`, `OrdinalConverter`
-(`3` → `3rd`), `PaddedNumberConverter`, `PercentStringConverter`, `RatioToStringConverter`,
-`RomanNumeralConverter`, `SignedNumberStringConverter`, `ThousandsSeparatorConverter`.
+`AbbreviatedNumberConverter`, `ByteSizeConverter`, `ConcatStringConverter`, `CurrencyConverter`,
+`DecimalFormatConverter`, `DefaultStringConverter`, `GenericToString`, `MaskStringConverter`,
+`NumberFormatConverter`, `ObjectToStringConverter`, `OrdinalConverter`, `PadStringConverter`,
+`PaddedNumberConverter`, `PercentStringConverter`, `PluralizeConverter`,
+`RatioToStringConverter`, `RepeatStringConverter`, `ReplaceStringConverter`,
+`ReverseStringConverter`, `RichTextColorConverter`, `RichTextNoParseConverter`,
+`RichTextSizeConverter`, `RichTextStyleConverter`, `RomanNumeralConverter`,
+`SanitizeRichTextConverter`, `SignedNumberStringConverter`, `SplitJoinStringConverter`,
+`StringFormatConverter`, `StringToBoolParseConverter`, `StringToDateTimeConverter`,
+`StringToDecimalConverter`, `StringToDoubleConverter`, `StringToEnumConverter`,
+`StringToFloatConverter`, `StringToIntConverter`, `StringToLongConverter`,
+`StringToTimeSpanConverter`, `StringToVector2Converter`, `StringToVector3Converter`,
+`SubstringConverter`, `TextCaseConverter`, `ThousandsSeparatorConverter`,
+`ThresholdRichTextColorConverter`, `TimeSpanToStringConverter`, `TrimStringConverter`,
+`TruncateStringConverter`
 
-Манипуляции со строкой: `ConcatStringConverter`, `DefaultStringConverter`, `MaskStringConverter`,
-`PadStringConverter`, `PluralizeConverter`, `RepeatStringConverter`, `ReplaceStringConverter`,
-`ReverseStringConverter`, `SplitJoinStringConverter`, `SubstringConverter`, `TextCaseConverter`,
-`TrimStringConverter`, `TruncateStringConverter`.
-
-Rich text (TextMeshPro): `RichTextColorConverter`, `RichTextNoParseConverter`,
-`RichTextSizeConverter`, `RichTextStyleConverter`, `SanitizeRichTextConverter`,
-`ThresholdRichTextColorConverter`.
-
-> `RichTextNoParseConverter` — для любого текста, который ввёл игрок. TMP исполняет разметку в любой
-> строке, которую получает: ник `<size=400%>` растянет каждый ярлык, где он покажется, на экране
-> каждого другого игрока.
-
-Разбор строки: `StringToBoolParseConverter`, `StringToDateTimeConverter`, `StringToEnumConverter`,
-`StringToFloatConverter`, `StringToIntConverter`, `StringToLongConverter`.
-
-Общее: `GenericToString`, `ObjectToStringConverter`, `StringFormatConverter`,
-`TimeSpanToStringConverter`.
+> Для любого текста, который ввёл игрок, нужен `SanitizeRichTextConverter` или
+> `RichTextNoParseConverter`. TMP исполняет разметку в любой строке, которую получает: ник
+> `<size=400%>` растянет каждый ярлык, где он покажется, на экране каждого другого игрока.
+> `RichTextNoParse` заворачивает всё в `<noparse>`; `SanitizeRichText` вырезает или экранирует теги
+> выборочно, оставляя белый список.
 
 ### Aspid/Time (12)
 
@@ -154,46 +150,62 @@ Rich text (TextMeshPro): `RichTextColorConverter`, `RichTextNoParseConverter`,
 `SecondsToTimeStringConverter`, `TimeSpanArithmeticConverter`, `TimeSpanFormatConverter`,
 `TimeSpanToNumberConverter`, `TimeUntilConverter`, `UnixTimestampToDateTimeConverter`
 
-### Aspid/Colour (14)
+### Aspid/Colour (21)
 
-`ColorAlphaConverter`, `ColorBlockAlphaConverter`, `ColorBlockFadeDurationConverter`,
-`ColorBlockTintConverter`, `ColorGrayscaleConverter`, `ColorHsvConverter`, `ColorLerpConverter`,
-`ColorTintConverter`, `ColorToColorBlockConverter`, `ColorToHtmlStringConverter`,
-`GradientEvaluateConverter`, `HashToColorConverter`, `ParseHtmlStringConverter`,
-`ThresholdColorConverter`
+`Color32ToColorConverter`, `ColorAlphaConverter`, `ColorBlockAlphaConverter`,
+`ColorBlockFadeDurationConverter`, `ColorBlockStateConverter`, `ColorBlockTintConverter`,
+`ColorChannelConverter`, `ColorGrayscaleConverter`, `ColorHsvConverter`, `ColorLerpConverter`,
+`ColorTintConverter`, `ColorToColor32Converter`, `ColorToColorBlockConverter`,
+`ColorToHtmlStringConverter`, `ColorToVector4Converter`, `GradientEvaluateConverter`,
+`HashToColorConverter`, `HdrIntensityConverter`, `ParseHtmlStringConverter`,
+`ThresholdColorConverter`, `Vector4ToColorConverter`
 
-### Aspid/Vector (23)
+### Aspid/Vector (43)
 
-Арифметика и форма: `FloatToVector2Converter`, `FloatToVector3Converter`,
-`Vector2SubstitutionConverter`, `Vector2ToVector2IntConverter`, `Vector2ToVector3Converter`,
-`Vector3ArithmeticConverter`, `Vector3SubstitutionConverter`, `Vector3ToFloatConverter`,
-`Vector3ToVector2Converter`, `Vector3ToVector3IntConverter`, `VectorClampMagnitudeConverter`,
-`VectorLerpConverter`, `VectorNormalizeConverter`, `VectorRoundConverter`.
-
-Комбинирование со сценой — берут часть компонент у привязанного вектора, часть у компонента сцены:
-`Vector2CombineConverter`, `BoxColliderCentreCombineConverter`, `BoxColliderSizeCombineConverter`,
-`CapsuleColliderCentreCombineConverter`, `RectTransformAnchoredPositionCombineConverter`,
+`BoundsCenterConverter`, `BoundsSizeConverter`, `BoundsToRectConverter`,
+`BoxCollider2DOffsetCombineConverter`, `BoxCollider2DSizeCombineConverter`,
+`BoxColliderCentreCombineConverter`, `BoxColliderSizeCombineConverter`,
+`CapsuleColliderCentreCombineConverter`, `FloatToVector2Converter`, `FloatToVector3Converter`,
+`RectToVector4Converter`, `RectTransformAnchoredPosition2DCombineConverter`,
+`RectTransformAnchoredPositionCombineConverter`, `RectTransformSizeDeltaCombineConverter`,
 `SphereColliderCentreCombineConverter`, `TransformEulerAnglesCombineConverter`,
-`TransformPositionCombineConverter`, `TransformScaleCombineConverter`.
+`TransformPosition2DCombineConverter`, `TransformPositionCombineConverter`,
+`TransformScaleCombineConverter`, `Vector2ArithmeticConverter`,
+`Vector2ClampComponentsConverter`, `Vector2ClampMagnitudeConverter`,
+`Vector2NormalizeConverter`, `Vector2RoundConverter`, `Vector2SubstitutionConverter`,
+`Vector2ToFloatConverter`, `Vector2ToVector2IntConverter`, `Vector2ToVector3Converter`,
+`Vector3ArithmeticConverter`, `Vector3SubstitutionConverter`, `Vector3ToFloatConverter`,
+`Vector3ToVector2Converter`, `Vector3ToVector3IntConverter`, `Vector3ToVector4Converter`,
+`Vector4SwizzleConverter`, `Vector4ToRectConverter`, `Vector4ToVector3Converter`,
+`VectorClampComponentsConverter`, `VectorClampMagnitudeConverter`, `VectorDistanceConverter`,
+`VectorLerpConverter`, `VectorNormalizeConverter`, `VectorRoundConverter`
 
-### Aspid/Rotation (9)
+> Конвертеры `*CombineConverter` берут часть компонент у привязанного вектора, часть — у компонента
+> сцены (`Transform`, `RectTransform`, коллайдер). Пары `*2D*` — для двумерных коллайдеров и
+> `Vector2`-свойств.
 
-`AngleToDirectionConverter`, `AngleToQuaternionConverter`, `AngleWrapConverter`,
-`DegreesToRadiansConverter`, `DirectionToAngleConverter`, `EulerToQuaternionConverter`,
-`LookRotationConverter`, `QuaternionOffsetConverter`, `QuaternionToEulerConverter`
+### Aspid/Rotation (15)
 
-### Aspid/Collection (6)
+`AngleDifferenceConverter`, `AngleToDirectionConverter`, `AngleToQuaternionConverter`,
+`AngleWrapConverter`, `DegreesToRadiansConverter`, `DirectionToAngleConverter`,
+`EulerToQuaternionConverter`, `LookRotationConverter`, `QuaternionOffsetConverter`,
+`QuaternionSlerpConverter`, `QuaternionToAngleConverter`, `QuaternionToEulerConverter`,
+`QuaternionToVector4Converter`, `RadiansToDegreesConverter`, `Vector4ToQuaternionConverter`
+
+### Aspid/Collection (11)
 
 `CollectionAggregateConverter`, `CollectionContainsToBoolConverter`, `CollectionCountConverter`,
-`CollectionElementAtConverter`, `CollectionEmptyToBoolConverter`, `ListToStringConverter`
+`CollectionCountToStringConverter`, `CollectionElementAtConverter`,
+`CollectionEmptyToBoolConverter`, `CollectionFirstConverter`, `CollectionLastConverter`,
+`CollectionTakeConverter`, `DictionaryLookupConverter`, `ListToStringConverter`
 
 ### Остальные группы
 
 | Группа | Конвертеры |
 |--------|-----------|
-| `Aspid/Enum` (6) | `EnumToBoolConverter`, `EnumToDropdownOptionDataConverter`, `EnumToIntConverter`, `EnumToStringConverter`, `EnumToValueConverter`, `IntToEnumConverter` |
+| `Aspid/Enum` (8) | `EnumFlagsToStringConverter`, `EnumMaskConverter`, `EnumToBoolConverter`, `EnumToDropdownOptionDataConverter`, `EnumToIntConverter`, `EnumToStringConverter`, `EnumToValueConverter`, `IntToEnumConverter` |
 | `Aspid/Object` (3) | `EqualityToBoolConverter`, `IndexToValueConverter`, `NullCoalesceConverter` |
-| `Aspid/Texture` (4) | `NormalizedToSpriteConverter`, `ObjectNameConverter`, `SpriteToTextureConverter`, `Texture2DToSpriteConverter` |
+| `Aspid/Texture` (6) | `NormalizedToSpriteConverter`, `ObjectNameConverter`, `SpriteToTextureConverter`, `StringToSpriteConverter`, `Texture2DToSpriteConverter`, `TextureToSpriteRectConverter` |
 | `Aspid/Layout` (3) | `IntToRectOffsetConverter`, `RectOffsetScaleConverter`, `Vector4ToRectOffsetConverter` |
 | `Aspid/Localization` (4) | `LocaleToStringConverter`, `LocalizedEnumConverter`, `LocalizedNumberConverter`, `LocalizedStringConverter` |
 | `Aspid/Asset` (2) | `ConverterAssetReference`, `MaterialInstanceConverter` |

--- a/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Runtime/Converters/Collections/CollectionCountToStringConverter.cs
+++ b/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Runtime/Converters/Collections/CollectionCountToStringConverter.cs
@@ -12,21 +12,14 @@ namespace Aspid.MVVM.StarterKit
     /// </summary>
     /// <typeparam name="T">The type of the items.</typeparam>
     /// <remarks>
-    /// "3 items" under a list, and "Empty" when there is nothing in it — the caption every inventory,
-    /// party roster and mailbox needs, which otherwise lives as a formatted string property on the
-    /// ViewModel.
+    /// The two shipped halves do not compose into this: chaining
+    /// <see cref="CollectionCountConverter{T}"/> into <see cref="PluralizeConverter"/> puts the count in
+    /// front of whichever form it picked, so a zero form reads "0 Empty". The empty caption has to be a
+    /// phrase of its own.
     /// <para>
-    /// The two shipped halves do not compose into this. Chaining
-    /// <see cref="CollectionCountConverter{T}"/> into <see cref="PluralizeConverter"/> puts the count
-    /// in front of whichever form it picked, so a zero form reads "0 Empty"; clearing that format to
-    /// fix the zero case then drops the number from every other count. The empty caption has to be a
-    /// phrase of its own rather than a word the count is prepended to.
-    /// </para>
-    /// <para>
-    /// The last phrase is kept and returned again while the count is unchanged, because a binder
-    /// pushes on every notification rather than on every change and <c>string.Format</c> allocates a
-    /// string on each one. A field edited in the Inspector during play therefore shows up on the next
-    /// count change rather than immediately.
+    /// The last phrase is returned again while the count is unchanged, because a binder pushes on every
+    /// notification and <c>string.Format</c> allocates on each — so a field edited in the Inspector during
+    /// play shows up on the next count change rather than immediately.
     /// </para>
     /// </remarks>
     [Serializable]

--- a/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Runtime/Converters/Collections/CollectionCountToStringConverter.cs
+++ b/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Runtime/Converters/Collections/CollectionCountToStringConverter.cs
@@ -1,0 +1,149 @@
+#nullable enable
+using Aspid.FastTools.Types;
+using System;
+using UnityEngine;
+using System.Collections.Generic;
+
+// ReSharper disable once CheckNamespace
+namespace Aspid.MVVM.StarterKit
+{
+    /// <summary>
+    /// Writes how many items a collection holds, in words.
+    /// </summary>
+    /// <typeparam name="T">The type of the items.</typeparam>
+    /// <remarks>
+    /// "3 items" under a list, and "Empty" when there is nothing in it — the caption every inventory,
+    /// party roster and mailbox needs, which otherwise lives as a formatted string property on the
+    /// ViewModel.
+    /// <para>
+    /// The two shipped halves do not compose into this. Chaining
+    /// <see cref="CollectionCountConverter{T}"/> into <see cref="PluralizeConverter"/> puts the count
+    /// in front of whichever form it picked, so a zero form reads "0 Empty"; clearing that format to
+    /// fix the zero case then drops the number from every other count. The empty caption has to be a
+    /// phrase of its own rather than a word the count is prepended to.
+    /// </para>
+    /// <para>
+    /// The last phrase is kept and returned again while the count is unchanged, because a binder
+    /// pushes on every notification rather than on every change and <c>string.Format</c> allocates a
+    /// string on each one. A field edited in the Inspector during play therefore shows up on the next
+    /// count change rather than immediately.
+    /// </para>
+    /// </remarks>
+    [Serializable]
+    [TypeSelectorDisplay(Group = "Aspid/Collection", Name = "Collection Count To String", Tooltip = "Writes how many items a collection holds, in words")]
+    public sealed class CollectionCountToStringConverter<T> : IConverter<IReadOnlyCollection<T>?, string>
+    {
+        [Tooltip("Which grammar to follow when picking the word form.")]
+        [SerializeField] private PluralRule _rule = PluralRule.English;
+
+        [Tooltip("Written on its own for an empty collection, without the count in front of it. When empty, an empty collection is formatted like any other count.")]
+        [SerializeField] private string _zeroText = "Empty";
+
+        [Tooltip("The word used for one item.")]
+        [SerializeField] private string _oneForm = "item";
+
+        [Tooltip("The word used for two to four items under the Slavic rule. When empty, the many form is used. Ignored by the English rule.")]
+        [SerializeField] private string _fewForm = string.Empty;
+
+        [Tooltip("The word used for every other count.")]
+        [SerializeField] private string _manyForm = "items";
+
+        [Tooltip("A composite format for the result: {0} is the count, {1} the word. When empty, only the word is written.")]
+        [SerializeField] private string _format = "{0} {1}";
+
+        [NonSerialized] private int _cachedCount;
+        [NonSerialized] private string? _cached;
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="CollectionCountToStringConverter{T}"/> class
+        /// writing English item counts.
+        /// </summary>
+        public CollectionCountToStringConverter() { }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="CollectionCountToStringConverter{T}"/> class.
+        /// </summary>
+        /// <param name="oneForm">The word used for one item.</param>
+        /// <param name="manyForm">The word used for every other count.</param>
+        /// <param name="zeroText">
+        /// Written on its own for an empty collection. When <see langword="null"/>, an empty
+        /// collection is formatted like any other count.
+        /// </param>
+        /// <param name="rule">Which grammar to follow when picking the word form.</param>
+        /// <param name="fewForm">
+        /// The word used for two to four items under <see cref="PluralRule.Slavic"/>. When
+        /// <see langword="null"/>, the many form is used.
+        /// </param>
+        public CollectionCountToStringConverter(
+            string oneForm,
+            string manyForm,
+            string? zeroText = null,
+            PluralRule rule = PluralRule.English,
+            string? fewForm = null)
+        {
+            _oneForm = oneForm;
+            _manyForm = manyForm;
+            _zeroText = zeroText ?? string.Empty;
+            _rule = rule;
+            _fewForm = fewForm ?? manyForm;
+        }
+
+        /// <summary>
+        /// Writes the size of the specified collection.
+        /// </summary>
+        /// <param name="value">The collection to describe.</param>
+        /// <returns>
+        /// The formatted phrase, or the empty text when the collection is <see langword="null"/> or
+        /// empty and an empty text is authored.
+        /// </returns>
+        /// <exception cref="ArgumentOutOfRangeException">Thrown when the rule is not a declared value.</exception>
+        public string Convert(IReadOnlyCollection<T>? value)
+        {
+            var count = value?.Count ?? 0;
+
+            // The null check is the has-a-cache flag: a count of zero is a real answer, so it cannot
+            // double as one.
+            if (_cached is not null && _cachedCount == count) return _cached;
+
+            _cachedCount = count;
+            _cached = Build(count);
+
+            return _cached;
+        }
+
+        private string Build(int count)
+        {
+            if (count == 0 && !string.IsNullOrEmpty(_zeroText)) return _zeroText;
+
+            var word = Form(count);
+            return string.IsNullOrEmpty(_format) ? word : string.Format(_format, count, word);
+        }
+
+        private string Form(int count) => _rule switch
+        {
+            // A count is never negative, so the sign handling PluralizeConverter needs is absent here.
+            PluralRule.English => count == 1 ? _oneForm : _manyForm,
+            PluralRule.Slavic => SlavicForm(count),
+            _ => throw new ArgumentOutOfRangeException(nameof(_rule), _rule, null)
+        };
+
+        // The teens are the exception: 11 takes the many form even though it ends in 1, and 12-14
+        // take it even though they end in 2-4.
+        private string SlavicForm(int count)
+        {
+            if (count % 100 is >= 11 and <= 14) return _manyForm;
+
+            return (count % 10) switch
+            {
+                1 => _oneForm,
+
+                // The constructor falls back to the many form for a null few form; the field starts
+                // empty, so a converter authored in the Inspector needs the same fallback or the
+                // word is simply missing from the phrase.
+                2 or 3 or 4 => string.IsNullOrEmpty(_fewForm) ? _manyForm : _fewForm,
+
+                _ => _manyForm
+            };
+        }
+    }
+}

--- a/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Runtime/Converters/Collections/CollectionCountToStringConverter.cs
+++ b/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Runtime/Converters/Collections/CollectionCountToStringConverter.cs
@@ -47,15 +47,9 @@ namespace Aspid.MVVM.StarterKit
         [NonSerialized] private int _cachedCount;
         [NonSerialized] private string? _cached;
 
-        /// <summary>
-        /// Initializes a new instance of the <see cref="CollectionCountToStringConverter{T}"/> class
-        /// writing English item counts.
-        /// </summary>
+        /// <remarks>Default: writing English item counts.</remarks>
         public CollectionCountToStringConverter() { }
 
-        /// <summary>
-        /// Initializes a new instance of the <see cref="CollectionCountToStringConverter{T}"/> class.
-        /// </summary>
         /// <param name="oneForm">The word used for one item.</param>
         /// <param name="manyForm">The word used for every other count.</param>
         /// <param name="zeroText">

--- a/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Runtime/Converters/Collections/CollectionCountToStringConverter.cs.meta
+++ b/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Runtime/Converters/Collections/CollectionCountToStringConverter.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 592dbd7cbc1a4224935d229206474a17

--- a/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Runtime/Converters/Collections/CollectionFirstConverter.cs
+++ b/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Runtime/Converters/Collections/CollectionFirstConverter.cs
@@ -23,14 +23,8 @@ namespace Aspid.MVVM.StarterKit
         [Tooltip("Returned when the sequence is empty.")]
         [SerializeField] private T _fallback = default!;
 
-        /// <summary>
-        /// Initializes a new instance of the <see cref="CollectionFirstConverter{T}"/> class with no fallback.
-        /// </summary>
         public CollectionFirstConverter() { }
 
-        /// <summary>
-        /// Initializes a new instance of the <see cref="CollectionFirstConverter{T}"/> class.
-        /// </summary>
         /// <param name="fallback">Returned when the sequence is empty.</param>
         public CollectionFirstConverter(T fallback)
         {

--- a/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Runtime/Converters/Collections/CollectionFirstConverter.cs
+++ b/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Runtime/Converters/Collections/CollectionFirstConverter.cs
@@ -12,13 +12,9 @@ namespace Aspid.MVVM.StarterKit
     /// </summary>
     /// <typeparam name="T">The type of the items.</typeparam>
     /// <remarks>
-    /// "Next in the queue", "the current objective" — the head of a bound sequence, shown on its own.
     /// <see cref="CollectionElementAtConverter{T}"/> answers the same question but needs an
     /// <see cref="IReadOnlyList{T}"/>, which an observable set, queue or stack is not: they stop at
-    /// <see cref="IReadOnlyCollection{T}"/> and expose no indexer to read.
-    /// <para>
-    /// Only the first item is read, so the cost does not grow with the length of the sequence.
-    /// </para>
+    /// <see cref="IReadOnlyCollection{T}"/> and expose no indexer. Only the first item is read here.
     /// </remarks>
     [Serializable]
     [TypeSelectorDisplay(Group = "Aspid/Collection", Name = "Collection First", Tooltip = "Takes the first item of a sequence")]

--- a/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Runtime/Converters/Collections/CollectionFirstConverter.cs
+++ b/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Runtime/Converters/Collections/CollectionFirstConverter.cs
@@ -1,0 +1,60 @@
+#nullable enable
+using Aspid.FastTools.Types;
+using System;
+using UnityEngine;
+using System.Collections.Generic;
+
+// ReSharper disable once CheckNamespace
+namespace Aspid.MVVM.StarterKit
+{
+    /// <summary>
+    /// Takes the first item of a sequence.
+    /// </summary>
+    /// <typeparam name="T">The type of the items.</typeparam>
+    /// <remarks>
+    /// "Next in the queue", "the current objective" — the head of a bound sequence, shown on its own.
+    /// <see cref="CollectionElementAtConverter{T}"/> answers the same question but needs an
+    /// <see cref="IReadOnlyList{T}"/>, which an observable set, queue or stack is not: they stop at
+    /// <see cref="IReadOnlyCollection{T}"/> and expose no indexer to read.
+    /// <para>
+    /// Only the first item is read, so the cost does not grow with the length of the sequence.
+    /// </para>
+    /// </remarks>
+    [Serializable]
+    [TypeSelectorDisplay(Group = "Aspid/Collection", Name = "Collection First", Tooltip = "Takes the first item of a sequence")]
+    public sealed class CollectionFirstConverter<T> : IConverter<IEnumerable<T>?, T?>
+    {
+        [Tooltip("Returned when the sequence is empty.")]
+        [SerializeField] private T _fallback = default!;
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="CollectionFirstConverter{T}"/> class with no fallback.
+        /// </summary>
+        public CollectionFirstConverter() { }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="CollectionFirstConverter{T}"/> class.
+        /// </summary>
+        /// <param name="fallback">Returned when the sequence is empty.</param>
+        public CollectionFirstConverter(T fallback)
+        {
+            _fallback = fallback;
+        }
+
+        /// <summary>
+        /// Takes the first item of the specified sequence.
+        /// </summary>
+        /// <param name="value">The sequence to read.</param>
+        /// <returns>The first item, or the fallback when there is none.</returns>
+        public T? Convert(IEnumerable<T>? value)
+        {
+            if (value is null) return _fallback;
+            if (value is IReadOnlyList<T> list) return list.Count > 0 ? list[0] : _fallback;
+
+            // foreach disposes the enumerator on the way out, which a bare MoveNext would not.
+            foreach (var item in value) return item;
+
+            return _fallback;
+        }
+    }
+}

--- a/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Runtime/Converters/Collections/CollectionFirstConverter.cs.meta
+++ b/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Runtime/Converters/Collections/CollectionFirstConverter.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 3c11bd112e4dd35b1f0d3b32c9b2925f

--- a/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Runtime/Converters/Collections/CollectionLastConverter.cs
+++ b/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Runtime/Converters/Collections/CollectionLastConverter.cs
@@ -24,14 +24,8 @@ namespace Aspid.MVVM.StarterKit
         [Tooltip("Returned when the sequence is empty.")]
         [SerializeField] private T _fallback = default!;
 
-        /// <summary>
-        /// Initializes a new instance of the <see cref="CollectionLastConverter{T}"/> class with no fallback.
-        /// </summary>
         public CollectionLastConverter() { }
 
-        /// <summary>
-        /// Initializes a new instance of the <see cref="CollectionLastConverter{T}"/> class.
-        /// </summary>
         /// <param name="fallback">Returned when the sequence is empty.</param>
         public CollectionLastConverter(T fallback)
         {

--- a/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Runtime/Converters/Collections/CollectionLastConverter.cs
+++ b/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Runtime/Converters/Collections/CollectionLastConverter.cs
@@ -12,14 +12,10 @@ namespace Aspid.MVVM.StarterKit
     /// </summary>
     /// <typeparam name="T">The type of the items.</typeparam>
     /// <remarks>
-    /// "The most recent message", "the latest unlock" — the tail of a bound sequence, shown on its own.
-    /// <see cref="CollectionElementAtConverter{T}"/> reaches the same item with index 0 counted from
-    /// the end, but it needs an <see cref="IReadOnlyList{T}"/>; this one takes any
-    /// <see cref="IEnumerable{T}"/>, which is what an observable set, queue or stack arrives as.
-    /// <para>
-    /// A sequence that exposes no indexer has to be walked to its end before its last item is known;
-    /// there is no cheaper way to ask. A list or an array is read straight from its last index.
-    /// </para>
+    /// <see cref="CollectionElementAtConverter{T}"/> reaches the same item with index 0 counted from the
+    /// end, but it needs an <see cref="IReadOnlyList{T}"/>; this one takes any
+    /// <see cref="IEnumerable{T}"/>, which is what an observable set, queue or stack arrives as — and
+    /// has to be walked to its end before its last item is known.
     /// </remarks>
     [Serializable]
     [TypeSelectorDisplay(Group = "Aspid/Collection", Name = "Collection Last", Tooltip = "Takes the last item of a sequence")]

--- a/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Runtime/Converters/Collections/CollectionLastConverter.cs
+++ b/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Runtime/Converters/Collections/CollectionLastConverter.cs
@@ -1,0 +1,64 @@
+#nullable enable
+using Aspid.FastTools.Types;
+using System;
+using UnityEngine;
+using System.Collections.Generic;
+
+// ReSharper disable once CheckNamespace
+namespace Aspid.MVVM.StarterKit
+{
+    /// <summary>
+    /// Takes the last item of a sequence.
+    /// </summary>
+    /// <typeparam name="T">The type of the items.</typeparam>
+    /// <remarks>
+    /// "The most recent message", "the latest unlock" — the tail of a bound sequence, shown on its own.
+    /// <see cref="CollectionElementAtConverter{T}"/> reaches the same item with index 0 counted from
+    /// the end, but it needs an <see cref="IReadOnlyList{T}"/>; this one takes any
+    /// <see cref="IEnumerable{T}"/>, which is what an observable set, queue or stack arrives as.
+    /// <para>
+    /// A sequence that exposes no indexer has to be walked to its end before its last item is known;
+    /// there is no cheaper way to ask. A list or an array is read straight from its last index.
+    /// </para>
+    /// </remarks>
+    [Serializable]
+    [TypeSelectorDisplay(Group = "Aspid/Collection", Name = "Collection Last", Tooltip = "Takes the last item of a sequence")]
+    public sealed class CollectionLastConverter<T> : IConverter<IEnumerable<T>?, T?>
+    {
+        [Tooltip("Returned when the sequence is empty.")]
+        [SerializeField] private T _fallback = default!;
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="CollectionLastConverter{T}"/> class with no fallback.
+        /// </summary>
+        public CollectionLastConverter() { }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="CollectionLastConverter{T}"/> class.
+        /// </summary>
+        /// <param name="fallback">Returned when the sequence is empty.</param>
+        public CollectionLastConverter(T fallback)
+        {
+            _fallback = fallback;
+        }
+
+        /// <summary>
+        /// Takes the last item of the specified sequence.
+        /// </summary>
+        /// <param name="value">The sequence to read.</param>
+        /// <returns>The last item, or the fallback when there is none.</returns>
+        public T? Convert(IEnumerable<T>? value)
+        {
+            if (value is null) return _fallback;
+            if (value is IReadOnlyList<T> list) return list.Count > 0 ? list[list.Count - 1] : _fallback;
+
+            // Starting from the fallback answers the empty sequence as well: nothing overwrites it.
+            var last = _fallback;
+
+            foreach (var item in value)
+                last = item;
+
+            return last;
+        }
+    }
+}

--- a/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Runtime/Converters/Collections/CollectionLastConverter.cs.meta
+++ b/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Runtime/Converters/Collections/CollectionLastConverter.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: caa74754e5771ad0034301cb0bded096

--- a/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Runtime/Converters/Collections/CollectionTakeConverter.cs
+++ b/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Runtime/Converters/Collections/CollectionTakeConverter.cs
@@ -1,0 +1,93 @@
+#nullable enable
+using Aspid.FastTools.Types;
+using System;
+using UnityEngine;
+using System.Collections.Generic;
+
+// ReSharper disable once CheckNamespace
+namespace Aspid.MVVM.StarterKit
+{
+    /// <summary>
+    /// Keeps a few items off one end of a sequence.
+    /// </summary>
+    /// <typeparam name="T">The type of the items.</typeparam>
+    /// <remarks>
+    /// A "top three" feed into a virtualized list, or the last five lines of a log — a shorter view of
+    /// a bound collection, without a second projected property on the ViewModel that has to be rebuilt
+    /// whenever the source changes.
+    /// <para>
+    /// The result is one <see cref="List{T}"/> reused between calls, because a binder pushes on every
+    /// notification and a fresh list per push allocates once a frame while a value is being dragged.
+    /// Read it inside the push it arrived on: the next conversion clears and refills the same list, so
+    /// anything that stores it ends up holding a view of whatever came last.
+    /// </para>
+    /// </remarks>
+    [Serializable]
+    [TypeSelectorDisplay(Group = "Aspid/Collection", Name = "Collection Take", Tooltip = "Keeps a few items off one end of a sequence")]
+    public sealed class CollectionTakeConverter<T> : IConverter<IEnumerable<T>?, IEnumerable<T>>
+    {
+        [Tooltip("How many items to keep. Zero or fewer keeps none of them.")]
+        [SerializeField] private int _count = 3;
+
+        [Tooltip("Take from the end of the sequence rather than from its start.")]
+        [SerializeField] private bool _fromEnd;
+
+        [NonSerialized] private List<T>? _buffer;
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="CollectionTakeConverter{T}"/> class keeping the
+        /// first three items.
+        /// </summary>
+        public CollectionTakeConverter() { }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="CollectionTakeConverter{T}"/> class.
+        /// </summary>
+        /// <param name="count">How many items to keep.</param>
+        /// <param name="fromEnd">Whether to take from the end rather than from the start.</param>
+        public CollectionTakeConverter(int count, bool fromEnd = false)
+        {
+            _count = count;
+            _fromEnd = fromEnd;
+        }
+
+        /// <summary>
+        /// Keeps the configured items of the specified sequence.
+        /// </summary>
+        /// <param name="value">The sequence to shorten.</param>
+        /// <returns>
+        /// The kept items, in their original order, in a list this converter reuses on the next call.
+        /// </returns>
+        public IEnumerable<T> Convert(IEnumerable<T>? value)
+        {
+            _buffer ??= new List<T>();
+            _buffer.Clear();
+
+            if (value is null || _count <= 0) return _buffer;
+
+            if (value is IReadOnlyList<T> list)
+            {
+                var start = _fromEnd ? Math.Max(0, list.Count - _count) : 0;
+                var end = _fromEnd ? list.Count : Math.Min(list.Count, _count);
+
+                for (var i = start; i < end; i++)
+                    _buffer.Add(list[i]);
+
+                return _buffer;
+            }
+
+            foreach (var item in value)
+            {
+                _buffer.Add(item);
+                if (!_fromEnd && _buffer.Count == _count) break;
+            }
+
+            // A sequence with no indexer gives no way to know where its last few items begin until it
+            // has been walked, so the tail case buffers all of it and drops the front in one move.
+            if (_fromEnd && _buffer.Count > _count)
+                _buffer.RemoveRange(0, _buffer.Count - _count);
+
+            return _buffer;
+        }
+    }
+}

--- a/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Runtime/Converters/Collections/CollectionTakeConverter.cs
+++ b/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Runtime/Converters/Collections/CollectionTakeConverter.cs
@@ -28,15 +28,9 @@ namespace Aspid.MVVM.StarterKit
 
         [NonSerialized] private List<T>? _buffer;
 
-        /// <summary>
-        /// Initializes a new instance of the <see cref="CollectionTakeConverter{T}"/> class keeping the
-        /// first three items.
-        /// </summary>
+        /// <remarks>Default: keeping the first three items.</remarks>
         public CollectionTakeConverter() { }
 
-        /// <summary>
-        /// Initializes a new instance of the <see cref="CollectionTakeConverter{T}"/> class.
-        /// </summary>
         /// <param name="count">How many items to keep.</param>
         /// <param name="fromEnd">Whether to take from the end rather than from the start.</param>
         public CollectionTakeConverter(int count, bool fromEnd = false)

--- a/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Runtime/Converters/Collections/CollectionTakeConverter.cs
+++ b/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Runtime/Converters/Collections/CollectionTakeConverter.cs
@@ -12,15 +12,9 @@ namespace Aspid.MVVM.StarterKit
     /// </summary>
     /// <typeparam name="T">The type of the items.</typeparam>
     /// <remarks>
-    /// A "top three" feed into a virtualized list, or the last five lines of a log — a shorter view of
-    /// a bound collection, without a second projected property on the ViewModel that has to be rebuilt
-    /// whenever the source changes.
-    /// <para>
     /// The result is one <see cref="List{T}"/> reused between calls, because a binder pushes on every
     /// notification and a fresh list per push allocates once a frame while a value is being dragged.
-    /// Read it inside the push it arrived on: the next conversion clears and refills the same list, so
-    /// anything that stores it ends up holding a view of whatever came last.
-    /// </para>
+    /// Read it inside the push it arrived on: the next conversion clears and refills the same list.
     /// </remarks>
     [Serializable]
     [TypeSelectorDisplay(Group = "Aspid/Collection", Name = "Collection Take", Tooltip = "Keeps a few items off one end of a sequence")]

--- a/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Runtime/Converters/Collections/CollectionTakeConverter.cs.meta
+++ b/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Runtime/Converters/Collections/CollectionTakeConverter.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: c1d096fde1b9468199c1e36efabba82c

--- a/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Runtime/Converters/Collections/DictionaryLookupConverter.cs
+++ b/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Runtime/Converters/Collections/DictionaryLookupConverter.cs
@@ -30,15 +30,8 @@ namespace Aspid.MVVM.StarterKit
         [Tooltip("Returned for a key the table does not list.")]
         [SerializeField] private TValue _fallback = default!;
 
-        /// <summary>
-        /// Initializes a new instance of the <see cref="DictionaryLookupConverter{TKey, TValue}"/>
-        /// class with an empty table.
-        /// </summary>
         public DictionaryLookupConverter() { }
 
-        /// <summary>
-        /// Initializes a new instance of the <see cref="DictionaryLookupConverter{TKey, TValue}"/> class.
-        /// </summary>
         /// <param name="map">The value returned for each key.</param>
         /// <param name="fallback">Returned for a key <paramref name="map"/> does not list.</param>
         public DictionaryLookupConverter(LookupEntry<TKey, TValue>[]? map, TValue fallback = default!)

--- a/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Runtime/Converters/Collections/DictionaryLookupConverter.cs
+++ b/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Runtime/Converters/Collections/DictionaryLookupConverter.cs
@@ -13,14 +13,11 @@ namespace Aspid.MVVM.StarterKit
     /// <typeparam name="TKey">The type of the key being looked up.</typeparam>
     /// <typeparam name="TValue">The type of the value the key names.</typeparam>
     /// <remarks>
-    /// A ViewModel holds an id — an item key, a status code, a faction name — and the View wants the
-    /// thing that id names: an icon, a label, a colour. Seated on any binder bound to that id, this
-    /// converter carries the map. The enum-keyed form of the same table already ships as
-    /// <see cref="EnumToValueConverter{TEnum, T}"/>, but a key that is a string or an int had nowhere
-    /// to look, so the map ended up as a switch in the ViewModel.
+    /// The enum-keyed form of the same table ships as <see cref="EnumToValueConverter{TEnum, T}"/>; this
+    /// takes a string or an int key.
     /// <para>
-    /// Keys are matched with the type's own equality, which for a string is ordinal and
-    /// case-sensitive: an id authored as "Fire" does not answer a pushed "fire".
+    /// Keys are matched with the type's own equality, which for a string is ordinal and case-sensitive:
+    /// an id authored as "Fire" does not answer a pushed "fire".
     /// </para>
     /// </remarks>
     [Serializable]

--- a/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Runtime/Converters/Collections/DictionaryLookupConverter.cs
+++ b/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Runtime/Converters/Collections/DictionaryLookupConverter.cs
@@ -1,0 +1,71 @@
+#nullable enable
+using Aspid.FastTools.Types;
+using System;
+using UnityEngine;
+using System.Collections.Generic;
+
+// ReSharper disable once CheckNamespace
+namespace Aspid.MVVM.StarterKit
+{
+    /// <summary>
+    /// Looks a key up in an authored table.
+    /// </summary>
+    /// <typeparam name="TKey">The type of the key being looked up.</typeparam>
+    /// <typeparam name="TValue">The type of the value the key names.</typeparam>
+    /// <remarks>
+    /// A ViewModel holds an id — an item key, a status code, a faction name — and the View wants the
+    /// thing that id names: an icon, a label, a colour. Seated on any binder bound to that id, this
+    /// converter carries the map. The enum-keyed form of the same table already ships as
+    /// <see cref="EnumToValueConverter{TEnum, T}"/>, but a key that is a string or an int had nowhere
+    /// to look, so the map ended up as a switch in the ViewModel.
+    /// <para>
+    /// Keys are matched with the type's own equality, which for a string is ordinal and
+    /// case-sensitive: an id authored as "Fire" does not answer a pushed "fire".
+    /// </para>
+    /// </remarks>
+    [Serializable]
+    [TypeSelectorDisplay(Group = "Aspid/Collection", Name = "Dictionary Lookup", Tooltip = "Looks a key up in an authored table")]
+    public sealed class DictionaryLookupConverter<TKey, TValue> : IConverter<TKey, TValue?>
+    {
+        [Tooltip("The value returned for each key. Keys not listed use the fallback.")]
+        [SerializeField] private LookupEntry<TKey, TValue>[] _map = Array.Empty<LookupEntry<TKey, TValue>>();
+
+        [Tooltip("Returned for a key the table does not list.")]
+        [SerializeField] private TValue _fallback = default!;
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="DictionaryLookupConverter{TKey, TValue}"/>
+        /// class with an empty table.
+        /// </summary>
+        public DictionaryLookupConverter() { }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="DictionaryLookupConverter{TKey, TValue}"/> class.
+        /// </summary>
+        /// <param name="map">The value returned for each key.</param>
+        /// <param name="fallback">Returned for a key <paramref name="map"/> does not list.</param>
+        public DictionaryLookupConverter(LookupEntry<TKey, TValue>[]? map, TValue fallback = default!)
+        {
+            _map = map ?? Array.Empty<LookupEntry<TKey, TValue>>();
+            _fallback = fallback;
+        }
+
+        /// <summary>
+        /// Looks the specified key up in the table.
+        /// </summary>
+        /// <param name="value">The key to look up.</param>
+        /// <returns>The value the table gives for that key, or the fallback when it lists no such key.</returns>
+        public TValue? Convert(TKey value)
+        {
+            if (_map is null) return _fallback;
+
+            // A linear scan for the same reason EnumToValueConverter uses one: an authored table is a
+            // handful of rows, and a Dictionary would have to be rebuilt after every deserialization.
+            for (var i = 0; i < _map.Length; i++)
+                if (EqualityComparer<TKey>.Default.Equals(_map[i].Key, value))
+                    return _map[i].Value;
+
+            return _fallback;
+        }
+    }
+}

--- a/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Runtime/Converters/Collections/DictionaryLookupConverter.cs.meta
+++ b/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Runtime/Converters/Collections/DictionaryLookupConverter.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: c1019f893ef64ce682f81c7d4997ed25

--- a/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Runtime/Converters/Collections/ListToStringConverter.cs
+++ b/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Runtime/Converters/Collections/ListToStringConverter.cs
@@ -12,15 +12,10 @@ namespace Aspid.MVVM.StarterKit
     /// </summary>
     /// <typeparam name="T">The type of the items.</typeparam>
     /// <remarks>
-    /// Tag lists, party rosters, ingredient lines. The builder is reused between calls, and so is the
-    /// text it produced: a binder pushes on every notification rather than on every change, so the
-    /// converter reuses the previous result when the text it builds is unchanged, where
-    /// <c>string.Join</c> hands back a new string on every push.
-    /// <para>
-    /// Each item can carry a wrapper of its own — brackets around a tag, a bullet in front of a line.
-    /// <c>string.Join</c> cannot express that without projecting the whole collection first, which is
-    /// a second allocation on top of the one this converter exists to avoid.
-    /// </para>
+    /// The builder is reused between calls, and so is the text it produced: a binder pushes on every
+    /// notification, where <c>string.Join</c> hands back a new string on every push. Each item can also
+    /// carry a wrapper of its own, which <c>string.Join</c> cannot express without projecting the whole
+    /// collection first.
     /// </remarks>
     [Serializable]
     [TypeSelectorDisplay(Group = "Aspid/Collection", Name = "List To String", Tooltip = "Joins a collection into one string")]

--- a/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Runtime/Converters/Collections/ListToStringConverter.cs
+++ b/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Runtime/Converters/Collections/ListToStringConverter.cs
@@ -12,8 +12,15 @@ namespace Aspid.MVVM.StarterKit
     /// </summary>
     /// <typeparam name="T">The type of the items.</typeparam>
     /// <remarks>
-    /// Tag lists, party rosters, ingredient lines. The builder is reused between calls, because a
-    /// binder pushes on every notification and <c>string.Join</c> would allocate on each one.
+    /// Tag lists, party rosters, ingredient lines. The builder is reused between calls, and so is the
+    /// text it produced: a binder pushes on every notification rather than on every change, so the
+    /// converter reuses the previous result when the text it builds is unchanged, where
+    /// <c>string.Join</c> hands back a new string on every push.
+    /// <para>
+    /// Each item can carry a wrapper of its own — brackets around a tag, a bullet in front of a line.
+    /// <c>string.Join</c> cannot express that without projecting the whole collection first, which is
+    /// a second allocation on top of the one this converter exists to avoid.
+    /// </para>
     /// </remarks>
     [Serializable]
     [TypeSelectorDisplay(Group = "Aspid/Collection", Name = "List To String", Tooltip = "Joins a collection into one string")]
@@ -21,6 +28,9 @@ namespace Aspid.MVVM.StarterKit
     {
         [Tooltip("Placed between items.")]
         [SerializeField] private string _separator = ", ";
+
+        [Tooltip("A composite format applied to each item: {0} is the item. When empty, the item is written as it is.")]
+        [SerializeField] private string _itemFormat = string.Empty;
 
         [Tooltip("How many items to show. Zero shows all of them.")]
         [SerializeField] private int _maxItems;
@@ -32,6 +42,7 @@ namespace Aspid.MVVM.StarterKit
         [SerializeField] private string _emptyText = string.Empty;
 
         [NonSerialized] private StringBuilder? _builder;
+        [NonSerialized] private string? _cached;
 
         /// <remarks>Default: joining with commas.</remarks>
         public ListToStringConverter() { }
@@ -39,18 +50,26 @@ namespace Aspid.MVVM.StarterKit
         /// <param name="separator">Placed between items.</param>
         /// <param name="maxItems">How many items to show. Zero shows all of them.</param>
         /// <param name="emptyText">Shown when the collection is empty.</param>
-        public ListToStringConverter(string separator, int maxItems = 0, string emptyText = "")
+        /// <param name="itemFormat">
+        /// A composite format applied to each item, where <c>{0}</c> is the item. When empty, the item
+        /// is written as it is.
+        /// </param>
+        public ListToStringConverter(string separator, int maxItems = 0, string emptyText = "", string itemFormat = "")
         {
             _separator = separator;
             _maxItems = maxItems;
             _emptyText = emptyText;
+            _itemFormat = itemFormat;
         }
 
         /// <summary>
         /// Joins the specified collection.
         /// </summary>
         /// <param name="value">The collection to join.</param>
-        /// <returns>The joined text, or the empty text when there is nothing to join.</returns>
+        /// <returns>
+        /// The joined text, or the empty text when there is nothing to join. The same string is
+        /// returned again while the text being built is unchanged.
+        /// </returns>
         public string Convert(IEnumerable<T>? value)
         {
             if (value is null) return _emptyText;
@@ -67,7 +86,13 @@ namespace Aspid.MVVM.StarterKit
                 if (_maxItems > 0 && shown >= _maxItems) continue;
 
                 if (shown > 0) _builder.Append(_separator);
-                _builder.Append(item);
+
+                // Not AppendFormat with a "{0}" default: it would re-parse that format for every item
+                // of every push, and no format at all is the common case. T is unconstrained, so both
+                // calls bind to the object overload and a value-type item is boxed on the way in.
+                if (string.IsNullOrEmpty(_itemFormat)) _builder.Append(item);
+                else _builder.AppendFormat(_itemFormat, item);
+
                 shown++;
             }
 
@@ -77,7 +102,30 @@ namespace Aspid.MVVM.StarterKit
             if (hidden > 0 && !string.IsNullOrEmpty(_overflowFormat))
                 _builder.AppendFormat(_overflowFormat, hidden);
 
-            return _builder.ToString();
+            return Take();
+        }
+
+        // Reusing the builder only saves its char buffer; ToString allocates a fresh string on every
+        // push. Comparing what was built against the last result costs no allocation, so a push that
+        // reads the same as the one before it hands back the string it already has.
+        private string Take()
+        {
+            if (_cached is not null && Matches(_cached)) return _cached;
+
+            _cached = _builder!.ToString();
+            return _cached;
+        }
+
+        private bool Matches(string text)
+        {
+            var builder = _builder!;
+            if (builder.Length != text.Length) return false;
+
+            for (var i = 0; i < text.Length; i++)
+                if (builder[i] != text[i])
+                    return false;
+
+            return true;
         }
     }
 }

--- a/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Runtime/Converters/Collections/LookupEntry.cs
+++ b/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Runtime/Converters/Collections/LookupEntry.cs
@@ -1,0 +1,28 @@
+#nullable enable
+using System;
+using UnityEngine;
+
+// ReSharper disable once CheckNamespace
+namespace Aspid.MVVM.StarterKit
+{
+    /// <summary>
+    /// One row of a <see cref="DictionaryLookupConverter{TKey, TValue}"/> table.
+    /// </summary>
+    /// <typeparam name="TKey">The type of the key being looked up.</typeparam>
+    /// <typeparam name="TValue">The type of the value the key names.</typeparam>
+    [Serializable]
+    public struct LookupEntry<TKey, TValue>
+    {
+        /// <summary>
+        /// The key this row matches.
+        /// </summary>
+        [Tooltip("The key this row matches.")]
+        public TKey Key;
+
+        /// <summary>
+        /// The value returned for <see cref="Key"/>.
+        /// </summary>
+        [Tooltip("The value returned for the key.")]
+        public TValue Value;
+    }
+}

--- a/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Runtime/Converters/Collections/LookupEntry.cs.meta
+++ b/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Runtime/Converters/Collections/LookupEntry.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: b98183bf0cdd876a4c9043dbf097ea7f

--- a/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Runtime/Converters/Strings/PluralizeConverter.cs
+++ b/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Runtime/Converters/Strings/PluralizeConverter.cs
@@ -87,7 +87,10 @@ namespace Aspid.MVVM.StarterKit
             return (magnitude % 10) switch
             {
                 1 => _oneForm,
-                2 or 3 or 4 => _fewForm,
+                // The constructor substitutes the many form for an absent few form; the field
+                // initializer cannot, so an Inspector-authored converter reaches here with an empty
+                // string and writes "2 " with the word missing.
+                2 or 3 or 4 => string.IsNullOrEmpty(_fewForm) ? _manyForm : _fewForm,
                 _ => _manyForm
             };
         }

--- a/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Runtime/Converters/Strings/StringToDateTimeConverter.cs
+++ b/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Runtime/Converters/Strings/StringToDateTimeConverter.cs
@@ -59,15 +59,21 @@ namespace Aspid.MVVM.StarterKit
 
         private DateTime OnUnparsed(string? value, DateTime fallback)
         {
-            var expected = string.IsNullOrWhiteSpace(_format) ? "a date" : $"a date shaped \"{_format}\"";
-
             if (_onFailure is ConverterFailureMode.Throw)
-                throw ConverterFailure.Rejected(nameof(StringToDateTimeConverter), value, expected);
+                throw ConverterFailure.Rejected(nameof(StringToDateTimeConverter), value, Expected());
+
+            // Report keeps the first message and drops every one after it, and text that will not
+            // parse usually fails on every push: composing the message past that point allocates a
+            // string per notification for the guard inside Report to throw away.
+            if (_loggedFailure) return fallback;
 
             ConverterFailure.Report(
-                ref _loggedFailure, nameof(StringToDateTimeConverter), value, expected, "the fallback date");
+                ref _loggedFailure, nameof(StringToDateTimeConverter), value, Expected(), "the fallback date");
             return fallback;
         }
+
+        private string Expected() =>
+            string.IsNullOrWhiteSpace(_format) ? "a date" : $"a date shaped \"{_format}\"";
 
         [NonSerialized] private bool _loggedFailure;
     }

--- a/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Runtime/Converters/Strings/StringToDecimalConverter.cs
+++ b/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Runtime/Converters/Strings/StringToDecimalConverter.cs
@@ -31,14 +31,9 @@ namespace Aspid.MVVM.StarterKit
         [Tooltip("The culture the text is read with.")]
         [SerializeField] private CultureInfoMode _culture = CultureInfoMode.CurrentCulture;
 
-        /// <summary>
-        /// Initializes a new instance of the <see cref="StringToDecimalConverter"/> class falling back to zero.
-        /// </summary>
+        /// <remarks>Default: falling back to zero.</remarks>
         public StringToDecimalConverter() { }
 
-        /// <summary>
-        /// Initializes a new instance of the <see cref="StringToDecimalConverter"/> class.
-        /// </summary>
         /// <param name="fallback">Returned when the text is not a number.</param>
         /// <param name="culture">The culture the text is read with.</param>
         public StringToDecimalConverter(decimal fallback, CultureInfoMode culture = CultureInfoMode.CurrentCulture)

--- a/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Runtime/Converters/Strings/StringToDecimalConverter.cs
+++ b/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Runtime/Converters/Strings/StringToDecimalConverter.cs
@@ -10,18 +10,11 @@ namespace Aspid.MVVM.StarterKit
     /// Reads an exact decimal number out of text.
     /// </summary>
     /// <remarks>
-    /// Prices, balances and anything else where a tenth has to stay a tenth: binary floating point
-    /// cannot hold 0.1, so a shop total accumulated in <see langword="float"/> drifts by a fraction of
-    /// a cent and then shows it.
-    /// <para>
-    /// Unity cannot serialize a <see langword="decimal"/> field, so the fallback is authored as text
-    /// and read with the invariant culture — write <c>1.5</c>, never <c>1,5</c>, whatever the machine
-    /// reads player input with. A comma there is refused rather than read as a group separator, so an
-    /// author who types the number their own machine shows them is told about it instead of getting
-    /// ten times the value they meant. Bounds are not offered: they would have to be authored as text
-    /// for the same reason, and nothing this converter is for — a price, a balance, an id — has
-    /// wanted a range yet.
-    /// </para>
+    /// Unity cannot serialize a <see langword="decimal"/> field, so the fallback is authored as text and
+    /// read with the invariant culture — write <c>1.5</c>, never <c>1,5</c>. A comma there is refused
+    /// rather than read as a group separator, so an author who types the number their own machine shows
+    /// them is told about it instead of getting ten times the value they meant. Bounds are not offered
+    /// for the same reason.
     /// </remarks>
     [Serializable]
     [TypeSelectorDisplay(Group = "Aspid/String", Name = "String To Decimal", Tooltip = "Reads an exact decimal number out of text")]

--- a/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Runtime/Converters/Strings/StringToDecimalConverter.cs
+++ b/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Runtime/Converters/Strings/StringToDecimalConverter.cs
@@ -1,0 +1,142 @@
+using Aspid.FastTools.Types;
+using System;
+using UnityEngine;
+using System.Globalization;
+
+// ReSharper disable once CheckNamespace
+namespace Aspid.MVVM.StarterKit
+{
+    /// <summary>
+    /// Reads an exact decimal number out of text.
+    /// </summary>
+    /// <remarks>
+    /// Prices, balances and anything else where a tenth has to stay a tenth: binary floating point
+    /// cannot hold 0.1, so a shop total accumulated in <see langword="float"/> drifts by a fraction of
+    /// a cent and then shows it.
+    /// <para>
+    /// Unity cannot serialize a <see langword="decimal"/> field, so the fallback is authored as text
+    /// and read with the invariant culture — write <c>1.5</c>, never <c>1,5</c>, whatever the machine
+    /// reads player input with. A comma there is refused rather than read as a group separator, so an
+    /// author who types the number their own machine shows them is told about it instead of getting
+    /// ten times the value they meant. Bounds are not offered: they would have to be authored as text
+    /// for the same reason, and nothing this converter is for — a price, a balance, an id — has
+    /// wanted a range yet.
+    /// </para>
+    /// </remarks>
+    [Serializable]
+    [TypeSelectorDisplay(Group = "Aspid/String", Name = "String To Decimal", Tooltip = "Reads an exact decimal number out of text")]
+    public sealed class StringToDecimalConverter : ITwoWayConverter<string?, decimal>
+    {
+        [Tooltip("Returned when the text is not a number. Written in the invariant culture — 1.5, "
+            + "never 1,5 — because it is authored once rather than typed by a player.")]
+        [SerializeField] private string _fallback = "0";
+
+        [Tooltip("What to do with text that does not parse. ReturnInput is not available here — the "
+            + "input is text and the output is not — and behaves as ReturnFallback.")]
+        [SerializeField] private ConverterFailureMode _onFailure = ConverterFailureMode.ReturnFallback;
+
+        [Tooltip("The culture the text is read with.")]
+        [SerializeField] private CultureInfoMode _culture = CultureInfoMode.CurrentCulture;
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="StringToDecimalConverter"/> class falling back to zero.
+        /// </summary>
+        public StringToDecimalConverter() { }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="StringToDecimalConverter"/> class.
+        /// </summary>
+        /// <param name="fallback">Returned when the text is not a number.</param>
+        /// <param name="culture">The culture the text is read with.</param>
+        public StringToDecimalConverter(decimal fallback, CultureInfoMode culture = CultureInfoMode.CurrentCulture)
+        {
+            _fallback = fallback.ToString(CultureInfo.InvariantCulture);
+            _culture = culture;
+        }
+
+        /// <summary>
+        /// Reads a number out of the specified text.
+        /// </summary>
+        /// <param name="value">The text to read.</param>
+        /// <returns>The number, or the fallback when the text is not one.</returns>
+        public decimal Convert(string? value)
+        {
+            // Blank text is an unfilled field, not a malformed number. Reporting it would fire on
+            // every scene with an empty input, which is the noise that gets error logs ignored.
+            if (string.IsNullOrWhiteSpace(value)) return Fallback();
+
+            // AllowExponent on top of Number: the reason to reach for this converter over the double
+            // one is a value that arrived as text from somewhere exact, and a backend that serializes
+            // 1E5 would otherwise be readable by the converter with less precision and not by this one.
+            const NumberStyles styles = NumberStyles.Number | NumberStyles.AllowExponent;
+
+            return decimal.TryParse(value, styles, _culture.ToCultureInfo(), out var parsed)
+                ? parsed
+                : OnUnparsed(value);
+        }
+
+        // The fallback arrives as text and a binder pushes on every notification, so the parse is
+        // kept against the string it came from rather than repeated per call. Unity hands back a
+        // fresh string on deserialization, which is precisely when the cache should miss.
+        private decimal Fallback()
+        {
+            if (ReferenceEquals(_fallbackSource, _fallback)) return _fallbackValue;
+
+            _fallbackSource = _fallback;
+            _fallbackValue = decimal.Zero;
+
+            // An unfilled field is zero rather than a malformed number, the same reading blank input
+            // gets a few lines above.
+            if (string.IsNullOrWhiteSpace(_fallback)) return _fallbackValue;
+
+            // Float rather than Number: the fallback is read as invariant, where the comma is the
+            // GROUP separator, so Number would read the "1,5" the field's own tooltip warns against
+            // as fifteen instead of refusing it — silently, and authored once for every player.
+            const NumberStyles styles = NumberStyles.Float;
+
+            if (decimal.TryParse(_fallback, styles, CultureInfo.InvariantCulture, out var parsed))
+            {
+                _fallbackValue = parsed;
+                return _fallbackValue;
+            }
+
+            // Reported rather than thrown whatever the failure mode says: this is the value the
+            // converter falls back TO, so throwing from it would leave the failure path with nothing
+            // to return, and a fallback that reads as zero is a scene bug nobody would otherwise see.
+            ConverterFailure.Report(
+                ref _loggedFallbackFailure,
+                nameof(StringToDecimalConverter),
+                _fallback,
+                "a fallback written as an exact decimal number in the invariant culture — 1.5, never 1,5",
+                "zero");
+
+            return _fallbackValue;
+        }
+
+        private decimal OnUnparsed(string? value)
+        {
+            if (_onFailure is ConverterFailureMode.Throw)
+                throw ConverterFailure.Rejected(nameof(StringToDecimalConverter), value, "an exact decimal number");
+
+            ConverterFailure.Report(
+                ref _loggedFailure,
+                nameof(StringToDecimalConverter),
+                value,
+                "an exact decimal number",
+                "the fallback");
+            return Fallback();
+        }
+
+        /// <summary>
+        /// Writes the specified number as text.
+        /// </summary>
+        /// <param name="value">The number to write.</param>
+        /// <returns>The text.</returns>
+        public string ConvertBack(decimal value) => value.ToString(_culture.ToCultureInfo());
+
+        [NonSerialized] private string? _fallbackSource;
+        [NonSerialized] private decimal _fallbackValue;
+        [NonSerialized] private bool _loggedFailure;
+        [NonSerialized] private bool _loggedFallbackFailure;
+    }
+}

--- a/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Runtime/Converters/Strings/StringToDecimalConverter.cs.meta
+++ b/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Runtime/Converters/Strings/StringToDecimalConverter.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: de453fa8c47fa1d6f53ab63d88edf906

--- a/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Runtime/Converters/Strings/StringToDoubleConverter.cs
+++ b/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Runtime/Converters/Strings/StringToDoubleConverter.cs
@@ -37,14 +37,9 @@ namespace Aspid.MVVM.StarterKit
         [Tooltip("The culture the text is read with.")]
         [SerializeField] private CultureInfoMode _culture = CultureInfoMode.CurrentCulture;
 
-        /// <summary>
-        /// Initializes a new instance of the <see cref="StringToDoubleConverter"/> class falling back to zero.
-        /// </summary>
+        /// <remarks>Default: falling back to zero.</remarks>
         public StringToDoubleConverter() { }
 
-        /// <summary>
-        /// Initializes a new instance of the <see cref="StringToDoubleConverter"/> class.
-        /// </summary>
         /// <param name="fallback">Returned when the text is not a number.</param>
         /// <param name="culture">The culture the text is read with.</param>
         public StringToDoubleConverter(double fallback, CultureInfoMode culture = CultureInfoMode.CurrentCulture)

--- a/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Runtime/Converters/Strings/StringToDoubleConverter.cs
+++ b/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Runtime/Converters/Strings/StringToDoubleConverter.cs
@@ -10,14 +10,9 @@ namespace Aspid.MVVM.StarterKit
     /// Reads a decimal number out of text, keeping the precision a float would lose.
     /// </summary>
     /// <remarks>
-    /// <c>InputFieldBinder</c> has a double path of its own, hard-coded the same way its int and float
-    /// paths were: the machine's culture, no fallback, and a silent swallow when the text is not a
-    /// number. This is that path made authorable.
-    /// <para>
-    /// Use it over <see cref="StringToFloatConverter"/> when the number is large or precise rather
-    /// than merely fractional — a currency total, a cumulative timer, an id that arrived as text — as
-    /// a <see langword="float"/> carries about seven significant digits and quietly rounds past them.
-    /// </para>
+    /// Use it over <see cref="StringToFloatConverter"/> when the number is large or precise rather than
+    /// merely fractional — a currency total, a cumulative timer, an id that arrived as text — since a
+    /// <see langword="float"/> carries about seven significant digits and quietly rounds past them.
     /// </remarks>
     [Serializable]
     [TypeSelectorDisplay(Group = "Aspid/String", Name = "String To Double", Tooltip = "Reads a decimal number out of text, keeping the precision a float would lose")]

--- a/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Runtime/Converters/Strings/StringToDoubleConverter.cs
+++ b/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Runtime/Converters/Strings/StringToDoubleConverter.cs
@@ -1,0 +1,108 @@
+using Aspid.FastTools.Types;
+using System;
+using UnityEngine;
+using System.Globalization;
+
+// ReSharper disable once CheckNamespace
+namespace Aspid.MVVM.StarterKit
+{
+    /// <summary>
+    /// Reads a decimal number out of text, keeping the precision a float would lose.
+    /// </summary>
+    /// <remarks>
+    /// <c>InputFieldBinder</c> has a double path of its own, hard-coded the same way its int and float
+    /// paths were: the machine's culture, no fallback, and a silent swallow when the text is not a
+    /// number. This is that path made authorable.
+    /// <para>
+    /// Use it over <see cref="StringToFloatConverter"/> when the number is large or precise rather
+    /// than merely fractional — a currency total, a cumulative timer, an id that arrived as text — as
+    /// a <see langword="float"/> carries about seven significant digits and quietly rounds past them.
+    /// </para>
+    /// </remarks>
+    [Serializable]
+    [TypeSelectorDisplay(Group = "Aspid/String", Name = "String To Double", Tooltip = "Reads a decimal number out of text, keeping the precision a float would lose")]
+    public sealed class StringToDoubleConverter : ITwoWayConverter<string?, double>
+    {
+        [Tooltip("Returned when the text is not a number.")]
+        [SerializeField] private double _fallback;
+
+        [Tooltip("What to do with text that does not parse. ReturnInput is not available here — the "
+            + "input is text and the output is not — and behaves as ReturnFallback.")]
+        [SerializeField] private ConverterFailureMode _onFailure = ConverterFailureMode.ReturnFallback;
+
+        [Tooltip("Hold the result inside the bounds below.")]
+        [SerializeField] private bool _clamp;
+
+        [Tooltip("The lowest value allowed through when clamping.")]
+        [SerializeField] private double _min = double.MinValue;
+
+        [Tooltip("The highest value allowed through when clamping.")]
+        [SerializeField] private double _max = double.MaxValue;
+
+        [Tooltip("The culture the text is read with.")]
+        [SerializeField] private CultureInfoMode _culture = CultureInfoMode.CurrentCulture;
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="StringToDoubleConverter"/> class falling back to zero.
+        /// </summary>
+        public StringToDoubleConverter() { }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="StringToDoubleConverter"/> class.
+        /// </summary>
+        /// <param name="fallback">Returned when the text is not a number.</param>
+        /// <param name="culture">The culture the text is read with.</param>
+        public StringToDoubleConverter(double fallback, CultureInfoMode culture = CultureInfoMode.CurrentCulture)
+        {
+            _fallback = fallback;
+            _culture = culture;
+        }
+
+        /// <summary>
+        /// Reads a number out of the specified text.
+        /// </summary>
+        /// <param name="value">The text to read.</param>
+        /// <returns>The number, or the fallback when the text is not one.</returns>
+        public double Convert(string? value)
+        {
+            // Blank text is an unfilled field, not a malformed number. Reporting it would fire on
+            // every scene with an empty input, which is the noise that gets error logs ignored.
+            if (string.IsNullOrWhiteSpace(value)) return _fallback;
+
+            const NumberStyles styles = NumberStyles.Float | NumberStyles.AllowThousands;
+
+            if (!double.TryParse(value, styles, _culture.ToCultureInfo(), out var parsed))
+                return OnUnparsed(value);
+
+            return _clamp ? Clamp(parsed) : parsed;
+        }
+
+        // Two comparisons rather than Math.Clamp, which throws when Max is authored below Min: the
+        // bounds are Inspector fields with nothing to validate them, and an exception on the push
+        // path is not what ReturnFallback promises. A NaN fails both comparisons and passes through.
+        private double Clamp(double value)
+        {
+            if (value < _min) return _min;
+            return value > _max ? _max : value;
+        }
+
+        private double OnUnparsed(string? value)
+        {
+            if (_onFailure is ConverterFailureMode.Throw)
+                throw ConverterFailure.Rejected(nameof(StringToDoubleConverter), value, "a decimal number");
+
+            ConverterFailure.Report(
+                ref _loggedFailure, nameof(StringToDoubleConverter), value, "a decimal number", "the fallback");
+            return _fallback;
+        }
+
+        /// <summary>
+        /// Writes the specified number as text.
+        /// </summary>
+        /// <param name="value">The number to write.</param>
+        /// <returns>The text.</returns>
+        public string ConvertBack(double value) => value.ToString(_culture.ToCultureInfo());
+
+        [NonSerialized] private bool _loggedFailure;
+    }
+}

--- a/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Runtime/Converters/Strings/StringToDoubleConverter.cs.meta
+++ b/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Runtime/Converters/Strings/StringToDoubleConverter.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 5a4390089b7ef8b87ac7fce8673de2a3

--- a/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Runtime/Converters/Strings/StringToFloatConverter.cs
+++ b/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Runtime/Converters/Strings/StringToFloatConverter.cs
@@ -63,7 +63,16 @@ namespace Aspid.MVVM.StarterKit
             if (!float.TryParse(value, styles, _culture.ToCultureInfo(), out var parsed))
                 return OnUnparsed(value);
 
-            return _clamp ? Mathf.Clamp(parsed, _min, _max) : parsed;
+            return _clamp ? Clamp(parsed) : parsed;
+        }
+
+        // Two comparisons, the same shape the int, long and double siblings use: Math.Clamp throws
+        // when Max is authored below Min, and the whole family reads a reversed pair as the minimum
+        // rather than as a crash. A NaN fails both comparisons and passes through.
+        private float Clamp(float value)
+        {
+            if (value < _min) return _min;
+            return value > _max ? _max : value;
         }
 
         private float OnUnparsed(string? value)

--- a/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Runtime/Converters/Strings/StringToIntConverter.cs
+++ b/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Runtime/Converters/Strings/StringToIntConverter.cs
@@ -59,10 +59,25 @@ namespace Aspid.MVVM.StarterKit
             // every scene with an empty input, which is the noise that gets error logs ignored.
             if (string.IsNullOrWhiteSpace(value)) return _fallback;
 
-            if (!int.TryParse(value, NumberStyles.Integer, _culture.ToCultureInfo(), out var parsed))
+            // Grouped text is a spelling of the number rather than a mistake — a player typing
+            // 1,000 in en-US means a thousand — and the float, double and decimal converters in this
+            // family already read it as one. The group separator is the player's own, so a culture
+            // that writes 1,5 for one and a half still refuses that text here.
+            const NumberStyles styles = NumberStyles.Integer | NumberStyles.AllowThousands;
+
+            if (!int.TryParse(value, styles, _culture.ToCultureInfo(), out var parsed))
                 return OnUnparsed(value);
 
-            return _clamp ? Math.Clamp(parsed, _min, _max) : parsed;
+            return _clamp ? Clamp(parsed) : parsed;
+        }
+
+        // Two comparisons rather than Math.Clamp, which throws when Max is authored below Min: the
+        // bounds are Inspector fields with nothing to validate them, and an exception on the push
+        // path is not what ReturnFallback promises. A reversed pair reads as the minimum.
+        private int Clamp(int value)
+        {
+            if (value < _min) return _min;
+            return value > _max ? _max : value;
         }
 
         private int OnUnparsed(string? value)

--- a/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Runtime/Converters/Strings/StringToIntConverter.cs.meta
+++ b/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Runtime/Converters/Strings/StringToIntConverter.cs.meta
@@ -1,2 +1,2 @@
 fileFormatVersion: 2
-guid: b35c1ed45ee1840368df35fd6b9e8f16
+guid: 2a6274f14e136bad3672b1a8e92106eb

--- a/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Runtime/Converters/Strings/StringToLongConverter.cs
+++ b/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Runtime/Converters/Strings/StringToLongConverter.cs
@@ -7,11 +7,14 @@ using System.Globalization;
 namespace Aspid.MVVM.StarterKit
 {
     /// <summary>
-    /// Reads a whole number out of text.
+    /// Reads a whole number out of text, past the range an <see langword="int"/> can hold.
     /// </summary>
     /// <inheritdoc cref="StringToIntConverter" path="/remarks"/>
     [Serializable]
-    [TypeSelectorDisplay(Group = "Aspid/String", Name = "String To Long", Tooltip = "Reads a whole number out of text")]
+    [TypeSelectorDisplay(
+        Group = "Aspid/String",
+        Name = "String To Long",
+        Tooltip = "Reads a whole number out of text, past the range an int can hold")]
     public sealed class StringToLongConverter : ITwoWayConverter<string?, long>
     {
         [Tooltip("Returned when the text is not a number.")]
@@ -21,6 +24,15 @@ namespace Aspid.MVVM.StarterKit
             + "input is text and the output is not — and behaves as ReturnFallback.")]
         [SerializeField] private ConverterFailureMode _onFailure = ConverterFailureMode.ReturnFallback;
 
+        [Tooltip("Hold the result inside the bounds below.")]
+        [SerializeField] private bool _clamp;
+
+        [Tooltip("The lowest value allowed through when clamping.")]
+        [SerializeField] private long _min = long.MinValue;
+
+        [Tooltip("The highest value allowed through when clamping.")]
+        [SerializeField] private long _max = long.MaxValue;
+
         [Tooltip("The culture the text is read with.")]
         [SerializeField] private CultureInfoMode _culture = CultureInfoMode.CurrentCulture;
 
@@ -28,9 +40,11 @@ namespace Aspid.MVVM.StarterKit
         public StringToLongConverter() { }
 
         /// <param name="fallback">Returned when the text is not a number.</param>
-        public StringToLongConverter(long fallback)
+        /// <param name="culture">The culture the text is read with.</param>
+        public StringToLongConverter(long fallback, CultureInfoMode culture = CultureInfoMode.CurrentCulture)
         {
             _fallback = fallback;
+            _culture = culture;
         }
 
         /// <summary>
@@ -44,9 +58,24 @@ namespace Aspid.MVVM.StarterKit
             // every scene with an empty input, which is the noise that gets error logs ignored.
             if (string.IsNullOrWhiteSpace(value)) return _fallback;
 
-            return long.TryParse(value, NumberStyles.Integer, _culture.ToCultureInfo(), out var parsed)
-                ? parsed
-                : OnUnparsed(value);
+            // Grouped text is read here for the same reason as in StringToIntConverter, whose
+            // remarks this class shares: the family documents one culture story, and a thousand
+            // cannot be spelled one way for the int path and another for the double one.
+            const NumberStyles styles = NumberStyles.Integer | NumberStyles.AllowThousands;
+
+            if (!long.TryParse(value, styles, _culture.ToCultureInfo(), out var parsed))
+                return OnUnparsed(value);
+
+            return _clamp ? Clamp(parsed) : parsed;
+        }
+
+        // Two comparisons rather than Math.Clamp, which throws when Max is authored below Min: the
+        // bounds are Inspector fields with nothing to validate them, and an exception on the push
+        // path is not what ReturnFallback promises. A reversed pair reads as the minimum.
+        private long Clamp(long value)
+        {
+            if (value < _min) return _min;
+            return value > _max ? _max : value;
         }
 
         private long OnUnparsed(string? value)

--- a/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Runtime/Converters/Strings/StringToTimeSpanConverter.cs
+++ b/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Runtime/Converters/Strings/StringToTimeSpanConverter.cs
@@ -32,14 +32,9 @@ namespace Aspid.MVVM.StarterKit
             + "them to the second.")]
         [SerializeField] private long _fallbackTicks;
 
-        /// <summary>
-        /// Initializes a new instance of the <see cref="StringToTimeSpanConverter"/> class accepting any format.
-        /// </summary>
+        /// <remarks>Default: accepting any format.</remarks>
         public StringToTimeSpanConverter() { }
 
-        /// <summary>
-        /// Initializes a new instance of the <see cref="StringToTimeSpanConverter"/> class.
-        /// </summary>
         /// <param name="format">The exact format expected.</param>
         /// <param name="fallback">Returned when the text is not a duration.</param>
         public StringToTimeSpanConverter(string format, TimeSpan fallback = default)

--- a/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Runtime/Converters/Strings/StringToTimeSpanConverter.cs
+++ b/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Runtime/Converters/Strings/StringToTimeSpanConverter.cs
@@ -9,16 +9,9 @@ namespace Aspid.MVVM.StarterKit
     /// Reads a duration out of text.
     /// </summary>
     /// <remarks>
-    /// The outbound half of this ships twice — <see cref="TimeSpanToStringConverter"/> and
-    /// <see cref="TimeSpanFormatConverter"/> — while nothing read a duration back in; a cooldown or a
-    /// session length arriving from a save file or a backend as <c>"00:01:30"</c> had to be parsed by
-    /// the ViewModel before it could reach a binder.
-    /// <para>
-    /// A bare number is not seconds here: <c>TimeSpan</c> reads <c>"90"</c> as ninety <i>days</i>,
-    /// which is the trap this converter is most often walked into. Text that counts seconds wants
-    /// <see cref="StringToFloatConverter"/> followed by <see cref="SecondsToTimeSpanConverter"/>
-    /// instead.
-    /// </para>
+    /// A bare number is not seconds here: <c>TimeSpan</c> reads <c>"90"</c> as ninety <i>days</i>, which
+    /// is the trap this converter is most often walked into. Text that counts seconds wants
+    /// <see cref="StringToFloatConverter"/> followed by <see cref="SecondsToTimeSpanConverter"/> instead.
     /// </remarks>
     [Serializable]
     [TypeSelectorDisplay(Group = "Aspid/String", Name = "String To Time Span", Tooltip = "Reads a duration out of text")]

--- a/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Runtime/Converters/Strings/StringToTimeSpanConverter.cs
+++ b/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Runtime/Converters/Strings/StringToTimeSpanConverter.cs
@@ -1,0 +1,98 @@
+using Aspid.FastTools.Types;
+using System;
+using UnityEngine;
+
+// ReSharper disable once CheckNamespace
+namespace Aspid.MVVM.StarterKit
+{
+    /// <summary>
+    /// Reads a duration out of text.
+    /// </summary>
+    /// <remarks>
+    /// The outbound half of this ships twice — <see cref="TimeSpanToStringConverter"/> and
+    /// <see cref="TimeSpanFormatConverter"/> — while nothing read a duration back in; a cooldown or a
+    /// session length arriving from a save file or a backend as <c>"00:01:30"</c> had to be parsed by
+    /// the ViewModel before it could reach a binder.
+    /// <para>
+    /// A bare number is not seconds here: <c>TimeSpan</c> reads <c>"90"</c> as ninety <i>days</i>,
+    /// which is the trap this converter is most often walked into. Text that counts seconds wants
+    /// <see cref="StringToFloatConverter"/> followed by <see cref="SecondsToTimeSpanConverter"/>
+    /// instead.
+    /// </para>
+    /// </remarks>
+    [Serializable]
+    [TypeSelectorDisplay(Group = "Aspid/String", Name = "String To Time Span", Tooltip = "Reads a duration out of text")]
+    public sealed class StringToTimeSpanConverter : IConverter<string?, TimeSpan>
+    {
+        [Tooltip("The exact format expected, as a TimeSpan format string — \"hh\\:mm\\:ss\". When "
+            + "empty, any format the culture understands is accepted.")]
+        [SerializeField] private string _format = string.Empty;
+
+        [Tooltip("The culture the text is read with.")]
+        [SerializeField] private CultureInfoMode _culture = CultureInfoMode.CurrentCulture;
+
+        [Tooltip("What to do with text that does not parse. ReturnInput is not available here — the "
+            + "input is text and the output is not — and behaves as ReturnFallback.")]
+        [SerializeField] private ConverterFailureMode _onFailure = ConverterFailureMode.ReturnFallback;
+
+        [Tooltip("Ticks of the duration returned when the text is not one. There are ten million of "
+            + "them to the second.")]
+        [SerializeField] private long _fallbackTicks;
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="StringToTimeSpanConverter"/> class accepting any format.
+        /// </summary>
+        public StringToTimeSpanConverter() { }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="StringToTimeSpanConverter"/> class.
+        /// </summary>
+        /// <param name="format">The exact format expected.</param>
+        /// <param name="fallback">Returned when the text is not a duration.</param>
+        public StringToTimeSpanConverter(string format, TimeSpan fallback = default)
+        {
+            _format = format;
+            _fallbackTicks = fallback.Ticks;
+        }
+
+        /// <summary>
+        /// Reads a duration out of the specified text.
+        /// </summary>
+        /// <param name="value">The text to read.</param>
+        /// <returns>The duration, or the fallback when the text is not one.</returns>
+        public TimeSpan Convert(string? value)
+        {
+            var culture = _culture.ToCultureInfo();
+            var fallback = new TimeSpan(_fallbackTicks);
+
+            // Empty text is absence rather than a malformed duration, so it takes the fallback quietly.
+            if (string.IsNullOrWhiteSpace(value)) return fallback;
+
+            var parsed = string.IsNullOrWhiteSpace(_format)
+                ? TimeSpan.TryParse(value, culture, out var any) ? any : (TimeSpan?)null
+                : TimeSpan.TryParseExact(value, _format, culture, out var exact) ? exact : null;
+
+            return parsed ?? OnUnparsed(value, fallback);
+        }
+
+        private TimeSpan OnUnparsed(string? value, TimeSpan fallback)
+        {
+            if (_onFailure is ConverterFailureMode.Throw)
+                throw ConverterFailure.Rejected(nameof(StringToTimeSpanConverter), value, Expected());
+
+            // Report keeps the first message and drops every one after it, and text that will not
+            // parse usually fails on every push: composing the message past that point allocates a
+            // string per notification for the guard inside Report to throw away.
+            if (_loggedFailure) return fallback;
+
+            ConverterFailure.Report(
+                ref _loggedFailure, nameof(StringToTimeSpanConverter), value, Expected(), "the fallback duration");
+            return fallback;
+        }
+
+        private string Expected() =>
+            string.IsNullOrWhiteSpace(_format) ? "a duration" : $"a duration shaped \"{_format}\"";
+
+        [NonSerialized] private bool _loggedFailure;
+    }
+}

--- a/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Runtime/Converters/Strings/StringToTimeSpanConverter.cs.meta
+++ b/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Runtime/Converters/Strings/StringToTimeSpanConverter.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: c8e2a29d7b537a741fd14462303947af

--- a/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Runtime/Converters/Strings/StringToVector2Converter.cs
+++ b/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Runtime/Converters/Strings/StringToVector2Converter.cs
@@ -9,21 +9,13 @@ namespace Aspid.MVVM.StarterKit
     /// Reads a 2D vector out of text.
     /// </summary>
     /// <remarks>
-    /// Debug consoles, level tools and cheat panels, where a position or a size is typed into one
-    /// field rather than authored component by component. It reads back what a vector's own
-    /// <see cref="object.ToString"/> writes, brackets and all, so a value copied out of a log or a
-    /// console goes straight back in.
+    /// Reads back what a vector's own <see cref="object.ToString"/> writes, brackets and all, so a value
+    /// copied out of a log goes straight back in.
     /// <para>
-    /// The culture defaults to invariant rather than to the machine's, unlike the rest of this family:
-    /// a culture that writes <c>1,5</c> for one and a half cannot also use a comma between the
-    /// components, and a tool field is typed by whoever is debugging rather than by a player. Thousands
-    /// separators are refused for the same reason.
-    /// </para>
-    /// <para>
-    /// A culture chosen anyway whose decimal separator <i>is</i> the separator — the machine's, on a
-    /// German player's device — reads and writes its components as invariant instead. The pair would
-    /// otherwise be written <c>"1,5,2,5"</c>, which no split recovers, and the two halves of a
-    /// two-way converter have to agree on text one of them can read back.
+    /// The culture defaults to invariant rather than to the machine's, unlike the rest of this family: a
+    /// culture that writes <c>1,5</c> cannot also use a comma between components, and thousands
+    /// separators are refused for the same reason. A culture chosen anyway whose decimal separator
+    /// <i>is</i> the component separator reads and writes its components as invariant instead.
     /// </para>
     /// </remarks>
     [Serializable]

--- a/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Runtime/Converters/Strings/StringToVector2Converter.cs
+++ b/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Runtime/Converters/Strings/StringToVector2Converter.cs
@@ -40,14 +40,9 @@ namespace Aspid.MVVM.StarterKit
             + "input is text and the output is not — and behaves as ReturnFallback.")]
         [SerializeField] private ConverterFailureMode _onFailure = ConverterFailureMode.ReturnFallback;
 
-        /// <summary>
-        /// Initializes a new instance of the <see cref="StringToVector2Converter"/> class reading comma-separated text.
-        /// </summary>
+        /// <remarks>Default: reading comma-separated text.</remarks>
         public StringToVector2Converter() { }
 
-        /// <summary>
-        /// Initializes a new instance of the <see cref="StringToVector2Converter"/> class.
-        /// </summary>
         /// <param name="separator">Placed between the components.</param>
         /// <param name="fallback">Returned when the text is not a vector.</param>
         /// <param name="culture">The culture the components are read with.</param>

--- a/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Runtime/Converters/Strings/StringToVector2Converter.cs
+++ b/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Runtime/Converters/Strings/StringToVector2Converter.cs
@@ -1,0 +1,158 @@
+using Aspid.FastTools.Types;
+using System;
+using UnityEngine;
+
+// ReSharper disable once CheckNamespace
+namespace Aspid.MVVM.StarterKit
+{
+    /// <summary>
+    /// Reads a 2D vector out of text.
+    /// </summary>
+    /// <remarks>
+    /// Debug consoles, level tools and cheat panels, where a position or a size is typed into one
+    /// field rather than authored component by component. It reads back what a vector's own
+    /// <see cref="object.ToString"/> writes, brackets and all, so a value copied out of a log or a
+    /// console goes straight back in.
+    /// <para>
+    /// The culture defaults to invariant rather than to the machine's, unlike the rest of this family:
+    /// a culture that writes <c>1,5</c> for one and a half cannot also use a comma between the
+    /// components, and a tool field is typed by whoever is debugging rather than by a player. Thousands
+    /// separators are refused for the same reason.
+    /// </para>
+    /// <para>
+    /// A culture chosen anyway whose decimal separator <i>is</i> the separator — the machine's, on a
+    /// German player's device — reads and writes its components as invariant instead. The pair would
+    /// otherwise be written <c>"1,5,2,5"</c>, which no split recovers, and the two halves of a
+    /// two-way converter have to agree on text one of them can read back.
+    /// </para>
+    /// </remarks>
+    [Serializable]
+    [TypeSelectorDisplay(Group = "Aspid/String", Name = "String To Vector2", Tooltip = "Reads a 2D vector out of text")]
+    public sealed class StringToVector2Converter : ITwoWayConverter<string?, Vector2>
+    {
+        [Tooltip("Placed between the components. The Inspector has no field for a single character, "
+            + "so the whole text is the separator — \"; \" works as well as \",\". Left empty, a "
+            + "comma stands in.")]
+        [SerializeField] private string _separator = ",";
+
+        [Tooltip("Returned when the text is not a vector.")]
+        [SerializeField] private Vector2 _fallback;
+
+        [Tooltip("The culture the components are read and written with. Invariant unless the "
+            + "separator is something other than a comma: a culture whose own decimal separator is "
+            + "the separator cannot write a pair this converter reads back, so it is read as "
+            + "invariant anyway.")]
+        [SerializeField] private CultureInfoMode _culture = CultureInfoMode.InvariantCulture;
+
+        [Tooltip("What to do with text that does not parse. ReturnInput is not available here — the "
+            + "input is text and the output is not — and behaves as ReturnFallback.")]
+        [SerializeField] private ConverterFailureMode _onFailure = ConverterFailureMode.ReturnFallback;
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="StringToVector2Converter"/> class reading comma-separated text.
+        /// </summary>
+        public StringToVector2Converter() { }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="StringToVector2Converter"/> class.
+        /// </summary>
+        /// <param name="separator">Placed between the components.</param>
+        /// <param name="fallback">Returned when the text is not a vector.</param>
+        /// <param name="culture">The culture the components are read with.</param>
+        public StringToVector2Converter(
+            string separator,
+            Vector2 fallback = default,
+            CultureInfoMode culture = CultureInfoMode.InvariantCulture)
+        {
+            _separator = separator;
+            _fallback = fallback;
+            _culture = culture;
+        }
+
+        /// <summary>
+        /// Reads a vector out of the specified text.
+        /// </summary>
+        /// <param name="value">The text to read.</param>
+        /// <returns>The vector, or the fallback when the text is not one.</returns>
+        public Vector2 Convert(string? value)
+        {
+            // Blank text is an unfilled field, not a malformed vector.
+            if (string.IsNullOrWhiteSpace(value)) return _fallback;
+
+            // Splitting allocates and a binder pushes on every notification, not on every change, so
+            // the last parse is kept. The separator and the culture are part of the key: both are
+            // editable while the game runs, and a hit that ignored them would freeze the old reading in.
+            if (string.Equals(_parsedText, value, StringComparison.Ordinal)
+                && ReferenceEquals(_parsedSeparator, _separator)
+                && _parsedCulture == _culture)
+                return _parsed;
+
+            var parsed = Parse(value!);
+            if (parsed is null) return OnUnparsed(value);
+
+            _parsedText = value;
+            _parsedSeparator = _separator;
+            _parsedCulture = _culture;
+            _parsed = parsed.Value;
+
+            return _parsed;
+        }
+
+        private Vector2? Parse(string value)
+        {
+            var separator = VectorText.Separator(_separator);
+            var (start, end) = VectorText.Unwrap(value);
+
+            var split = value.IndexOf(separator, start, end - start, StringComparison.Ordinal);
+            if (split < 0) return null;
+
+            var culture = VectorText.ComponentCulture(_culture.ToCultureInfo(), separator);
+            var rest = split + separator.Length;
+
+            if (!VectorText.TryReadAxis(value, start, split - start, culture, out var x)) return null;
+            if (!VectorText.TryReadAxis(value, rest, end - rest, culture, out var y)) return null;
+
+            return new Vector2(x, y);
+        }
+
+        private Vector2 OnUnparsed(string? value)
+        {
+            if (_onFailure is ConverterFailureMode.Throw)
+                throw ConverterFailure.Rejected(nameof(StringToVector2Converter), value, Expected());
+
+            // Report keeps the first message and drops every one after it, and text that will not
+            // parse usually fails on every push: composing the message past that point allocates a
+            // string per notification for the guard inside Report to throw away.
+            if (_loggedFailure) return _fallback;
+
+            ConverterFailure.Report(
+                ref _loggedFailure, nameof(StringToVector2Converter), value, Expected(), "the fallback vector");
+            return _fallback;
+        }
+
+        private string Expected() => $"two numbers separated by \"{VectorText.Separator(_separator)}\"";
+
+        /// <summary>
+        /// Writes the specified vector as text.
+        /// </summary>
+        /// <param name="value">The vector to write.</param>
+        /// <returns>
+        /// The two components with the separator between them, without brackets. The components are
+        /// written as invariant when the chosen culture's decimal separator is the separator itself,
+        /// so that what is written here is what <see cref="Convert"/> reads.
+        /// </returns>
+        public string ConvertBack(Vector2 value)
+        {
+            var separator = VectorText.Separator(_separator);
+            var culture = VectorText.ComponentCulture(_culture.ToCultureInfo(), separator);
+
+            return value.x.ToString(culture) + separator + value.y.ToString(culture);
+        }
+
+        [NonSerialized] private string? _parsedText;
+        [NonSerialized] private string? _parsedSeparator;
+        [NonSerialized] private CultureInfoMode _parsedCulture;
+        [NonSerialized] private Vector2 _parsed;
+        [NonSerialized] private bool _loggedFailure;
+    }
+}

--- a/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Runtime/Converters/Strings/StringToVector2Converter.cs.meta
+++ b/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Runtime/Converters/Strings/StringToVector2Converter.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: b35c1ed45ee1840368df35fd6b9e8f16

--- a/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Runtime/Converters/Strings/StringToVector3Converter.cs
+++ b/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Runtime/Converters/Strings/StringToVector3Converter.cs
@@ -1,0 +1,149 @@
+using Aspid.FastTools.Types;
+using System;
+using UnityEngine;
+
+// ReSharper disable once CheckNamespace
+namespace Aspid.MVVM.StarterKit
+{
+    /// <summary>
+    /// Reads a 3D vector out of text.
+    /// </summary>
+    /// <inheritdoc cref="StringToVector2Converter" path="/remarks"/>
+    [Serializable]
+    [TypeSelectorDisplay(Group = "Aspid/String", Name = "String To Vector3", Tooltip = "Reads a 3D vector out of text")]
+    public sealed class StringToVector3Converter : ITwoWayConverter<string?, Vector3>
+    {
+        [Tooltip("Placed between the components. The Inspector has no field for a single character, "
+            + "so the whole text is the separator — \"; \" works as well as \",\". Left empty, a "
+            + "comma stands in.")]
+        [SerializeField] private string _separator = ",";
+
+        [Tooltip("Returned when the text is not a vector.")]
+        [SerializeField] private Vector3 _fallback;
+
+        [Tooltip("The culture the components are read and written with. Invariant unless the "
+            + "separator is something other than a comma: a culture whose own decimal separator is "
+            + "the separator cannot write a triple this converter reads back, so it is read as "
+            + "invariant anyway.")]
+        [SerializeField] private CultureInfoMode _culture = CultureInfoMode.InvariantCulture;
+
+        [Tooltip("What to do with text that does not parse. ReturnInput is not available here — the "
+            + "input is text and the output is not — and behaves as ReturnFallback.")]
+        [SerializeField] private ConverterFailureMode _onFailure = ConverterFailureMode.ReturnFallback;
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="StringToVector3Converter"/> class reading comma-separated text.
+        /// </summary>
+        public StringToVector3Converter() { }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="StringToVector3Converter"/> class.
+        /// </summary>
+        /// <param name="separator">Placed between the components.</param>
+        /// <param name="fallback">Returned when the text is not a vector.</param>
+        /// <param name="culture">The culture the components are read with.</param>
+        public StringToVector3Converter(
+            string separator,
+            Vector3 fallback = default,
+            CultureInfoMode culture = CultureInfoMode.InvariantCulture)
+        {
+            _separator = separator;
+            _fallback = fallback;
+            _culture = culture;
+        }
+
+        /// <summary>
+        /// Reads a vector out of the specified text.
+        /// </summary>
+        /// <param name="value">The text to read.</param>
+        /// <returns>The vector, or the fallback when the text is not one.</returns>
+        public Vector3 Convert(string? value)
+        {
+            // Blank text is an unfilled field, not a malformed vector.
+            if (string.IsNullOrWhiteSpace(value)) return _fallback;
+
+            // Splitting allocates and a binder pushes on every notification, not on every change, so
+            // the last parse is kept. The separator and the culture are part of the key: both are
+            // editable while the game runs, and a hit that ignored them would freeze the old reading in.
+            if (string.Equals(_parsedText, value, StringComparison.Ordinal)
+                && ReferenceEquals(_parsedSeparator, _separator)
+                && _parsedCulture == _culture)
+                return _parsed;
+
+            var parsed = Parse(value!);
+            if (parsed is null) return OnUnparsed(value);
+
+            _parsedText = value;
+            _parsedSeparator = _separator;
+            _parsedCulture = _culture;
+            _parsed = parsed.Value;
+
+            return _parsed;
+        }
+
+        private Vector3? Parse(string value)
+        {
+            var separator = VectorText.Separator(_separator);
+            var (start, end) = VectorText.Unwrap(value);
+
+            var first = value.IndexOf(separator, start, end - start, StringComparison.Ordinal);
+            if (first < 0) return null;
+
+            var second = first + separator.Length;
+            second = value.IndexOf(separator, second, end - second, StringComparison.Ordinal);
+            if (second < 0) return null;
+
+            var culture = VectorText.ComponentCulture(_culture.ToCultureInfo(), separator);
+            var middle = first + separator.Length;
+            var last = second + separator.Length;
+
+            if (!VectorText.TryReadAxis(value, start, first - start, culture, out var x)) return null;
+            if (!VectorText.TryReadAxis(value, middle, second - middle, culture, out var y)) return null;
+            if (!VectorText.TryReadAxis(value, last, end - last, culture, out var z)) return null;
+
+            return new Vector3(x, y, z);
+        }
+
+        private Vector3 OnUnparsed(string? value)
+        {
+            if (_onFailure is ConverterFailureMode.Throw)
+                throw ConverterFailure.Rejected(nameof(StringToVector3Converter), value, Expected());
+
+            // Report keeps the first message and drops every one after it, and text that will not
+            // parse usually fails on every push: composing the message past that point allocates a
+            // string per notification for the guard inside Report to throw away.
+            if (_loggedFailure) return _fallback;
+
+            ConverterFailure.Report(
+                ref _loggedFailure, nameof(StringToVector3Converter), value, Expected(), "the fallback vector");
+            return _fallback;
+        }
+
+        private string Expected() => $"three numbers separated by \"{VectorText.Separator(_separator)}\"";
+
+        /// <summary>
+        /// Writes the specified vector as text.
+        /// </summary>
+        /// <param name="value">The vector to write.</param>
+        /// <returns>
+        /// The three components with the separator between them, without brackets. The components are
+        /// written as invariant when the chosen culture's decimal separator is the separator itself,
+        /// so that what is written here is what <see cref="Convert"/> reads.
+        /// </returns>
+        public string ConvertBack(Vector3 value)
+        {
+            var separator = VectorText.Separator(_separator);
+            var culture = VectorText.ComponentCulture(_culture.ToCultureInfo(), separator);
+
+            return value.x.ToString(culture)
+                + separator + value.y.ToString(culture)
+                + separator + value.z.ToString(culture);
+        }
+
+        [NonSerialized] private string? _parsedText;
+        [NonSerialized] private string? _parsedSeparator;
+        [NonSerialized] private CultureInfoMode _parsedCulture;
+        [NonSerialized] private Vector3 _parsed;
+        [NonSerialized] private bool _loggedFailure;
+    }
+}

--- a/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Runtime/Converters/Strings/StringToVector3Converter.cs
+++ b/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Runtime/Converters/Strings/StringToVector3Converter.cs
@@ -31,14 +31,9 @@ namespace Aspid.MVVM.StarterKit
             + "input is text and the output is not — and behaves as ReturnFallback.")]
         [SerializeField] private ConverterFailureMode _onFailure = ConverterFailureMode.ReturnFallback;
 
-        /// <summary>
-        /// Initializes a new instance of the <see cref="StringToVector3Converter"/> class reading comma-separated text.
-        /// </summary>
+        /// <remarks>Default: reading comma-separated text.</remarks>
         public StringToVector3Converter() { }
 
-        /// <summary>
-        /// Initializes a new instance of the <see cref="StringToVector3Converter"/> class.
-        /// </summary>
         /// <param name="separator">Placed between the components.</param>
         /// <param name="fallback">Returned when the text is not a vector.</param>
         /// <param name="culture">The culture the components are read with.</param>

--- a/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Runtime/Converters/Strings/StringToVector3Converter.cs.meta
+++ b/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Runtime/Converters/Strings/StringToVector3Converter.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: b11ac1b0f24071156333c32a818d7576

--- a/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Runtime/Converters/Strings/VectorText.cs
+++ b/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Runtime/Converters/Strings/VectorText.cs
@@ -1,0 +1,99 @@
+using System;
+using UnityEngine;
+using System.Globalization;
+
+// ReSharper disable once CheckNamespace
+namespace Aspid.MVVM.StarterKit
+{
+    /// <summary>
+    /// The reading the two vector parsers share.
+    /// </summary>
+    /// <remarks>
+    /// Both walk the same text the same way and differ only in how many components they expect, so the
+    /// walking lives here — a fix to what counts as a bracket or as a number has one place to be made.
+    /// </remarks>
+    internal static class VectorText
+    {
+        /// <summary>
+        /// Resolves the text placed between the components.
+        /// </summary>
+        /// <param name="separator">The authored separator.</param>
+        /// <returns>The separator, or a comma when none is authored.</returns>
+        /// <remarks>
+        /// The Inspector can clear the field and the constructors take any string, so the stand-in has
+        /// to be the same on both halves of the round trip: a write that joined with nothing would put
+        /// <c>"12"</c> on screen for <c>(1, 2)</c>, and the read of that is no vector at all.
+        /// </remarks>
+        internal static string Separator(string? separator) =>
+            string.IsNullOrEmpty(separator) ? "," : separator!;
+
+        /// <summary>
+        /// Resolves the culture the components are written and read in.
+        /// </summary>
+        /// <param name="culture">The authored culture.</param>
+        /// <param name="separator">The text placed between the components.</param>
+        /// <returns>
+        /// The culture, or the invariant one when its decimal separator is the separator itself.
+        /// </returns>
+        /// <remarks>
+        /// A culture that writes one and a half as <c>"1,5"</c> cannot also have a comma between the
+        /// components: the pair comes out <c>"1,5,2,5"</c> and no split of that recovers it. The
+        /// machine's culture is whatever the player's device says, so the collision appears on their
+        /// machine and not on the author's — both halves step back to the invariant reading rather
+        /// than each resolving it differently.
+        /// </remarks>
+        internal static CultureInfo ComponentCulture(CultureInfo culture, string separator) =>
+            string.Equals(culture.NumberFormat.NumberDecimalSeparator, separator, StringComparison.Ordinal)
+                ? CultureInfo.InvariantCulture
+                : culture;
+
+        /// <summary>
+        /// Finds the part of the text the components are written in.
+        /// </summary>
+        /// <param name="value">The text to look at.</param>
+        /// <returns>The first index of the body and the index just past its end.</returns>
+        /// <remarks>
+        /// <see cref="Vector3.ToString()"/> writes <c>"(1.00, 2.00, 3.00)"</c>, so text copied out of a
+        /// log arrives wrapped. The ends are moved rather than a trimmed copy taken: reading the
+        /// components already costs one substring each, and the brackets need not cost another.
+        /// </remarks>
+        internal static (int Start, int End) Unwrap(string value)
+        {
+            var start = 0;
+            var end = value.Length;
+
+            while (start < end && char.IsWhiteSpace(value[start])) start++;
+            while (end > start && char.IsWhiteSpace(value[end - 1])) end--;
+
+            if (end - start >= 2 && value[start] == '(' && value[end - 1] == ')')
+            {
+                start++;
+                end--;
+            }
+
+            return (start, end);
+        }
+
+        /// <summary>
+        /// Reads one component of a vector out of a stretch of text.
+        /// </summary>
+        /// <param name="value">The text holding the component.</param>
+        /// <param name="start">Where the component begins.</param>
+        /// <param name="length">How long it is.</param>
+        /// <param name="culture">The culture it is written in.</param>
+        /// <param name="axis">The number read, or zero when there is none.</param>
+        /// <returns><see langword="true"/> when the stretch of text is a number.</returns>
+        /// <remarks>
+        /// Thousands separators are refused: the group separator and the separator between components
+        /// are the same character in most cultures, so accepting both would make <c>"1,5"</c> a vector
+        /// in one reading and the number fifteen thousand in the other.
+        /// </remarks>
+        internal static bool TryReadAxis(string value, int start, int length, CultureInfo culture, out float axis)
+        {
+            axis = 0f;
+            if (length <= 0) return false;
+
+            return float.TryParse(value.Substring(start, length), NumberStyles.Float, culture, out axis);
+        }
+    }
+}

--- a/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Runtime/Converters/Strings/VectorText.cs.meta
+++ b/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Runtime/Converters/Strings/VectorText.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: d9c3815f51e390dcc2001514fc5f1dc9

--- a/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Unity/Runtime/AssemblyInfo.cs
+++ b/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Unity/Runtime/AssemblyInfo.cs
@@ -1,0 +1,7 @@
+using System.Runtime.CompilerServices;
+
+// The vector clamps put a pair the Inspector lets a user type backwards into the right order, and
+// that ordering is worth a test of its own rather than one that reaches it through a converted
+// vector. The helpers doing it are not API and stay internal; the test assembly is the only thing
+// that needs to name them.
+[assembly: InternalsVisibleTo("Aspid.MVVM.StarterKit.Tests")]

--- a/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Unity/Runtime/AssemblyInfo.cs.meta
+++ b/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Unity/Runtime/AssemblyInfo.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 6e9dae82fb7c04e328ff3b0500d2d4f1

--- a/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Unity/Runtime/Converters/Colors/ChannelOp.cs
+++ b/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Unity/Runtime/Converters/Colors/ChannelOp.cs
@@ -1,0 +1,26 @@
+#nullable enable
+
+// ReSharper disable once CheckNamespace
+namespace Aspid.MVVM.StarterKit
+{
+    /// <summary>
+    /// What <see cref="ColorChannelConverter"/> does to each channel it writes.
+    /// </summary>
+    public enum ChannelOp
+    {
+        /// <summary>
+        /// Replace the channel with the operand.
+        /// </summary>
+        Set,
+
+        /// <summary>
+        /// Scale the channel by the operand.
+        /// </summary>
+        Multiply,
+
+        /// <summary>
+        /// Add the operand to the channel.
+        /// </summary>
+        Add,
+    }
+}

--- a/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Unity/Runtime/Converters/Colors/ChannelOp.cs.meta
+++ b/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Unity/Runtime/Converters/Colors/ChannelOp.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 13c4537ed41f973b6ed50c105de0fc14

--- a/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Unity/Runtime/Converters/Colors/Color32ToColorConverter.cs
+++ b/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Unity/Runtime/Converters/Colors/Color32ToColorConverter.cs
@@ -1,0 +1,28 @@
+#nullable enable
+using Aspid.FastTools.Types;
+using System;
+using UnityEngine;
+
+// ReSharper disable once CheckNamespace
+namespace Aspid.MVVM.StarterKit
+{
+    /// <summary>
+    /// Widens a <see cref="Color32"/> into a <see cref="Color"/>.
+    /// </summary>
+    /// <remarks>
+    /// A backend that sends colours as four bytes — the compact form in a JSON payload or a save
+    /// file — reaching a binder that works in floats. Every binder in the package takes
+    /// <see cref="Color"/>, so a ViewModel holding the byte form could not bind one at all.
+    /// </remarks>
+    [Serializable]
+    [TypeSelectorDisplay(Group = "Aspid/Colour", Name = "Color32 To Color", Tooltip = "Widens a Color32 into a Color")]
+    public sealed class Color32ToColorConverter : IConverter<Color32, Color>
+    {
+        /// <summary>
+        /// Widens the specified byte colour.
+        /// </summary>
+        /// <param name="value">The byte colour to widen.</param>
+        /// <returns>The same colour with each channel as a 0..1 float.</returns>
+        public Color Convert(Color32 value) => value;
+    }
+}

--- a/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Unity/Runtime/Converters/Colors/Color32ToColorConverter.cs.meta
+++ b/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Unity/Runtime/Converters/Colors/Color32ToColorConverter.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 45871aae6464df5f888af88fcfc7f1d1

--- a/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Unity/Runtime/Converters/Colors/ColorAlphaConverter.cs
+++ b/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Unity/Runtime/Converters/Colors/ColorAlphaConverter.cs
@@ -46,14 +46,18 @@ namespace Aspid.MVVM.StarterKit
         /// <param name="value">The colour to adjust.</param>
         /// <returns>The colour with its alpha changed.</returns>
         /// <exception cref="ArgumentOutOfRangeException">Thrown when the mode is not a declared value.</exception>
-        public Color Convert(Color value)
+        public Color Convert(Color value) => Apply(value, _alpha, _mode);
+
+        // Static because ColorBlockAlphaConverter needs the same arithmetic for five colours on every
+        // push, and reaching it through an instance meant constructing one converter per notification.
+        internal static Color Apply(Color value, float alpha, AlphaMode mode)
         {
-            value.a = _mode switch
+            value.a = mode switch
             {
-                AlphaMode.Set => _alpha,
-                AlphaMode.Multiply => Mathf.Clamp01(value.a * _alpha),
-                AlphaMode.Add => Mathf.Clamp01(value.a + _alpha),
-                _ => throw new ArgumentOutOfRangeException(nameof(_mode), _mode, null)
+                AlphaMode.Set => alpha,
+                AlphaMode.Multiply => Mathf.Clamp01(value.a * alpha),
+                AlphaMode.Add => Mathf.Clamp01(value.a + alpha),
+                _ => throw new ArgumentOutOfRangeException(nameof(mode), mode, null)
             };
 
             return value;

--- a/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Unity/Runtime/Converters/Colors/ColorBlockAlphaConverter.cs
+++ b/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Unity/Runtime/Converters/Colors/ColorBlockAlphaConverter.cs
@@ -44,15 +44,17 @@ namespace Aspid.MVVM.StarterKit
         /// <returns>The adjusted block.</returns>
         public ColorBlock Convert(ColorBlock value)
         {
-            var alpha = new ColorAlphaConverter(_alpha, _mode);
-
-            value.normalColor = alpha.Convert(value.normalColor);
-            value.highlightedColor = alpha.Convert(value.highlightedColor);
-            value.pressedColor = alpha.Convert(value.pressedColor);
-            value.selectedColor = alpha.Convert(value.selectedColor);
-            value.disabledColor = alpha.Convert(value.disabledColor);
+            value.normalColor = Fade(value.normalColor);
+            value.highlightedColor = Fade(value.highlightedColor);
+            value.pressedColor = Fade(value.pressedColor);
+            value.selectedColor = Fade(value.selectedColor);
+            value.disabledColor = Fade(value.disabledColor);
 
             return value;
         }
+
+        // Through the static rather than a ColorAlphaConverter instance: this runs on every push, and
+        // an instance per push is an allocation per notification for arithmetic that holds no state.
+        private Color Fade(Color color) => ColorAlphaConverter.Apply(color, _alpha, _mode);
     }
 }

--- a/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Unity/Runtime/Converters/Colors/ColorBlockStateConverter.cs
+++ b/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Unity/Runtime/Converters/Colors/ColorBlockStateConverter.cs
@@ -1,0 +1,70 @@
+#nullable enable
+using Aspid.FastTools.Types;
+using System;
+using UnityEngine;
+using UnityEngine.UI;
+
+// The named converter aliases are [Obsolete]. The converters below keep implementing them for
+// one release so that a [SerializeReference] field a project declares as one still
+// deserializes; the base lists go with the aliases in the next major.
+#pragma warning disable CS0618 // Type or member is obsolete
+
+// ReSharper disable once CheckNamespace
+namespace Aspid.MVVM.StarterKit
+{
+    /// <summary>
+    /// Writes one authored colour into the chosen states of a <see cref="ColorBlock"/>.
+    /// </summary>
+    /// <remarks>
+    /// Overriding a single state of a block that comes from somewhere else — the disabled grey a
+    /// theme should not have touched, or a pressed colour a designer wants louder than the derived
+    /// one. Chained after <see cref="ColorToColorBlockConverter"/> it corrects the one state whose
+    /// derived value was wrong, without the ViewModel producing a whole block to correct it.
+    /// <para>
+    /// The state is a mask rather than a single choice, so one converter can pin normal and selected
+    /// to the same colour — the usual way to say "this toggle stays lit once chosen".
+    /// </para>
+    /// </remarks>
+    [Serializable]
+    [TypeSelectorDisplay(Group = "Aspid/Colour", Name = "Color Block State", Tooltip = "Writes one authored colour into the chosen states of a ColorBlock")]
+    public sealed class ColorBlockStateConverter : IConverterColorBlock
+    {
+        [Tooltip("Which states the colour is written into. The rest pass through untouched.")]
+        [SerializeField] private SelectableStates _states = SelectableStates.Disabled;
+
+        [Tooltip("The colour written into the chosen states.")]
+        [SerializeField] private Color _color = Color.gray;
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="ColorBlockStateConverter"/> class overriding the disabled state.
+        /// </summary>
+        public ColorBlockStateConverter() { }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="ColorBlockStateConverter"/> class.
+        /// </summary>
+        /// <param name="states">Which states the colour is written into.</param>
+        /// <param name="color">The colour written into the chosen states.</param>
+        public ColorBlockStateConverter(SelectableStates states, Color color)
+        {
+            _states = states;
+            _color = color;
+        }
+
+        /// <summary>
+        /// Writes the authored colour into the chosen states of the specified block.
+        /// </summary>
+        /// <param name="value">The block to override.</param>
+        /// <returns>The block, with the states outside the mask unchanged.</returns>
+        public ColorBlock Convert(ColorBlock value)
+        {
+            if (_states.HasFlag(SelectableStates.Normal)) value.normalColor = _color;
+            if (_states.HasFlag(SelectableStates.Highlighted)) value.highlightedColor = _color;
+            if (_states.HasFlag(SelectableStates.Pressed)) value.pressedColor = _color;
+            if (_states.HasFlag(SelectableStates.Selected)) value.selectedColor = _color;
+            if (_states.HasFlag(SelectableStates.Disabled)) value.disabledColor = _color;
+
+            return value;
+        }
+    }
+}

--- a/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Unity/Runtime/Converters/Colors/ColorBlockStateConverter.cs
+++ b/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Unity/Runtime/Converters/Colors/ColorBlockStateConverter.cs
@@ -30,14 +30,9 @@ namespace Aspid.MVVM.StarterKit
         [Tooltip("The colour written into the chosen states.")]
         [SerializeField] private Color _color = Color.gray;
 
-        /// <summary>
-        /// Initializes a new instance of the <see cref="ColorBlockStateConverter"/> class overriding the disabled state.
-        /// </summary>
+        /// <remarks>Default: overriding the disabled state.</remarks>
         public ColorBlockStateConverter() { }
 
-        /// <summary>
-        /// Initializes a new instance of the <see cref="ColorBlockStateConverter"/> class.
-        /// </summary>
         /// <param name="states">Which states the colour is written into.</param>
         /// <param name="color">The colour written into the chosen states.</param>
         public ColorBlockStateConverter(SelectableStates states, Color color)

--- a/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Unity/Runtime/Converters/Colors/ColorBlockStateConverter.cs
+++ b/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Unity/Runtime/Converters/Colors/ColorBlockStateConverter.cs
@@ -16,14 +16,9 @@ namespace Aspid.MVVM.StarterKit
     /// Writes one authored colour into the chosen states of a <see cref="ColorBlock"/>.
     /// </summary>
     /// <remarks>
-    /// Overriding a single state of a block that comes from somewhere else — the disabled grey a
-    /// theme should not have touched, or a pressed colour a designer wants louder than the derived
-    /// one. Chained after <see cref="ColorToColorBlockConverter"/> it corrects the one state whose
-    /// derived value was wrong, without the ViewModel producing a whole block to correct it.
-    /// <para>
-    /// The state is a mask rather than a single choice, so one converter can pin normal and selected
-    /// to the same colour — the usual way to say "this toggle stays lit once chosen".
-    /// </para>
+    /// Chained after <see cref="ColorToColorBlockConverter"/> it corrects the one state whose derived
+    /// value was wrong. The state is a mask rather than a single choice, so one converter can pin normal
+    /// and selected to the same colour.
     /// </remarks>
     [Serializable]
     [TypeSelectorDisplay(Group = "Aspid/Colour", Name = "Color Block State", Tooltip = "Writes one authored colour into the chosen states of a ColorBlock")]

--- a/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Unity/Runtime/Converters/Colors/ColorBlockStateConverter.cs.meta
+++ b/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Unity/Runtime/Converters/Colors/ColorBlockStateConverter.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 48e5bb5e0e6156e82cedf35d20140a30

--- a/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Unity/Runtime/Converters/Colors/ColorBlockTintConverter.cs
+++ b/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Unity/Runtime/Converters/Colors/ColorBlockTintConverter.cs
@@ -16,12 +16,8 @@ namespace Aspid.MVVM.StarterKit
     /// Tints the chosen colours of a <see cref="ColorBlock"/>.
     /// </summary>
     /// <remarks>
-    /// Theming a whole button at once — faction colours, a disabled palette.
-    /// <para>
-    /// The mask is what keeps the disabled colour out of the theme. A faction tint that also
-    /// recolours the disabled state makes an unavailable button look like an available one in
-    /// another faction's colours, which is the one thing that state exists to say.
-    /// </para>
+    /// The mask is what keeps the disabled colour out of the theme: a faction tint that also recolours
+    /// the disabled state makes an unavailable button look available in another faction's colours.
     /// </remarks>
     [Serializable]
     [TypeSelectorDisplay(Group = "Aspid/Colour", Name = "Color Block Tint", Tooltip = "Tints the chosen colours of a ColorBlock")]

--- a/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Unity/Runtime/Converters/Colors/ColorBlockTintConverter.cs
+++ b/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Unity/Runtime/Converters/Colors/ColorBlockTintConverter.cs
@@ -13,14 +13,21 @@ using UnityEngine.UI;
 namespace Aspid.MVVM.StarterKit
 {
     /// <summary>
-    /// Tints every colour of a <see cref="ColorBlock"/>.
+    /// Tints the chosen colours of a <see cref="ColorBlock"/>.
     /// </summary>
-    /// <remarks>Theming a whole button at once — faction colours, a disabled palette.</remarks>
+    /// <remarks>
+    /// Theming a whole button at once — faction colours, a disabled palette.
+    /// <para>
+    /// The mask is what keeps the disabled colour out of the theme. A faction tint that also
+    /// recolours the disabled state makes an unavailable button look like an available one in
+    /// another faction's colours, which is the one thing that state exists to say.
+    /// </para>
+    /// </remarks>
     [Serializable]
-    [TypeSelectorDisplay(Group = "Aspid/Colour", Name = "Color Block Tint", Tooltip = "Tints every colour of a ColorBlock")]
+    [TypeSelectorDisplay(Group = "Aspid/Colour", Name = "Color Block Tint", Tooltip = "Tints the chosen colours of a ColorBlock")]
     public sealed class ColorBlockTintConverter : IConverterColorBlock
     {
-        [Tooltip("The colour every state is combined with.")]
+        [Tooltip("The colour the chosen states are combined with.")]
         [SerializeField] private Color _tint = Color.white;
 
         [Tooltip("How the two are combined.")]
@@ -29,32 +36,42 @@ namespace Aspid.MVVM.StarterKit
         [Tooltip("How far towards the tint to move, for the Lerp blend.")]
         [SerializeField, Range(0f, 1f)] private float _amount = 1f;
 
+        [Tooltip("Which states are tinted. The rest pass through untouched.")]
+        [SerializeField] private SelectableStates _states = SelectableStates.All;
+
         public ColorBlockTintConverter() { }
 
-        /// <param name="tint">The colour every state is combined with.</param>
+        /// <param name="tint">The colour the chosen states are combined with.</param>
         /// <param name="blend">How the two are combined.</param>
-        public ColorBlockTintConverter(Color tint, ColorBlend blend = ColorBlend.Multiply)
+        /// <param name="states">Which states are tinted.</param>
+        public ColorBlockTintConverter(
+            Color tint,
+            ColorBlend blend = ColorBlend.Multiply,
+            SelectableStates states = SelectableStates.All)
         {
             _tint = tint;
             _blend = blend;
+            _states = states;
         }
 
         /// <summary>
-        /// Tints every state of the specified block.
+        /// Tints the chosen states of the specified block.
         /// </summary>
         /// <param name="value">The block to tint.</param>
-        /// <returns>The tinted block.</returns>
+        /// <returns>The tinted block, with the states outside the mask unchanged.</returns>
         public ColorBlock Convert(ColorBlock value)
         {
-            var tint = new ColorTintConverter(_tint, _blend, _amount);
-
-            value.normalColor = tint.Convert(value.normalColor);
-            value.highlightedColor = tint.Convert(value.highlightedColor);
-            value.pressedColor = tint.Convert(value.pressedColor);
-            value.selectedColor = tint.Convert(value.selectedColor);
-            value.disabledColor = tint.Convert(value.disabledColor);
+            if (_states.HasFlag(SelectableStates.Normal)) value.normalColor = Tint(value.normalColor);
+            if (_states.HasFlag(SelectableStates.Highlighted)) value.highlightedColor = Tint(value.highlightedColor);
+            if (_states.HasFlag(SelectableStates.Pressed)) value.pressedColor = Tint(value.pressedColor);
+            if (_states.HasFlag(SelectableStates.Selected)) value.selectedColor = Tint(value.selectedColor);
+            if (_states.HasFlag(SelectableStates.Disabled)) value.disabledColor = Tint(value.disabledColor);
 
             return value;
         }
+
+        // Through the static rather than a ColorTintConverter instance: this runs on every push, and
+        // an instance per push is an allocation per notification for arithmetic that holds no state.
+        private Color Tint(Color color) => ColorTintConverter.Blend(color, _tint, _blend, _amount);
     }
 }

--- a/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Unity/Runtime/Converters/Colors/ColorBlockTintConverter.cs.meta
+++ b/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Unity/Runtime/Converters/Colors/ColorBlockTintConverter.cs.meta
@@ -1,2 +1,2 @@
 fileFormatVersion: 2
-guid: 596548b44ae80451eb768f4460088a6d
+guid: 83506f45ae9a11a41e3915e236cbc56d

--- a/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Unity/Runtime/Converters/Colors/ColorBlockTintConverter.cs.meta
+++ b/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Unity/Runtime/Converters/Colors/ColorBlockTintConverter.cs.meta
@@ -1,2 +1,2 @@
 fileFormatVersion: 2
-guid: 83506f45ae9a11a41e3915e236cbc56d
+guid: 596548b44ae80451eb768f4460088a6d

--- a/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Unity/Runtime/Converters/Colors/ColorChannelConverter.cs
+++ b/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Unity/Runtime/Converters/Colors/ColorChannelConverter.cs
@@ -38,14 +38,8 @@ namespace Aspid.MVVM.StarterKit
         [Tooltip("Hold every written channel inside 0..1. Clear it for HDR colours, which live above one.")]
         [SerializeField] private bool _clamp = true;
 
-        /// <summary>
-        /// Initializes a new instance of the <see cref="ColorChannelConverter"/> class that changes nothing.
-        /// </summary>
         public ColorChannelConverter() { }
 
-        /// <summary>
-        /// Initializes a new instance of the <see cref="ColorChannelConverter"/> class.
-        /// </summary>
         /// <param name="operation">What the operand does to each chosen channel.</param>
         /// <param name="operand">Supplies the operand for each channel.</param>
         /// <param name="channels">Which channels are written.</param>

--- a/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Unity/Runtime/Converters/Colors/ColorChannelConverter.cs
+++ b/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Unity/Runtime/Converters/Colors/ColorChannelConverter.cs
@@ -15,16 +15,10 @@ namespace Aspid.MVVM.StarterKit
     /// Applies one arithmetic operation to the chosen channels of a colour.
     /// </summary>
     /// <remarks>
-    /// The general case the other colour converters are special cases of — boosting only red for a
-    /// damage flash, zeroing blue for a sepia pass, halving green on a colour-blind palette. Each of
-    /// those otherwise needs its own converter or a hand-written one.
-    /// <para>
-    /// Channels outside the mask pass through untouched, so a mask of <see cref="ColorChannels.A"/>
-    /// with <see cref="ChannelOp.Set"/> is <see cref="ColorAlphaConverter"/>, and a mask of
+    /// Channels outside the mask pass through untouched, so a mask of <see cref="ColorChannels.A"/> with
+    /// <see cref="ChannelOp.Set"/> is <see cref="ColorAlphaConverter"/>, and a mask of
     /// <see cref="ColorChannels.All"/> with <see cref="ChannelOp.Multiply"/> is a
-    /// <see cref="ColorTintConverter"/> multiply. Reach for those when they say what you mean; reach
-    /// for this when they do not.
-    /// </para>
+    /// <see cref="ColorTintConverter"/> multiply. Reach for those when they say what you mean.
     /// </remarks>
     [Serializable]
     [TypeSelectorDisplay(Group = "Aspid/Colour", Name = "Color Channel", Tooltip = "Applies one arithmetic operation to the chosen channels of a colour")]

--- a/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Unity/Runtime/Converters/Colors/ColorChannelConverter.cs
+++ b/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Unity/Runtime/Converters/Colors/ColorChannelConverter.cs
@@ -1,0 +1,99 @@
+#nullable enable
+using Aspid.FastTools.Types;
+using System;
+using UnityEngine;
+
+// The named converter aliases are [Obsolete]. The converters below keep implementing them for
+// one release so that a [SerializeReference] field a project declares as one still
+// deserializes; the base lists go with the aliases in the next major.
+#pragma warning disable CS0618 // Type or member is obsolete
+
+// ReSharper disable once CheckNamespace
+namespace Aspid.MVVM.StarterKit
+{
+    /// <summary>
+    /// Applies one arithmetic operation to the chosen channels of a colour.
+    /// </summary>
+    /// <remarks>
+    /// The general case the other colour converters are special cases of — boosting only red for a
+    /// damage flash, zeroing blue for a sepia pass, halving green on a colour-blind palette. Each of
+    /// those otherwise needs its own converter or a hand-written one.
+    /// <para>
+    /// Channels outside the mask pass through untouched, so a mask of <see cref="ColorChannels.A"/>
+    /// with <see cref="ChannelOp.Set"/> is <see cref="ColorAlphaConverter"/>, and a mask of
+    /// <see cref="ColorChannels.All"/> with <see cref="ChannelOp.Multiply"/> is a
+    /// <see cref="ColorTintConverter"/> multiply. Reach for those when they say what you mean; reach
+    /// for this when they do not.
+    /// </para>
+    /// </remarks>
+    [Serializable]
+    [TypeSelectorDisplay(Group = "Aspid/Colour", Name = "Color Channel", Tooltip = "Applies one arithmetic operation to the chosen channels of a colour")]
+    public sealed class ColorChannelConverter : IConverterColor
+    {
+        // Multiply against the white operand below, so a freshly picked converter passes the bound
+        // colour through: Set would emit the operand and read as a binding that stopped working.
+        [Tooltip("What the operand does to each chosen channel.")]
+        [SerializeField] private ChannelOp _operation = ChannelOp.Multiply;
+
+        [Tooltip("Supplies the operand for each channel — red operates on red, green on green.")]
+        [SerializeField] private Color _operand = Color.white;
+
+        [Tooltip("Which channels are written. The rest pass through untouched.")]
+        [SerializeField] private ColorChannels _channels = ColorChannels.Rgb;
+
+        [Tooltip("Hold every written channel inside 0..1. Clear it for HDR colours, which live above one.")]
+        [SerializeField] private bool _clamp = true;
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="ColorChannelConverter"/> class that changes nothing.
+        /// </summary>
+        public ColorChannelConverter() { }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="ColorChannelConverter"/> class.
+        /// </summary>
+        /// <param name="operation">What the operand does to each chosen channel.</param>
+        /// <param name="operand">Supplies the operand for each channel.</param>
+        /// <param name="channels">Which channels are written.</param>
+        /// <param name="clamp">Whether to hold every written channel inside 0..1.</param>
+        public ColorChannelConverter(
+            ChannelOp operation,
+            Color operand,
+            ColorChannels channels = ColorChannels.Rgb,
+            bool clamp = true)
+        {
+            _operation = operation;
+            _operand = operand;
+            _channels = channels;
+            _clamp = clamp;
+        }
+
+        /// <summary>
+        /// Applies the operation to the chosen channels of the specified colour.
+        /// </summary>
+        /// <param name="value">The colour to operate on.</param>
+        /// <returns>The colour, with the channels outside the mask unchanged.</returns>
+        /// <exception cref="ArgumentOutOfRangeException">Thrown when the operation is not a declared value.</exception>
+        public Color Convert(Color value) => new(
+            Apply(value.r, _operand.r, ColorChannels.R),
+            Apply(value.g, _operand.g, ColorChannels.G),
+            Apply(value.b, _operand.b, ColorChannels.B),
+            Apply(value.a, _operand.a, ColorChannels.A));
+
+        /// <exception cref="ArgumentOutOfRangeException">Thrown when the operation is not a declared value.</exception>
+        private float Apply(float channel, float operand, ColorChannels flag)
+        {
+            if (!_channels.HasFlag(flag)) return channel;
+
+            var result = _operation switch
+            {
+                ChannelOp.Set => operand,
+                ChannelOp.Multiply => channel * operand,
+                ChannelOp.Add => channel + operand,
+                _ => throw new ArgumentOutOfRangeException(nameof(_operation), _operation, null)
+            };
+
+            return _clamp ? Mathf.Clamp01(result) : result;
+        }
+    }
+}

--- a/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Unity/Runtime/Converters/Colors/ColorChannelConverter.cs.meta
+++ b/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Unity/Runtime/Converters/Colors/ColorChannelConverter.cs.meta
@@ -1,2 +1,2 @@
 fileFormatVersion: 2
-guid: 398909b3dda05425ab4848c59dd1f7a1
+guid: a34cdc951551cfd2c0b14d12b792d57d

--- a/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Unity/Runtime/Converters/Colors/ColorChannelConverter.cs.meta
+++ b/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Unity/Runtime/Converters/Colors/ColorChannelConverter.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 398909b3dda05425ab4848c59dd1f7a1

--- a/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Unity/Runtime/Converters/Colors/ColorChannels.cs
+++ b/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Unity/Runtime/Converters/Colors/ColorChannels.cs
@@ -1,0 +1,48 @@
+#nullable enable
+using System;
+
+// ReSharper disable once CheckNamespace
+namespace Aspid.MVVM.StarterKit
+{
+    /// <summary>
+    /// Which channels of a colour a converter writes.
+    /// </summary>
+    [Flags]
+    public enum ColorChannels
+    {
+        /// <summary>
+        /// No channel.
+        /// </summary>
+        None = 0,
+
+        /// <summary>
+        /// The red channel.
+        /// </summary>
+        R = 1,
+
+        /// <summary>
+        /// The green channel.
+        /// </summary>
+        G = 2,
+
+        /// <summary>
+        /// The blue channel.
+        /// </summary>
+        B = 4,
+
+        /// <summary>
+        /// The alpha channel.
+        /// </summary>
+        A = 8,
+
+        /// <summary>
+        /// The three colour channels, leaving the alpha alone.
+        /// </summary>
+        Rgb = R | G | B,
+
+        /// <summary>
+        /// Every channel.
+        /// </summary>
+        All = R | G | B | A,
+    }
+}

--- a/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Unity/Runtime/Converters/Colors/ColorChannels.cs.meta
+++ b/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Unity/Runtime/Converters/Colors/ColorChannels.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: c8cd00bfcb80315a505ccb26ec445682

--- a/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Unity/Runtime/Converters/Colors/ColorLerpConverter.cs
+++ b/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Unity/Runtime/Converters/Colors/ColorLerpConverter.cs
@@ -10,18 +10,12 @@ namespace Aspid.MVVM.StarterKit
     /// Moves between two colours by a 0..1 amount.
     /// </summary>
     /// <remarks>
-    /// A two-stop gradient without a <see cref="Gradient"/> to author.
+    /// A two-stop gradient without a <see cref="Gradient"/> to author, with a curve shaping how the
+    /// amount travels between the two colours.
     /// <para>
-    /// The curve shapes how the amount travels between the two colours, which is what a straight
-    /// lerp cannot do: a bar that should look red well before it is empty needs the change bunched
-    /// at one end, and without the curve that meant reaching for a <see cref="Gradient"/> and
-    /// authoring both stops again.
-    /// </para>
-    /// <para>
-    /// Shaping and extrapolating are one choice rather than two. A curve answers with its end key
-    /// for anything past either end of its own range — no wrap mode extrapolates — so an amount
-    /// outside 0..1 cannot survive one. The clamp therefore turns the curve on; clearing it hands
-    /// the amount to the lerp as it arrived, and the colours carry past the two stops.
+    /// Shaping and extrapolating are one choice rather than two. A curve answers with its end key past
+    /// either end of its own range — no wrap mode extrapolates — so the clamp turns the curve on;
+    /// clearing it hands the amount to the lerp as it arrived, and the colours carry past the two stops.
     /// </para>
     /// </remarks>
     [Serializable]

--- a/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Unity/Runtime/Converters/Colors/ColorLerpConverter.cs
+++ b/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Unity/Runtime/Converters/Colors/ColorLerpConverter.cs
@@ -9,7 +9,21 @@ namespace Aspid.MVVM.StarterKit
     /// <summary>
     /// Moves between two colours by a 0..1 amount.
     /// </summary>
-    /// <remarks>A two-stop gradient without a <see cref="Gradient"/> to author.</remarks>
+    /// <remarks>
+    /// A two-stop gradient without a <see cref="Gradient"/> to author.
+    /// <para>
+    /// The curve shapes how the amount travels between the two colours, which is what a straight
+    /// lerp cannot do: a bar that should look red well before it is empty needs the change bunched
+    /// at one end, and without the curve that meant reaching for a <see cref="Gradient"/> and
+    /// authoring both stops again.
+    /// </para>
+    /// <para>
+    /// Shaping and extrapolating are one choice rather than two. A curve answers with its end key
+    /// for anything past either end of its own range — no wrap mode extrapolates — so an amount
+    /// outside 0..1 cannot survive one. The clamp therefore turns the curve on; clearing it hands
+    /// the amount to the lerp as it arrived, and the colours carry past the two stops.
+    /// </para>
+    /// </remarks>
     [Serializable]
     [TypeSelectorDisplay(Group = "Aspid/Colour", Name = "Color Lerp", Tooltip = "Moves between two colours by a 0..1 amount")]
     public sealed class ColorLerpConverter : IConverter<float, Color>
@@ -20,7 +34,10 @@ namespace Aspid.MVVM.StarterKit
         [Tooltip("The colour at 1.")]
         [SerializeField] private Color _to = Color.green;
 
-        [Tooltip("Hold the incoming amount inside 0..1.")]
+        [Tooltip("Shapes the travel between the two colours. A straight line, or no curve at all, moves evenly. Read only while Clamp is on, because a curve cannot answer past its own ends.")]
+        [SerializeField] private AnimationCurve _curve = AnimationCurve.Linear(0f, 0f, 1f, 1f);
+
+        [Tooltip("Hold the incoming amount inside 0..1 and shape it with the curve. Clear it to let an amount outside 0..1 carry past the two colours, which skips the curve.")]
         [SerializeField] private bool _clamp = true;
 
         /// <remarks>Default: going red to green.</remarks>
@@ -28,18 +45,33 @@ namespace Aspid.MVVM.StarterKit
 
         /// <param name="from">The colour at 0.</param>
         /// <param name="to">The colour at 1.</param>
-        public ColorLerpConverter(Color from, Color to)
+        /// <param name="curve">Shapes the travel between the two colours, while the amount is clamped. Leave it out to move evenly.</param>
+        public ColorLerpConverter(Color from, Color to, AnimationCurve? curve = null)
         {
             _from = from;
             _to = to;
+
+            if (curve is not null) _curve = curve;
         }
 
         /// <summary>
         /// Reads the colour at the specified amount.
         /// </summary>
         /// <param name="value">The 0..1 amount.</param>
-        /// <returns>The colour there.</returns>
-        public Color Convert(float value) =>
-            _clamp ? Color.Lerp(_from, _to, value) : Color.LerpUnclamped(_from, _to, value);
+        /// <returns>
+        /// The colour there, after the curve has shaped the amount. With the clamp cleared the amount
+        /// reaches the two colours as it arrived and the curve takes no part, so an amount outside
+        /// 0..1 carries past them.
+        /// </returns>
+        public Color Convert(float value) => _clamp
+            ? Color.Lerp(_from, _to, Ease(value))
+            // Not through the curve: it answers with its end key past either end of its own range,
+            // and no wrap mode extrapolates, so routing an unclamped amount through one would clamp
+            // it here and leave the field meaning nothing.
+            : Color.LerpUnclamped(_from, _to, value);
+
+        // A curve field that was never authored deserializes as a curve with no keys rather than as
+        // null, and evaluating that returns zero — which would pin every value to the first colour.
+        private float Ease(float value) => _curve is { length: > 1 } ? _curve.Evaluate(value) : value;
     }
 }

--- a/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Unity/Runtime/Converters/Colors/ColorTintConverter.cs
+++ b/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Unity/Runtime/Converters/Colors/ColorTintConverter.cs
@@ -46,17 +46,21 @@ namespace Aspid.MVVM.StarterKit
         /// <param name="value">The colour to tint.</param>
         /// <returns>The combined colour.</returns>
         /// <exception cref="ArgumentOutOfRangeException">Thrown when the blend is not a declared value.</exception>
-        public Color Convert(Color value) => _blend switch
+        public Color Convert(Color value) => Blend(value, _tint, _blend, _amount);
+
+        // Static because ColorBlockTintConverter needs the same arithmetic for five colours on every
+        // push, and reaching it through an instance meant constructing one converter per notification.
+        internal static Color Blend(Color value, Color tint, ColorBlend blend, float amount) => blend switch
         {
-            ColorBlend.Multiply => value * _tint,
+            ColorBlend.Multiply => value * tint,
             ColorBlend.Add => new Color(
-                Mathf.Clamp01(value.r + _tint.r),
-                Mathf.Clamp01(value.g + _tint.g),
-                Mathf.Clamp01(value.b + _tint.b),
+                Mathf.Clamp01(value.r + tint.r),
+                Mathf.Clamp01(value.g + tint.g),
+                Mathf.Clamp01(value.b + tint.b),
                 value.a),
-            ColorBlend.Lerp => Color.Lerp(value, _tint, _amount),
-            ColorBlend.Replace => new Color(_tint.r, _tint.g, _tint.b, value.a),
-            _ => throw new ArgumentOutOfRangeException(nameof(_blend), _blend, null)
+            ColorBlend.Lerp => Color.Lerp(value, tint, amount),
+            ColorBlend.Replace => new Color(tint.r, tint.g, tint.b, value.a),
+            _ => throw new ArgumentOutOfRangeException(nameof(blend), blend, null)
         };
     }
 }

--- a/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Unity/Runtime/Converters/Colors/ColorTintConverter.cs.meta
+++ b/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Unity/Runtime/Converters/Colors/ColorTintConverter.cs.meta
@@ -1,2 +1,2 @@
 fileFormatVersion: 2
-guid: 398909b3dda05425ab4848c59dd1f7a1
+guid: eafa75ef5757cde806dbfd618bfd6721

--- a/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Unity/Runtime/Converters/Colors/ColorToColor32Converter.cs
+++ b/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Unity/Runtime/Converters/Colors/ColorToColor32Converter.cs
@@ -10,12 +10,8 @@ namespace Aspid.MVVM.StarterKit
     /// Narrows a <see cref="Color"/> into a <see cref="Color32"/>.
     /// </summary>
     /// <remarks>
-    /// The other direction of <see cref="Color32ToColorConverter"/>: handing a picked colour back to
-    /// something that stores bytes — a mesh's vertex colours, a network message, a save file.
-    /// <para>
-    /// Each channel is clamped to 0..255 and rounded, so an HDR colour loses everything above white
-    /// and the round trip back through <see cref="Color32ToColorConverter"/> is not exact.
-    /// </para>
+    /// Each channel is clamped to 0..255 and rounded, so an HDR colour loses everything above white and
+    /// the round trip back through <see cref="Color32ToColorConverter"/> is not exact.
     /// </remarks>
     [Serializable]
     [TypeSelectorDisplay(Group = "Aspid/Colour", Name = "Color To Color32", Tooltip = "Narrows a Color into a Color32")]

--- a/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Unity/Runtime/Converters/Colors/ColorToColor32Converter.cs
+++ b/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Unity/Runtime/Converters/Colors/ColorToColor32Converter.cs
@@ -1,0 +1,31 @@
+#nullable enable
+using Aspid.FastTools.Types;
+using System;
+using UnityEngine;
+
+// ReSharper disable once CheckNamespace
+namespace Aspid.MVVM.StarterKit
+{
+    /// <summary>
+    /// Narrows a <see cref="Color"/> into a <see cref="Color32"/>.
+    /// </summary>
+    /// <remarks>
+    /// The other direction of <see cref="Color32ToColorConverter"/>: handing a picked colour back to
+    /// something that stores bytes — a mesh's vertex colours, a network message, a save file.
+    /// <para>
+    /// Each channel is clamped to 0..255 and rounded, so an HDR colour loses everything above white
+    /// and the round trip back through <see cref="Color32ToColorConverter"/> is not exact.
+    /// </para>
+    /// </remarks>
+    [Serializable]
+    [TypeSelectorDisplay(Group = "Aspid/Colour", Name = "Color To Color32", Tooltip = "Narrows a Color into a Color32")]
+    public sealed class ColorToColor32Converter : IConverter<Color, Color32>
+    {
+        /// <summary>
+        /// Narrows the specified colour.
+        /// </summary>
+        /// <param name="value">The colour to narrow.</param>
+        /// <returns>The same colour with each channel as a byte.</returns>
+        public Color32 Convert(Color value) => value;
+    }
+}

--- a/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Unity/Runtime/Converters/Colors/ColorToColor32Converter.cs.meta
+++ b/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Unity/Runtime/Converters/Colors/ColorToColor32Converter.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: a4fb4010d7928a44de95002cb0695519

--- a/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Unity/Runtime/Converters/Colors/ColorToColorBlockConverter.cs.meta
+++ b/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Unity/Runtime/Converters/Colors/ColorToColorBlockConverter.cs.meta
@@ -1,2 +1,2 @@
 fileFormatVersion: 2
-guid: 596548b44ae80451eb768f4460088a6d
+guid: a58a04210f7e401fd61350ff5df9c984

--- a/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Unity/Runtime/Converters/Colors/ColorToColorBlockConverter.cs.meta
+++ b/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Unity/Runtime/Converters/Colors/ColorToColorBlockConverter.cs.meta
@@ -1,2 +1,2 @@
 fileFormatVersion: 2
-guid: a58a04210f7e401fd61350ff5df9c984
+guid: 596548b44ae80451eb768f4460088a6d

--- a/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Unity/Runtime/Converters/Colors/ColorToVector4Converter.cs
+++ b/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Unity/Runtime/Converters/Colors/ColorToVector4Converter.cs
@@ -1,0 +1,34 @@
+#nullable enable
+using Aspid.FastTools.Types;
+using System;
+using UnityEngine;
+
+// ReSharper disable once CheckNamespace
+namespace Aspid.MVVM.StarterKit
+{
+    /// <summary>
+    /// Reads a colour as a <see cref="Vector4"/>.
+    /// </summary>
+    /// <remarks>
+    /// A shader property authored as a vector rather than a colour — tint weights, a packed mask, a
+    /// <c>_MainTex_ST</c>-style parameter. The ViewModel keeps the colour it already has, and the
+    /// vector binder on the other side gets the four floats it wants, instead of the two properties
+    /// that were needed for one value.
+    /// <para>
+    /// The channels are copied as they are, with no colour-space conversion: a colour handed to a
+    /// shader as a vector arrives exactly as the ViewModel wrote it, which is what makes the round
+    /// trip through <see cref="Vector4ToColorConverter"/> exact.
+    /// </para>
+    /// </remarks>
+    [Serializable]
+    [TypeSelectorDisplay(Group = "Aspid/Colour", Name = "Color To Vector4", Tooltip = "Reads a colour as a Vector4")]
+    public sealed class ColorToVector4Converter : IConverter<Color, Vector4>
+    {
+        /// <summary>
+        /// Reads the specified colour as a vector.
+        /// </summary>
+        /// <param name="value">The colour to read.</param>
+        /// <returns>Its red, green, blue and alpha as x, y, z and w.</returns>
+        public Vector4 Convert(Color value) => new(value.r, value.g, value.b, value.a);
+    }
+}

--- a/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Unity/Runtime/Converters/Colors/ColorToVector4Converter.cs
+++ b/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Unity/Runtime/Converters/Colors/ColorToVector4Converter.cs
@@ -10,15 +10,8 @@ namespace Aspid.MVVM.StarterKit
     /// Reads a colour as a <see cref="Vector4"/>.
     /// </summary>
     /// <remarks>
-    /// A shader property authored as a vector rather than a colour — tint weights, a packed mask, a
-    /// <c>_MainTex_ST</c>-style parameter. The ViewModel keeps the colour it already has, and the
-    /// vector binder on the other side gets the four floats it wants, instead of the two properties
-    /// that were needed for one value.
-    /// <para>
-    /// The channels are copied as they are, with no colour-space conversion: a colour handed to a
-    /// shader as a vector arrives exactly as the ViewModel wrote it, which is what makes the round
-    /// trip through <see cref="Vector4ToColorConverter"/> exact.
-    /// </para>
+    /// The channels are copied as they are, with no colour-space conversion, which is what makes the
+    /// round trip through <see cref="Vector4ToColorConverter"/> exact.
     /// </remarks>
     [Serializable]
     [TypeSelectorDisplay(Group = "Aspid/Colour", Name = "Color To Vector4", Tooltip = "Reads a colour as a Vector4")]

--- a/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Unity/Runtime/Converters/Colors/ColorToVector4Converter.cs.meta
+++ b/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Unity/Runtime/Converters/Colors/ColorToVector4Converter.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 9928b33a6699d7f87515706199d7b55f

--- a/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Unity/Runtime/Converters/Colors/HdrIntensityConverter.cs
+++ b/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Unity/Runtime/Converters/Colors/HdrIntensityConverter.cs
@@ -1,0 +1,63 @@
+#nullable enable
+using Aspid.FastTools.Types;
+using System;
+using UnityEngine;
+
+// ReSharper disable once CheckNamespace
+namespace Aspid.MVVM.StarterKit
+{
+    /// <summary>
+    /// Pushes a colour above white by an exposure value.
+    /// </summary>
+    /// <remarks>
+    /// Emissive glow driven by a bound number — a charging weapon, an overheating engine, a portal
+    /// that brightens as it opens. A material's emission colour is what bloom reads, and it only
+    /// blooms above one, so the ViewModel would otherwise have to know the exposure maths to send a
+    /// colour a shader can glow with.
+    /// <para>
+    /// The exposure is in stops, matching Unity's own HDR colour field: the picked colour times two
+    /// to the power of the intensity. One stop is twice as bright.
+    /// </para>
+    /// <para>
+    /// The result leaves the 0..1 range on purpose, so it belongs on something that keeps it — a
+    /// material colour through <c>RendererMaterialColorBinder</c>, or a light. A UGUI
+    /// <see cref="UnityEngine.UI.Graphic"/> clamps it and shows no difference above white.
+    /// </para>
+    /// </remarks>
+    [Serializable]
+    [TypeSelectorDisplay(Group = "Aspid/Colour", Name = "Hdr Intensity", Tooltip = "Pushes a colour above white by an exposure value")]
+    public sealed class HdrIntensityConverter : IConverter<Color, Color>
+    {
+        [Tooltip("The exposure applied to the colour, in stops. Each whole step doubles its brightness; zero changes nothing.")]
+        [SerializeField] private float _intensity;
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="HdrIntensityConverter"/> class that changes nothing.
+        /// </summary>
+        public HdrIntensityConverter() { }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="HdrIntensityConverter"/> class.
+        /// </summary>
+        /// <param name="intensity">The exposure applied to the colour, in stops.</param>
+        public HdrIntensityConverter(float intensity)
+        {
+            _intensity = intensity;
+        }
+
+        /// <summary>
+        /// Applies the exposure to the specified colour.
+        /// </summary>
+        /// <param name="value">The colour to brighten.</param>
+        /// <returns>
+        /// The colour scaled by two to the power of the intensity, with its alpha untouched. The
+        /// channels are not clamped — an HDR colour above one is the point.
+        /// </returns>
+        public Color Convert(Color value)
+        {
+            var factor = Mathf.Pow(2f, _intensity);
+
+            return new Color(value.r * factor, value.g * factor, value.b * factor, value.a);
+        }
+    }
+}

--- a/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Unity/Runtime/Converters/Colors/HdrIntensityConverter.cs
+++ b/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Unity/Runtime/Converters/Colors/HdrIntensityConverter.cs
@@ -25,14 +25,8 @@ namespace Aspid.MVVM.StarterKit
         [Tooltip("The exposure applied to the colour, in stops. Each whole step doubles its brightness; zero changes nothing.")]
         [SerializeField] private float _intensity;
 
-        /// <summary>
-        /// Initializes a new instance of the <see cref="HdrIntensityConverter"/> class that changes nothing.
-        /// </summary>
         public HdrIntensityConverter() { }
 
-        /// <summary>
-        /// Initializes a new instance of the <see cref="HdrIntensityConverter"/> class.
-        /// </summary>
         /// <param name="intensity">The exposure applied to the colour, in stops.</param>
         public HdrIntensityConverter(float intensity)
         {

--- a/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Unity/Runtime/Converters/Colors/HdrIntensityConverter.cs
+++ b/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Unity/Runtime/Converters/Colors/HdrIntensityConverter.cs
@@ -10,18 +10,12 @@ namespace Aspid.MVVM.StarterKit
     /// Pushes a colour above white by an exposure value.
     /// </summary>
     /// <remarks>
-    /// Emissive glow driven by a bound number — a charging weapon, an overheating engine, a portal
-    /// that brightens as it opens. A material's emission colour is what bloom reads, and it only
-    /// blooms above one, so the ViewModel would otherwise have to know the exposure maths to send a
-    /// colour a shader can glow with.
+    /// The exposure is in stops, matching Unity's own HDR colour field: the picked colour times two to the
+    /// power of the intensity. One stop is twice as bright.
     /// <para>
-    /// The exposure is in stops, matching Unity's own HDR colour field: the picked colour times two
-    /// to the power of the intensity. One stop is twice as bright.
-    /// </para>
-    /// <para>
-    /// The result leaves the 0..1 range on purpose, so it belongs on something that keeps it — a
-    /// material colour through <c>RendererMaterialColorBinder</c>, or a light. A UGUI
-    /// <see cref="UnityEngine.UI.Graphic"/> clamps it and shows no difference above white.
+    /// The result leaves the 0..1 range on purpose, so it belongs on something that keeps it — a material
+    /// colour or a light. A UGUI <see cref="UnityEngine.UI.Graphic"/> clamps it and shows no difference
+    /// above white.
     /// </para>
     /// </remarks>
     [Serializable]

--- a/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Unity/Runtime/Converters/Colors/HdrIntensityConverter.cs.meta
+++ b/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Unity/Runtime/Converters/Colors/HdrIntensityConverter.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 623761459d3a4914894029be446ed91e

--- a/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Unity/Runtime/Converters/Colors/SelectableStates.cs
+++ b/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Unity/Runtime/Converters/Colors/SelectableStates.cs
@@ -1,0 +1,60 @@
+#nullable enable
+using System;
+using UnityEngine.UI;
+
+// ReSharper disable once CheckNamespace
+namespace Aspid.MVVM.StarterKit
+{
+    /// <summary>
+    /// Which states of a <see cref="ColorBlock"/> a converter writes.
+    /// </summary>
+    /// <remarks>
+    /// The five colours a <see cref="Selectable"/> keeps, as a mask. A converter that writes all of
+    /// them cannot express "everything except disabled", which is the usual shape of a theme: the
+    /// disabled colour says the control is unavailable and must survive the theming that recolours
+    /// the rest.
+    /// </remarks>
+    [Flags]
+    public enum SelectableStates
+    {
+        /// <summary>
+        /// No state.
+        /// </summary>
+        None = 0,
+
+        /// <summary>
+        /// The resting colour.
+        /// </summary>
+        Normal = 1,
+
+        /// <summary>
+        /// The colour under the pointer or the focus.
+        /// </summary>
+        Highlighted = 2,
+
+        /// <summary>
+        /// The colour while held down.
+        /// </summary>
+        Pressed = 4,
+
+        /// <summary>
+        /// The colour once chosen.
+        /// </summary>
+        Selected = 8,
+
+        /// <summary>
+        /// The colour while the control is not interactable.
+        /// </summary>
+        Disabled = 16,
+
+        /// <summary>
+        /// Every state but the disabled one, which usually has to stay readable as itself.
+        /// </summary>
+        Interactive = Normal | Highlighted | Pressed | Selected,
+
+        /// <summary>
+        /// Every state.
+        /// </summary>
+        All = Normal | Highlighted | Pressed | Selected | Disabled,
+    }
+}

--- a/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Unity/Runtime/Converters/Colors/SelectableStates.cs.meta
+++ b/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Unity/Runtime/Converters/Colors/SelectableStates.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 99ee06e793cd04a3d8bf4563f5021394

--- a/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Unity/Runtime/Converters/Colors/ThresholdColorConverter.cs
+++ b/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Unity/Runtime/Converters/Colors/ThresholdColorConverter.cs
@@ -10,12 +10,9 @@ namespace Aspid.MVVM.StarterKit
     /// Picks a colour by which threshold a number has passed.
     /// </summary>
     /// <remarks>
-    /// Stepped states — green, amber, red — rather than a continuous ramp.
-    /// <para>
-    /// Blending turns the same authored stops into that ramp, which is the difference between a
-    /// health bar that snaps at 25% and one that slides towards red as it approaches it. It is off
-    /// by default because the step is what makes a threshold readable as a state.
-    /// </para>
+    /// Stepped states — green, amber, red — rather than a continuous ramp. Blending turns the same
+    /// authored stops into that ramp; it is off by default because the step is what makes a threshold
+    /// readable as a state.
     /// </remarks>
     [Serializable]
     [TypeSelectorDisplay(Group = "Aspid/Colour", Name = "Threshold Color", Tooltip = "Picks a colour by which threshold a number has passed")]

--- a/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Unity/Runtime/Converters/Colors/ThresholdColorConverter.cs
+++ b/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Unity/Runtime/Converters/Colors/ThresholdColorConverter.cs
@@ -9,7 +9,14 @@ namespace Aspid.MVVM.StarterKit
     /// <summary>
     /// Picks a colour by which threshold a number has passed.
     /// </summary>
-    /// <remarks>Stepped states — green, amber, red — rather than a continuous ramp.</remarks>
+    /// <remarks>
+    /// Stepped states — green, amber, red — rather than a continuous ramp.
+    /// <para>
+    /// Blending turns the same authored stops into that ramp, which is the difference between a
+    /// health bar that snaps at 25% and one that slides towards red as it approaches it. It is off
+    /// by default because the step is what makes a threshold readable as a state.
+    /// </para>
+    /// </remarks>
     [Serializable]
     [TypeSelectorDisplay(Group = "Aspid/Colour", Name = "Threshold Color", Tooltip = "Picks a colour by which threshold a number has passed")]
     public sealed class ThresholdColorConverter : IConverter<float, Color>
@@ -20,36 +27,69 @@ namespace Aspid.MVVM.StarterKit
         [Tooltip("Used when the value is below every threshold.")]
         [SerializeField] private Color _fallback = Color.white;
 
+        [Tooltip("Blend towards the next stop up instead of holding this stop's colour until it is reached.")]
+        [SerializeField] private bool _interpolate;
+
         public ThresholdColorConverter() { }
 
         /// <param name="stops">Colours by threshold.</param>
         /// <param name="fallback">Used when the value is below every threshold.</param>
-        public ThresholdColorConverter(ColorStop[]? stops, Color fallback)
+        /// <param name="interpolate">Whether to blend towards the next stop up.</param>
+        public ThresholdColorConverter(ColorStop[]? stops, Color fallback, bool interpolate = false)
         {
             _stops = stops ?? Array.Empty<ColorStop>();
             _fallback = fallback;
+            _interpolate = interpolate;
         }
 
         /// <summary>
         /// Picks the colour for the specified value.
         /// </summary>
         /// <param name="value">The value to place.</param>
-        /// <returns>The colour of the highest qualifying stop, or the fallback.</returns>
+        /// <returns>
+        /// The colour of the highest qualifying stop, or the fallback. When blending, the colour
+        /// between that stop and the next one up, by how far the value has travelled between them.
+        /// </returns>
         public Color Convert(float value)
         {
             if (_stops is not { Length: > 0 }) return _fallback;
 
+            // The stops are authored in whatever order suits the Inspector, so both neighbours are
+            // found in one pass rather than by sorting — which would allocate on every push.
             var color = _fallback;
-            var best = float.NegativeInfinity;
+            var lower = 0f;
+            var hasLower = false;
+
+            var next = default(Color);
+            var upper = 0f;
+            var hasUpper = false;
 
             for (var i = 0; i < _stops.Length; i++)
-                if (value >= _stops[i].Threshold && _stops[i].Threshold > best)
-                {
-                    best = _stops[i].Threshold;
-                    color = _stops[i].Color;
-                }
+            {
+                var threshold = _stops[i].Threshold;
 
-            return color;
+                if (threshold <= value)
+                {
+                    if (hasLower && threshold <= lower) continue;
+
+                    lower = threshold;
+                    color = _stops[i].Color;
+                    hasLower = true;
+                }
+                else
+                {
+                    if (hasUpper && threshold >= upper) continue;
+
+                    upper = threshold;
+                    next = _stops[i].Color;
+                    hasUpper = true;
+                }
+            }
+
+            if (!_interpolate || !hasLower || !hasUpper) return color;
+
+            var span = upper - lower;
+            return span <= 0f ? color : Color.Lerp(color, next, (value - lower) / span);
         }
     }
 }

--- a/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Unity/Runtime/Converters/Colors/ThresholdColorConverter.cs.meta
+++ b/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Unity/Runtime/Converters/Colors/ThresholdColorConverter.cs.meta
@@ -1,2 +1,2 @@
 fileFormatVersion: 2
-guid: 2c1032229caab6ae60d344c7f7a9116e
+guid: 398909b3dda05425ab4848c59dd1f7a1

--- a/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Unity/Runtime/Converters/Colors/Vector4ToColorConverter.cs
+++ b/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Unity/Runtime/Converters/Colors/Vector4ToColorConverter.cs
@@ -1,0 +1,28 @@
+#nullable enable
+using Aspid.FastTools.Types;
+using System;
+using UnityEngine;
+
+// ReSharper disable once CheckNamespace
+namespace Aspid.MVVM.StarterKit
+{
+    /// <summary>
+    /// Reads a <see cref="Vector4"/> as a colour.
+    /// </summary>
+    /// <remarks>
+    /// The other direction of <see cref="ColorToVector4Converter"/>: a ViewModel that already stores
+    /// a vector — one row of a shader parameter table, a value read back off a material — driving a
+    /// colour binder without growing a second property to hold the same four numbers.
+    /// </remarks>
+    [Serializable]
+    [TypeSelectorDisplay(Group = "Aspid/Colour", Name = "Vector4 To Color", Tooltip = "Reads a Vector4 as a colour")]
+    public sealed class Vector4ToColorConverter : IConverter<Vector4, Color>
+    {
+        /// <summary>
+        /// Reads the specified vector as a colour.
+        /// </summary>
+        /// <param name="value">The vector to read.</param>
+        /// <returns>Its x, y, z and w as red, green, blue and alpha, unclamped.</returns>
+        public Color Convert(Vector4 value) => new(value.x, value.y, value.z, value.w);
+    }
+}

--- a/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Unity/Runtime/Converters/Colors/Vector4ToColorConverter.cs.meta
+++ b/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Unity/Runtime/Converters/Colors/Vector4ToColorConverter.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 93c4813daf9c4168ea06ca19f255972b

--- a/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Unity/Runtime/Converters/Enums/EnumBits.cs
+++ b/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Unity/Runtime/Converters/Enums/EnumBits.cs
@@ -9,13 +9,9 @@ namespace Aspid.MVVM.StarterKit
     /// </summary>
     /// <typeparam name="TEnum">The enum type described.</typeparam>
     /// <remarks>
-    /// An unconstrained enum has no non-boxing route to its underlying number, so reading the member
-    /// list per call would allocate once per member on every push. A static field of a generic type
-    /// is per closed type, so each enum pays for the table once, at type load.
-    /// <para>
-    /// <c>EnumMembers</c> in the StarterKit runtime assembly keeps the same table for the converters
-    /// that live beside it, but it is internal to that assembly and so out of reach here.
-    /// </para>
+    /// An unconstrained enum has no non-boxing route to its underlying number, so reading the member list
+    /// per call would allocate once per member on every push. A static field of a generic type is per
+    /// closed type, so each enum pays for the table once, at type load.
     /// </remarks>
     internal static class EnumBits<TEnum>
         where TEnum : struct, Enum

--- a/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Unity/Runtime/Converters/Enums/EnumBits.cs
+++ b/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Unity/Runtime/Converters/Enums/EnumBits.cs
@@ -1,0 +1,76 @@
+#nullable enable
+using System;
+
+// ReSharper disable once CheckNamespace
+namespace Aspid.MVVM.StarterKit
+{
+    /// <summary>
+    /// The bit pattern of every declared member of <typeparamref name="TEnum"/>.
+    /// </summary>
+    /// <typeparam name="TEnum">The enum type described.</typeparam>
+    /// <remarks>
+    /// An unconstrained enum has no non-boxing route to its underlying number, so reading the member
+    /// list per call would allocate once per member on every push. A static field of a generic type
+    /// is per closed type, so each enum pays for the table once, at type load.
+    /// <para>
+    /// <c>EnumMembers</c> in the StarterKit runtime assembly keeps the same table for the converters
+    /// that live beside it, but it is internal to that assembly and so out of reach here.
+    /// </para>
+    /// </remarks>
+    internal static class EnumBits<TEnum>
+        where TEnum : struct, Enum
+    {
+        /// <summary>
+        /// The declared members, in the order <c>Enum.GetValues</c> returns them.
+        /// </summary>
+        internal static readonly TEnum[] Values = (TEnum[])Enum.GetValues(typeof(TEnum));
+
+        /// <summary>
+        /// Whether the enum is marked <see cref="FlagsAttribute"/>, and so meant to be read as bits.
+        /// </summary>
+        internal static readonly bool IsFlags = typeof(TEnum).IsDefined(typeof(FlagsAttribute), inherit: false);
+
+        // Read by BuildBits below. Static initialisers run in declaration order, so moving this under
+        // the field that needs it would leave that one built from a false.
+        private static readonly bool IsUnsigned = Type.GetTypeCode(Enum.GetUnderlyingType(typeof(TEnum)))
+            is TypeCode.Byte or TypeCode.UInt16 or TypeCode.UInt32 or TypeCode.UInt64;
+
+        /// <summary>
+        /// The bit pattern of each member, in the same order as <see cref="Values"/>.
+        /// </summary>
+        internal static readonly ulong[] Bits = BuildBits();
+
+        /// <summary>
+        /// Reads a value as a bit pattern.
+        /// </summary>
+        /// <param name="value">The value to read.</param>
+        /// <returns>Its underlying number, widened to 64 bits.</returns>
+        /// <remarks>
+        /// The two conversions cover different halves of the range: <c>ToInt64</c> takes every signed
+        /// underlying type without overflowing, <c>ToUInt64</c> does the same for the unsigned ones,
+        /// where a member past <c>long.MaxValue</c> would make <c>ToInt64</c> throw. Both box,
+        /// which is why every caller here reaches this only when its cache has missed.
+        /// </remarks>
+        internal static ulong BitsOf(TEnum value) => IsUnsigned
+            ? System.Convert.ToUInt64(value)
+            : unchecked((ulong)System.Convert.ToInt64(value));
+
+        /// <summary>
+        /// Builds the value a bit pattern stands for.
+        /// </summary>
+        /// <param name="bits">The bit pattern.</param>
+        /// <returns>
+        /// The enum value holding those bits. Bits above the enum's underlying width are dropped, the
+        /// same way an assignment in code would drop them.
+        /// </returns>
+        internal static TEnum FromBits(ulong bits) => (TEnum)Enum.ToObject(typeof(TEnum), bits);
+
+        private static ulong[] BuildBits()
+        {
+            var bits = new ulong[Values.Length];
+            for (var i = 0; i < Values.Length; i++) bits[i] = BitsOf(Values[i]);
+
+            return bits;
+        }
+    }
+}

--- a/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Unity/Runtime/Converters/Enums/EnumBits.cs.meta
+++ b/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Unity/Runtime/Converters/Enums/EnumBits.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: f3a215ba116f9814734b852ce07d5064

--- a/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Unity/Runtime/Converters/Enums/EnumFlagsToStringConverter.cs
+++ b/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Unity/Runtime/Converters/Enums/EnumFlagsToStringConverter.cs
@@ -13,35 +13,20 @@ namespace Aspid.MVVM.StarterKit
     /// </summary>
     /// <typeparam name="TEnum">The enum type being named.</typeparam>
     /// <remarks>
-    /// A damage mask, an unlocked-ability set or a list of active status effects reaching the UI as
-    /// "Fire, Ice, Poison". Written in the ViewModel instead, the summary drags the separator and the
-    /// wording of the empty case into logic that is otherwise about the fight.
-    /// <para>
     /// <see cref="EnumToStringConverter{TEnum}"/> names one member and returns its fallback for a
-    /// combination, because a combination is not a declared member. This is the converter that takes
-    /// the value apart first, and it asks that one for each piece — so a member's
-    /// <see cref="InspectorNameAttribute"/> or
-    /// <see cref="System.ComponentModel.DescriptionAttribute"/> reads the same here as it does there.
+    /// combination; this takes the value apart first and asks that one for each piece, so a member's
+    /// <see cref="InspectorNameAttribute"/> reads the same here as it does there.
+    /// <para>
+    /// Members are read in the order <c>Enum.GetValues</c> returns them — by unsigned underlying value,
+    /// never declaration order — and each consumes the bits it names. A composite member always sorts
+    /// after its parts, so it is named only when the bits it covers are not declared members of their
+    /// own, and a member covering one declared bit and one undeclared one is skipped, leaving that bit
+    /// unnamed. On an enum not marked <see cref="FlagsAttribute"/> the value is named whole and the
+    /// separator goes unused.
     /// </para>
     /// <para>
-    /// Members are read in the order <c>Enum.GetValues</c> returns them — by unsigned underlying
-    /// value, never declaration order — and each consumes the bits it names. A composite member,
-    /// <c>All = Fire | Ice | Poison</c>, carries every bit its parts carry and so always sorts after
-    /// them: it is named only when the bits it covers are not declared members of their own, and
-    /// moving it up the enum cannot change that. A member covering one declared bit and one
-    /// undeclared one is skipped the same way, leaving the undeclared bit unnamed.
-    /// </para>
-    /// <para>
-    /// On an enum not marked <see cref="FlagsAttribute"/> the value is one member rather than a set
-    /// of bits, so it is named whole and the separator goes unused: splitting the number would name
-    /// whichever members happen to sit inside it.
-    /// </para>
-    /// <para>
-    /// The previous text is reused while the value is unchanged: a binder pushes on every
-    /// notification, and a summary rebuilt on each one would allocate a string per push. Only the
-    /// last value is remembered, so a source alternating between two values rebuilds on every push.
-    /// An edit to the separator or the empty text while the game is running therefore reaches the
-    /// View on the next value that differs, not on the next push.
+    /// The previous text is reused while the value is unchanged, so an edit to the separator or the
+    /// empty text while the game is running reaches the View on the next value that differs.
     /// </para>
     /// </remarks>
     [Serializable]

--- a/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Unity/Runtime/Converters/Enums/EnumFlagsToStringConverter.cs
+++ b/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Unity/Runtime/Converters/Enums/EnumFlagsToStringConverter.cs
@@ -51,14 +51,9 @@ namespace Aspid.MVVM.StarterKit
         [NonSerialized] private TEnum _cachedValue;
         [NonSerialized] private string _cachedText = string.Empty;
 
-        /// <summary>
-        /// Initializes a new instance of the <see cref="EnumFlagsToStringConverter{TEnum}"/> class joining with commas.
-        /// </summary>
+        /// <remarks>Default: joining with commas.</remarks>
         public EnumFlagsToStringConverter() { }
 
-        /// <summary>
-        /// Initializes a new instance of the <see cref="EnumFlagsToStringConverter{TEnum}"/> class.
-        /// </summary>
         /// <param name="separator">Placed between the named flags.</param>
         /// <param name="source">Where the name of each flag comes from.</param>
         /// <param name="noneText">Shown when the value names no flags.</param>

--- a/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Unity/Runtime/Converters/Enums/EnumFlagsToStringConverter.cs
+++ b/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Unity/Runtime/Converters/Enums/EnumFlagsToStringConverter.cs
@@ -1,0 +1,168 @@
+#nullable enable
+using Aspid.FastTools.Types;
+using System;
+using System.Text;
+using UnityEngine;
+using System.Collections.Generic;
+
+// ReSharper disable once CheckNamespace
+namespace Aspid.MVVM.StarterKit
+{
+    /// <summary>
+    /// Names the flags a value carries.
+    /// </summary>
+    /// <typeparam name="TEnum">The enum type being named.</typeparam>
+    /// <remarks>
+    /// A damage mask, an unlocked-ability set or a list of active status effects reaching the UI as
+    /// "Fire, Ice, Poison". Written in the ViewModel instead, the summary drags the separator and the
+    /// wording of the empty case into logic that is otherwise about the fight.
+    /// <para>
+    /// <see cref="EnumToStringConverter{TEnum}"/> names one member and returns its fallback for a
+    /// combination, because a combination is not a declared member. This is the converter that takes
+    /// the value apart first, and it asks that one for each piece — so a member's
+    /// <see cref="InspectorNameAttribute"/> or
+    /// <see cref="System.ComponentModel.DescriptionAttribute"/> reads the same here as it does there.
+    /// </para>
+    /// <para>
+    /// Members are read in the order <c>Enum.GetValues</c> returns them — by unsigned underlying
+    /// value, never declaration order — and each consumes the bits it names. A composite member,
+    /// <c>All = Fire | Ice | Poison</c>, carries every bit its parts carry and so always sorts after
+    /// them: it is named only when the bits it covers are not declared members of their own, and
+    /// moving it up the enum cannot change that. A member covering one declared bit and one
+    /// undeclared one is skipped the same way, leaving the undeclared bit unnamed.
+    /// </para>
+    /// <para>
+    /// On an enum not marked <see cref="FlagsAttribute"/> the value is one member rather than a set
+    /// of bits, so it is named whole and the separator goes unused: splitting the number would name
+    /// whichever members happen to sit inside it.
+    /// </para>
+    /// <para>
+    /// The previous text is reused while the value is unchanged: a binder pushes on every
+    /// notification, and a summary rebuilt on each one would allocate a string per push. Only the
+    /// last value is remembered, so a source alternating between two values rebuilds on every push.
+    /// An edit to the separator or the empty text while the game is running therefore reaches the
+    /// View on the next value that differs, not on the next push.
+    /// </para>
+    /// </remarks>
+    [Serializable]
+    [TypeSelectorDisplay(Group = "Aspid/Enum", Name = "Enum Flags To String", Tooltip = "Names the flags a value carries")]
+    public sealed class EnumFlagsToStringConverter<TEnum> : IConverter<TEnum, string>
+        where TEnum : struct, Enum
+    {
+        [Tooltip("Placed between the named flags. Unused on an enum not marked [Flags], where the value names one member rather than a set of bits.")]
+        [SerializeField] private string _separator = ", ";
+
+        [Tooltip("Where the name of each flag comes from.")]
+        [SerializeField] private EnumNameSource _source;
+
+        [Tooltip("Shown when the value names no flags.")]
+        [SerializeField] private string _noneText = string.Empty;
+
+        [NonSerialized] private StringBuilder? _builder;
+        [NonSerialized] private EnumToStringConverter<TEnum>? _names;
+        [NonSerialized] private EnumNameSource _namedSource;
+
+        [NonSerialized] private bool _hasCache;
+        [NonSerialized] private TEnum _cachedValue;
+        [NonSerialized] private string _cachedText = string.Empty;
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="EnumFlagsToStringConverter{TEnum}"/> class joining with commas.
+        /// </summary>
+        public EnumFlagsToStringConverter() { }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="EnumFlagsToStringConverter{TEnum}"/> class.
+        /// </summary>
+        /// <param name="separator">Placed between the named flags.</param>
+        /// <param name="source">Where the name of each flag comes from.</param>
+        /// <param name="noneText">Shown when the value names no flags.</param>
+        public EnumFlagsToStringConverter(
+            string separator,
+            EnumNameSource source = EnumNameSource.Name,
+            string noneText = "")
+        {
+            _separator = separator;
+            _source = source;
+            _noneText = noneText;
+        }
+
+        /// <summary>
+        /// Names the flags the specified value carries.
+        /// </summary>
+        /// <param name="value">The value to take apart.</param>
+        /// <returns>
+        /// The names of the flags it carries, joined by the separator, or the empty text when it
+        /// carries none. On an enum not marked <see cref="FlagsAttribute"/> the value names one
+        /// member and the separator is unused. The same string is returned while the value is
+        /// unchanged.
+        /// </returns>
+        /// <exception cref="ArgumentOutOfRangeException">Thrown when the name source is not a declared value.</exception>
+        public string Convert(TEnum value)
+        {
+            if (_hasCache
+                && _namedSource == _source
+                && EqualityComparer<TEnum>.Default.Equals(_cachedValue, value))
+                return _cachedText;
+
+            _cachedText = Build(value);
+            _cachedValue = value;
+            _hasCache = true;
+
+            return _cachedText;
+        }
+
+        private string Build(TEnum value)
+        {
+            var names = Names();
+
+            // Reading a value bit by bit only means anything on an enum whose members are bits. On
+            // any other enum the number is one member's value, and splitting it would name whichever
+            // members happen to sit inside it — so the plain name is the only sensible reading.
+            if (!EnumBits<TEnum>.IsFlags)
+            {
+                var single = names.Convert(value);
+                return string.IsNullOrEmpty(single) ? _noneText : single;
+            }
+
+            var remaining = EnumBits<TEnum>.BitsOf(value);
+            if (remaining == 0) return _noneText;
+
+            _builder ??= new StringBuilder();
+            _builder.Clear();
+
+            var members = EnumBits<TEnum>.Values;
+            var bits = EnumBits<TEnum>.Bits;
+            var written = 0;
+
+            for (var i = 0; i < members.Length; i++)
+            {
+                // A member declared as zero names the absence of every flag, which the empty text
+                // covers above. Matched here it would be named by every value instead.
+                if (bits[i] == 0) continue;
+                if ((remaining & bits[i]) != bits[i]) continue;
+
+                if (written > 0) _builder.Append(_separator);
+                _builder.Append(names.Convert(members[i]));
+
+                remaining &= ~bits[i];
+                written++;
+            }
+
+            // Bits no member declares have no name to give. Writing the leftover number instead would
+            // put something in the middle of a sentence that reads as a bug rather than as data.
+            return written == 0 ? _noneText : _builder.ToString();
+        }
+
+        // Held rather than rebuilt so the reflection behind InspectorName and Description is paid
+        // once. The source is checked because it is serialized, so the Inspector can change it
+        // between two pushes.
+        private EnumToStringConverter<TEnum> Names()
+        {
+            if (_names is not null && _namedSource == _source) return _names;
+
+            _namedSource = _source;
+            return _names = new EnumToStringConverter<TEnum>(_source);
+        }
+    }
+}

--- a/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Unity/Runtime/Converters/Enums/EnumFlagsToStringConverter.cs.meta
+++ b/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Unity/Runtime/Converters/Enums/EnumFlagsToStringConverter.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 4dcc4dee7b104f0dabf6b53865a13c61

--- a/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Unity/Runtime/Converters/Enums/EnumMaskConverter.cs
+++ b/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Unity/Runtime/Converters/Enums/EnumMaskConverter.cs
@@ -38,14 +38,8 @@ namespace Aspid.MVVM.StarterKit
         [NonSerialized] private TEnum _cachedResult;
         [NonSerialized] private EnumMaskOperation _cachedOperation;
 
-        /// <summary>
-        /// Initializes a new instance of the <see cref="EnumMaskConverter{TEnum}"/> class with an empty mask.
-        /// </summary>
         public EnumMaskConverter() { }
 
-        /// <summary>
-        /// Initializes a new instance of the <see cref="EnumMaskConverter{TEnum}"/> class.
-        /// </summary>
         /// <param name="mask">The flags the bound value is combined with.</param>
         /// <param name="operation">What is done with the flags <paramref name="mask"/> names.</param>
         public EnumMaskConverter(TEnum mask, EnumMaskOperation operation = EnumMaskOperation.And)

--- a/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Unity/Runtime/Converters/Enums/EnumMaskConverter.cs
+++ b/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Unity/Runtime/Converters/Enums/EnumMaskConverter.cs
@@ -12,25 +12,13 @@ namespace Aspid.MVVM.StarterKit
     /// </summary>
     /// <typeparam name="TEnum">The enum type being combined.</typeparam>
     /// <remarks>
-    /// One panel shows the elemental damage of an attack while another shows the physical part of the
-    /// same value. Both read one property, and the choice of which flags each cares about is the
-    /// View's business — as a mask on the binder it is authored beside the panel it belongs to,
-    /// rather than as a second filtered property on the ViewModel.
-    /// <para>
     /// Chained ahead of <see cref="EnumFlagsToStringConverter{TEnum}"/> or
-    /// <see cref="EnumToBoolConverter{TEnum}"/> it narrows what those see, which is what makes it
-    /// worth a node of its own rather than an option on each of them.
-    /// </para>
+    /// <see cref="EnumToBoolConverter{TEnum}"/> it narrows what those see.
     /// <para>
-    /// On an enum not marked <see cref="FlagsAttribute"/> the value passes through untouched: its
-    /// number is one member's value rather than a set of bits, and combining it would blank the
-    /// value or produce a number no member declares.
-    /// </para>
-    /// <para>
-    /// The previous result is reused while the value, the mask and the operation are unchanged: an
-    /// enum has no non-boxing route back from its bits, so a mask applied on every push would
-    /// allocate on every notification. Only the last input is remembered, so a source alternating
-    /// between two values pays for both.
+    /// On an enum not marked <see cref="FlagsAttribute"/> the value passes through untouched: its number
+    /// is one member's value rather than a set of bits. The previous result is reused while the value,
+    /// the mask and the operation are unchanged, because an enum has no non-boxing route back from its
+    /// bits — only the last input is remembered, so a source alternating between two values pays for both.
     /// </para>
     /// </remarks>
     [Serializable]

--- a/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Unity/Runtime/Converters/Enums/EnumMaskConverter.cs
+++ b/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Unity/Runtime/Converters/Enums/EnumMaskConverter.cs
@@ -1,0 +1,121 @@
+#nullable enable
+using Aspid.FastTools.Types;
+using System;
+using UnityEngine;
+using System.Collections.Generic;
+
+// ReSharper disable once CheckNamespace
+namespace Aspid.MVVM.StarterKit
+{
+    /// <summary>
+    /// Combines a bound flags value with an authored mask.
+    /// </summary>
+    /// <typeparam name="TEnum">The enum type being combined.</typeparam>
+    /// <remarks>
+    /// One panel shows the elemental damage of an attack while another shows the physical part of the
+    /// same value. Both read one property, and the choice of which flags each cares about is the
+    /// View's business — as a mask on the binder it is authored beside the panel it belongs to,
+    /// rather than as a second filtered property on the ViewModel.
+    /// <para>
+    /// Chained ahead of <see cref="EnumFlagsToStringConverter{TEnum}"/> or
+    /// <see cref="EnumToBoolConverter{TEnum}"/> it narrows what those see, which is what makes it
+    /// worth a node of its own rather than an option on each of them.
+    /// </para>
+    /// <para>
+    /// On an enum not marked <see cref="FlagsAttribute"/> the value passes through untouched: its
+    /// number is one member's value rather than a set of bits, and combining it would blank the
+    /// value or produce a number no member declares.
+    /// </para>
+    /// <para>
+    /// The previous result is reused while the value, the mask and the operation are unchanged: an
+    /// enum has no non-boxing route back from its bits, so a mask applied on every push would
+    /// allocate on every notification. Only the last input is remembered, so a source alternating
+    /// between two values pays for both.
+    /// </para>
+    /// </remarks>
+    [Serializable]
+    [TypeSelectorDisplay(Group = "Aspid/Enum", Name = "Enum Mask", Tooltip = "Combines a bound flags value with an authored mask")]
+    public sealed class EnumMaskConverter<TEnum> : IConverter<TEnum, TEnum>
+        where TEnum : struct, Enum
+    {
+        [Tooltip("The flags the bound value is combined with. Nothing is combined on an enum not marked [Flags], where the value passes through unchanged.")]
+        [SerializeField] private TEnum _mask;
+
+        [Tooltip("What is done with the flags the mask names.")]
+        [SerializeField] private EnumMaskOperation _operation;
+
+        [NonSerialized] private bool _hasCache;
+        [NonSerialized] private TEnum _cachedValue;
+        [NonSerialized] private TEnum _cachedMask;
+        [NonSerialized] private TEnum _cachedResult;
+        [NonSerialized] private EnumMaskOperation _cachedOperation;
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="EnumMaskConverter{TEnum}"/> class with an empty mask.
+        /// </summary>
+        public EnumMaskConverter() { }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="EnumMaskConverter{TEnum}"/> class.
+        /// </summary>
+        /// <param name="mask">The flags the bound value is combined with.</param>
+        /// <param name="operation">What is done with the flags <paramref name="mask"/> names.</param>
+        public EnumMaskConverter(TEnum mask, EnumMaskOperation operation = EnumMaskOperation.And)
+        {
+            _mask = mask;
+            _operation = operation;
+        }
+
+        /// <summary>
+        /// Applies the authored mask to the specified value.
+        /// </summary>
+        /// <param name="value">The value to combine with the mask.</param>
+        /// <returns>
+        /// The combined value. It need not be a declared member: a combination of flags is a legal
+        /// value the member list does not hold, which is the whole point of the type. On an enum not
+        /// marked <see cref="FlagsAttribute"/> the value is returned unchanged.
+        /// </returns>
+        /// <exception cref="ArgumentOutOfRangeException">Thrown when the operation is not a declared value.</exception>
+        public TEnum Convert(TEnum value)
+        {
+            // Combining bit by bit only means anything on an enum whose members are bits. On any
+            // other enum the number is one member's value: masking it would either blank it or hand
+            // the View a number no member declares, which is not a reading of the value at all.
+            if (!EnumBits<TEnum>.IsFlags) return value;
+
+            var comparer = EqualityComparer<TEnum>.Default;
+
+            // The mask and the operation are serialized, so the Inspector can change either between
+            // two pushes of the same value. Comparing them costs nothing next to what it guards.
+            if (_hasCache
+                && _cachedOperation == _operation
+                && comparer.Equals(_cachedValue, value)
+                && comparer.Equals(_cachedMask, _mask))
+                return _cachedResult;
+
+            var bits = EnumBits<TEnum>.BitsOf(value);
+            var mask = EnumBits<TEnum>.BitsOf(_mask);
+
+            var combined = _operation switch
+            {
+                EnumMaskOperation.And => bits & mask,
+                EnumMaskOperation.Or => bits | mask,
+                EnumMaskOperation.Xor => bits ^ mask,
+                // The complement sets every bit above the enum's own width, and the AND keeps them
+                // whenever the value carries them too — a member holding the sign bit of a signed
+                // underlying type sign-extends into all of them. FromBits truncates to that width,
+                // which is what makes this safe; the AND alone does not.
+                EnumMaskOperation.Clear => bits & ~mask,
+                _ => throw new ArgumentOutOfRangeException(nameof(_operation), _operation, null)
+            };
+
+            _cachedResult = EnumBits<TEnum>.FromBits(combined);
+            _cachedOperation = _operation;
+            _cachedValue = value;
+            _cachedMask = _mask;
+            _hasCache = true;
+
+            return _cachedResult;
+        }
+    }
+}

--- a/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Unity/Runtime/Converters/Enums/EnumMaskConverter.cs.meta
+++ b/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Unity/Runtime/Converters/Enums/EnumMaskConverter.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 0b2232942383aab876f669b85a75b22e

--- a/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Unity/Runtime/Converters/Enums/EnumMaskOperation.cs
+++ b/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Unity/Runtime/Converters/Enums/EnumMaskOperation.cs
@@ -1,0 +1,35 @@
+#nullable enable
+
+// ReSharper disable once CheckNamespace
+namespace Aspid.MVVM.StarterKit
+{
+    /// <summary>
+    /// What <see cref="EnumMaskConverter{TEnum}"/> does with the flags it is given.
+    /// </summary>
+    /// <remarks>
+    /// New members are appended rather than inserted: the order is the serialized value, so moving
+    /// one silently rewrites every converter already authored in a scene.
+    /// </remarks>
+    public enum EnumMaskOperation
+    {
+        /// <summary>
+        /// Keep only the flags the mask names.
+        /// </summary>
+        And,
+
+        /// <summary>
+        /// Add the flags the mask names.
+        /// </summary>
+        Or,
+
+        /// <summary>
+        /// Flip the flags the mask names.
+        /// </summary>
+        Xor,
+
+        /// <summary>
+        /// Remove the flags the mask names.
+        /// </summary>
+        Clear,
+    }
+}

--- a/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Unity/Runtime/Converters/Enums/EnumMaskOperation.cs.meta
+++ b/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Unity/Runtime/Converters/Enums/EnumMaskOperation.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: dcb5855dcc893445f9c5a4c1680ae6e1

--- a/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Unity/Runtime/Converters/Rotations/AngleDifferenceConverter.cs
+++ b/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Unity/Runtime/Converters/Rotations/AngleDifferenceConverter.cs
@@ -1,0 +1,59 @@
+#nullable enable
+using Aspid.FastTools.Types;
+using System;
+using UnityEngine;
+
+// The named converter aliases are [Obsolete]. The converters below keep implementing them for
+// one release so that a [SerializeReference] field a project declares as one still
+// deserializes; the base lists go with the aliases in the next major.
+#pragma warning disable CS0618 // Type or member is obsolete
+
+// ReSharper disable once CheckNamespace
+namespace Aspid.MVVM.StarterKit
+{
+    /// <summary>
+    /// Measures how far an angle is from a fixed one.
+    /// </summary>
+    /// <remarks>
+    /// Compass deviation, or how far a turret has swung off its rest heading. Subtracting the two
+    /// looks trivial until they straddle zero, where the plain difference reads 358° for what is
+    /// really two degrees the other way.
+    /// </remarks>
+    [Serializable]
+    [TypeSelectorDisplay(Group = "Aspid/Rotation", Name = "Angle Difference", Tooltip = "Measures how far an angle is from a fixed one")]
+    public sealed class AngleDifferenceConverter : IConverterFloat
+    {
+        [Tooltip("The angle the bound one is measured against, in degrees.")]
+        [SerializeField] private float _reference;
+
+        [Tooltip("Keep the sign. Clear it to report how far off the angle is whichever way it went.")]
+        [SerializeField] private bool _signed = true;
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="AngleDifferenceConverter"/> class measuring from zero.
+        /// </summary>
+        public AngleDifferenceConverter() { }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="AngleDifferenceConverter"/> class.
+        /// </summary>
+        /// <param name="reference">The angle the bound one is measured against, in degrees.</param>
+        /// <param name="signed">Whether to keep the sign of the difference.</param>
+        public AngleDifferenceConverter(float reference, bool signed = true)
+        {
+            _reference = reference;
+            _signed = signed;
+        }
+
+        /// <summary>
+        /// Measures the specified angle against the reference.
+        /// </summary>
+        /// <param name="value">The angle, in degrees.</param>
+        /// <returns>The shortest way round from the reference to it, in degrees.</returns>
+        public float Convert(float value)
+        {
+            var difference = Mathf.DeltaAngle(_reference, value);
+            return _signed ? difference : Mathf.Abs(difference);
+        }
+    }
+}

--- a/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Unity/Runtime/Converters/Rotations/AngleDifferenceConverter.cs
+++ b/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Unity/Runtime/Converters/Rotations/AngleDifferenceConverter.cs
@@ -29,14 +29,9 @@ namespace Aspid.MVVM.StarterKit
         [Tooltip("Keep the sign. Clear it to report how far off the angle is whichever way it went.")]
         [SerializeField] private bool _signed = true;
 
-        /// <summary>
-        /// Initializes a new instance of the <see cref="AngleDifferenceConverter"/> class measuring from zero.
-        /// </summary>
+        /// <remarks>Default: measuring from zero.</remarks>
         public AngleDifferenceConverter() { }
 
-        /// <summary>
-        /// Initializes a new instance of the <see cref="AngleDifferenceConverter"/> class.
-        /// </summary>
         /// <param name="reference">The angle the bound one is measured against, in degrees.</param>
         /// <param name="signed">Whether to keep the sign of the difference.</param>
         public AngleDifferenceConverter(float reference, bool signed = true)

--- a/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Unity/Runtime/Converters/Rotations/AngleDifferenceConverter.cs.meta
+++ b/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Unity/Runtime/Converters/Rotations/AngleDifferenceConverter.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 2849cfe6d2a2ba6dd18ffa50ba37b798

--- a/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Unity/Runtime/Converters/Rotations/AngleToQuaternionConverter.cs
+++ b/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Unity/Runtime/Converters/Rotations/AngleToQuaternionConverter.cs
@@ -47,10 +47,7 @@ namespace Aspid.MVVM.StarterKit
             _clockwise = clockwise;
         }
 
-        /// <summary>
-        /// Initializes a new instance of the <see cref="AngleToQuaternionConverter"/> class turning
-        /// around an arbitrary axis.
-        /// </summary>
+        /// <remarks>Default: turning around an arbitrary axis.</remarks>
         /// <param name="customAxis">The axis the angle turns around.</param>
         /// <param name="offset">Added to the angle before it is applied.</param>
         /// <param name="clockwise">If <see langword="true"/>, turns the other way.</param>

--- a/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Unity/Runtime/Converters/Rotations/AngleToQuaternionConverter.cs
+++ b/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Unity/Runtime/Converters/Rotations/AngleToQuaternionConverter.cs
@@ -25,6 +25,9 @@ namespace Aspid.MVVM.StarterKit
         [Tooltip("The axis the angle turns around. Z is the one a 2D UI element spins on.")]
         [SerializeField] private RotationAxis _axis = RotationAxis.Z;
 
+        [Tooltip("The axis the angle turns around when the axis above is set to Custom.")]
+        [SerializeField] private Vector3 _customAxis = Vector3.up;
+
         [Tooltip("Added to the angle before it is applied.")]
         [SerializeField] private float _offset;
 
@@ -45,6 +48,21 @@ namespace Aspid.MVVM.StarterKit
         }
 
         /// <summary>
+        /// Initializes a new instance of the <see cref="AngleToQuaternionConverter"/> class turning
+        /// around an arbitrary axis.
+        /// </summary>
+        /// <param name="customAxis">The axis the angle turns around.</param>
+        /// <param name="offset">Added to the angle before it is applied.</param>
+        /// <param name="clockwise">If <see langword="true"/>, turns the other way.</param>
+        public AngleToQuaternionConverter(Vector3 customAxis, float offset = 0f, bool clockwise = false)
+        {
+            _axis = RotationAxis.Custom;
+            _customAxis = customAxis;
+            _offset = offset;
+            _clockwise = clockwise;
+        }
+
+        /// <summary>
         /// Turns the specified angle into a rotation.
         /// </summary>
         /// <param name="value">The angle, in degrees.</param>
@@ -59,6 +77,7 @@ namespace Aspid.MVVM.StarterKit
                 RotationAxis.X => Quaternion.Euler(angle, 0f, 0f),
                 RotationAxis.Y => Quaternion.Euler(0f, angle, 0f),
                 RotationAxis.Z => Quaternion.Euler(0f, 0f, angle),
+                RotationAxis.Custom => CustomRotation(angle),
                 _ => throw new ArgumentOutOfRangeException(nameof(_axis), _axis, null)
             };
         }
@@ -68,6 +87,7 @@ namespace Aspid.MVVM.StarterKit
         /// </summary>
         /// <param name="value">The rotation to read.</param>
         /// <returns>The angle, in degrees.</returns>
+        /// <exception cref="ArgumentOutOfRangeException">Thrown when the axis is not a declared value.</exception>
         public float ConvertBack(Quaternion value)
         {
             var euler = value.eulerAngles;
@@ -77,11 +97,32 @@ namespace Aspid.MVVM.StarterKit
                 RotationAxis.X => euler.x,
                 RotationAxis.Y => euler.y,
                 RotationAxis.Z => euler.z,
+                RotationAxis.Custom => CustomAngle(value),
                 _ => throw new ArgumentOutOfRangeException(nameof(_axis), _axis, null)
             };
 
             angle -= _offset;
             return _clockwise ? -angle : angle;
+        }
+
+        // AngleAxis normalises the axis for us, and it already answers a zero axis with the
+        // identity, so this branch changes no result today. It is here because an axis nobody
+        // filled in is the ordinary way to reach this method and the identity is what the converter
+        // means to return there — said at the call site rather than left resting on a Unity
+        // behaviour the reader has to go and confirm.
+        private Quaternion CustomRotation(float angle) => _customAxis.sqrMagnitude <= Mathf.Epsilon
+            ? Quaternion.identity
+            : Quaternion.AngleAxis(angle, _customAxis);
+
+        // ToAngleAxis always reports a positive turn, flipping the axis when that is what it takes,
+        // so the axis it returns can be the opposite of the authored one. The dot picks which of the
+        // two equivalent readings is the one the author asked for.
+        private float CustomAngle(Quaternion value)
+        {
+            if (_customAxis.sqrMagnitude <= Mathf.Epsilon) return 0f;
+
+            value.ToAngleAxis(out var angle, out var axis);
+            return Vector3.Dot(axis, _customAxis) < 0f ? -angle : angle;
         }
     }
 }

--- a/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Unity/Runtime/Converters/Rotations/QuaternionSlerpConverter.cs
+++ b/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Unity/Runtime/Converters/Rotations/QuaternionSlerpConverter.cs
@@ -1,0 +1,76 @@
+#nullable enable
+using Aspid.FastTools.Types;
+using System;
+using UnityEngine;
+
+// ReSharper disable once CheckNamespace
+namespace Aspid.MVVM.StarterKit
+{
+    /// <summary>
+    /// Turns between two rotations by a 0..1 amount.
+    /// </summary>
+    /// <remarks>
+    /// A lid that swings open as a progress value advances, a gauge that sweeps between two stops.
+    /// The rotation counterpart of <see cref="VectorLerpConverter"/>, and slerp rather than lerp
+    /// because interpolating the four numbers of a rotation directly makes the turn speed up in the
+    /// middle.
+    /// <para>
+    /// Both ends are authored as Euler angles: a serialized <see cref="Quaternion"/> shows four raw
+    /// numbers in the Inspector, and nobody sets those by hand.
+    /// </para>
+    /// </remarks>
+    [Serializable]
+    [TypeSelectorDisplay(Group = "Aspid/Rotation", Name = "Quaternion Slerp", Tooltip = "Turns between two rotations by a 0..1 amount")]
+    public sealed class QuaternionSlerpConverter : IConverter<float, Quaternion>
+    {
+        [Tooltip("The rotation at 0, in Euler degrees.")]
+        [SerializeField] private Vector3 _fromEuler;
+
+        [Tooltip("The rotation at 1, in Euler degrees.")]
+        [SerializeField] private Vector3 _toEuler;
+
+        [Tooltip("Shapes the amount before the turn. Leave it empty for an even sweep.")]
+        [SerializeField] private AnimationCurve? _curve;
+
+        [Tooltip("Hold the incoming amount inside 0..1.")]
+        [SerializeField] private bool _clamp = true;
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="QuaternionSlerpConverter"/> class turning nowhere.
+        /// </summary>
+        public QuaternionSlerpConverter() { }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="QuaternionSlerpConverter"/> class.
+        /// </summary>
+        /// <param name="fromEuler">The rotation at 0, in Euler degrees.</param>
+        /// <param name="toEuler">The rotation at 1, in Euler degrees.</param>
+        /// <param name="curve">Shapes the amount before the turn, or <see langword="null"/> for an even sweep.</param>
+        public QuaternionSlerpConverter(Vector3 fromEuler, Vector3 toEuler, AnimationCurve? curve = null)
+        {
+            _fromEuler = fromEuler;
+            _toEuler = toEuler;
+            _curve = curve;
+        }
+
+        /// <summary>
+        /// Reads the rotation at the specified amount.
+        /// </summary>
+        /// <param name="value">The 0..1 amount.</param>
+        /// <returns>The rotation there.</returns>
+        public Quaternion Convert(float value)
+        {
+            // An unassigned curve deserializes as an empty one rather than as null, and evaluating
+            // an empty curve returns zero — which would pin the rotation at its starting end
+            // instead of leaving the amount alone. Both spellings of "no curve" mean the same thing.
+            var amount = _curve is null || _curve.length == 0 ? value : _curve.Evaluate(value);
+
+            var from = Quaternion.Euler(_fromEuler);
+            var to = Quaternion.Euler(_toEuler);
+
+            return _clamp
+                ? Quaternion.Slerp(from, to, amount)
+                : Quaternion.SlerpUnclamped(from, to, amount);
+        }
+    }
+}

--- a/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Unity/Runtime/Converters/Rotations/QuaternionSlerpConverter.cs
+++ b/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Unity/Runtime/Converters/Rotations/QuaternionSlerpConverter.cs
@@ -30,14 +30,8 @@ namespace Aspid.MVVM.StarterKit
         [Tooltip("Hold the incoming amount inside 0..1.")]
         [SerializeField] private bool _clamp = true;
 
-        /// <summary>
-        /// Initializes a new instance of the <see cref="QuaternionSlerpConverter"/> class turning nowhere.
-        /// </summary>
         public QuaternionSlerpConverter() { }
 
-        /// <summary>
-        /// Initializes a new instance of the <see cref="QuaternionSlerpConverter"/> class.
-        /// </summary>
         /// <param name="fromEuler">The rotation at 0, in Euler degrees.</param>
         /// <param name="toEuler">The rotation at 1, in Euler degrees.</param>
         /// <param name="curve">Shapes the amount before the turn, or <see langword="null"/> for an even sweep.</param>

--- a/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Unity/Runtime/Converters/Rotations/QuaternionSlerpConverter.cs
+++ b/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Unity/Runtime/Converters/Rotations/QuaternionSlerpConverter.cs
@@ -10,14 +10,9 @@ namespace Aspid.MVVM.StarterKit
     /// Turns between two rotations by a 0..1 amount.
     /// </summary>
     /// <remarks>
-    /// A lid that swings open as a progress value advances, a gauge that sweeps between two stops.
-    /// The rotation counterpart of <see cref="VectorLerpConverter"/>, and slerp rather than lerp
-    /// because interpolating the four numbers of a rotation directly makes the turn speed up in the
-    /// middle.
-    /// <para>
-    /// Both ends are authored as Euler angles: a serialized <see cref="Quaternion"/> shows four raw
-    /// numbers in the Inspector, and nobody sets those by hand.
-    /// </para>
+    /// Slerp rather than lerp, because interpolating the four numbers of a rotation directly makes the
+    /// turn speed up in the middle. Both ends are authored as Euler angles: a serialized
+    /// <see cref="Quaternion"/> shows four raw numbers in the Inspector, and nobody sets those by hand.
     /// </remarks>
     [Serializable]
     [TypeSelectorDisplay(Group = "Aspid/Rotation", Name = "Quaternion Slerp", Tooltip = "Turns between two rotations by a 0..1 amount")]

--- a/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Unity/Runtime/Converters/Rotations/QuaternionSlerpConverter.cs.meta
+++ b/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Unity/Runtime/Converters/Rotations/QuaternionSlerpConverter.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 6cd38db8b166479b4f0753eb1a2fc6b3

--- a/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Unity/Runtime/Converters/Rotations/QuaternionToAngleConverter.cs
+++ b/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Unity/Runtime/Converters/Rotations/QuaternionToAngleConverter.cs
@@ -10,17 +10,10 @@ namespace Aspid.MVVM.StarterKit
     /// Reads the angle a rotation carries around one axis.
     /// </summary>
     /// <remarks>
-    /// A dial or a steering wheel reporting where the player left it. A
-    /// <see cref="BindMode.OneWay"/> binding never calls <c>ConvertBack</c>, so a ViewModel that
-    /// wants an angle out of a rotation had nothing it could pick.
-    /// <para>
-    /// It is not <see cref="AngleToQuaternionConverter"/>'s <c>ConvertBack</c> spelled as a
-    /// converter of its own. It reads the axis the same way, but it carries no offset and no
-    /// clockwise flag of its own, and it folds the result into 0..360 or ±180. Reading back a
-    /// rotation an <see cref="AngleToQuaternionConverter"/> built with an offset, or set clockwise,
-    /// therefore does not return the angle that went in — that converter undoes both in its
-    /// <c>ConvertBack</c>, and this one has neither to undo.
-    /// </para>
+    /// Not <see cref="AngleToQuaternionConverter"/>'s <c>ConvertBack</c> spelled as a converter of its
+    /// own: it reads the axis the same way, but carries no offset and no clockwise flag, and folds the
+    /// result into 0..360 or ±180. Reading back a rotation that converter built with an offset, or set
+    /// clockwise, therefore does not return the angle that went in.
     /// </remarks>
     [Serializable]
     [TypeSelectorDisplay(Group = "Aspid/Rotation", Name = "Quaternion To Angle", Tooltip = "Reads the angle a rotation carries around one axis")]

--- a/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Unity/Runtime/Converters/Rotations/QuaternionToAngleConverter.cs
+++ b/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Unity/Runtime/Converters/Rotations/QuaternionToAngleConverter.cs
@@ -28,14 +28,9 @@ namespace Aspid.MVVM.StarterKit
         [Tooltip("Report the angle as -180..180 rather than Unity's 0..360.")]
         [SerializeField] private bool _signed = true;
 
-        /// <summary>
-        /// Initializes a new instance of the <see cref="QuaternionToAngleConverter"/> class reading Z.
-        /// </summary>
+        /// <remarks>Default: reading Z.</remarks>
         public QuaternionToAngleConverter() { }
 
-        /// <summary>
-        /// Initializes a new instance of the <see cref="QuaternionToAngleConverter"/> class.
-        /// </summary>
         /// <param name="axis">The axis the angle is read around.</param>
         /// <param name="signed">Whether to report the angle as -180..180.</param>
         public QuaternionToAngleConverter(RotationAxis axis, bool signed = true)

--- a/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Unity/Runtime/Converters/Rotations/QuaternionToAngleConverter.cs
+++ b/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Unity/Runtime/Converters/Rotations/QuaternionToAngleConverter.cs
@@ -1,0 +1,88 @@
+#nullable enable
+using Aspid.FastTools.Types;
+using System;
+using UnityEngine;
+
+// ReSharper disable once CheckNamespace
+namespace Aspid.MVVM.StarterKit
+{
+    /// <summary>
+    /// Reads the angle a rotation carries around one axis.
+    /// </summary>
+    /// <remarks>
+    /// A dial or a steering wheel reporting where the player left it. A
+    /// <see cref="BindMode.OneWay"/> binding never calls <c>ConvertBack</c>, so a ViewModel that
+    /// wants an angle out of a rotation had nothing it could pick.
+    /// <para>
+    /// It is not <see cref="AngleToQuaternionConverter"/>'s <c>ConvertBack</c> spelled as a
+    /// converter of its own. It reads the axis the same way, but it carries no offset and no
+    /// clockwise flag of its own, and it folds the result into 0..360 or ±180. Reading back a
+    /// rotation an <see cref="AngleToQuaternionConverter"/> built with an offset, or set clockwise,
+    /// therefore does not return the angle that went in — that converter undoes both in its
+    /// <c>ConvertBack</c>, and this one has neither to undo.
+    /// </para>
+    /// </remarks>
+    [Serializable]
+    [TypeSelectorDisplay(Group = "Aspid/Rotation", Name = "Quaternion To Angle", Tooltip = "Reads the angle a rotation carries around one axis")]
+    public sealed class QuaternionToAngleConverter : IConverter<Quaternion, float>
+    {
+        [Tooltip("The axis the angle is read around. Z is the one a 2D UI element spins on.")]
+        [SerializeField] private RotationAxis _axis = RotationAxis.Z;
+
+        [Tooltip("The axis the angle is read around when the axis above is set to Custom.")]
+        [SerializeField] private Vector3 _customAxis = Vector3.up;
+
+        [Tooltip("Report the angle as -180..180 rather than Unity's 0..360.")]
+        [SerializeField] private bool _signed = true;
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="QuaternionToAngleConverter"/> class reading Z.
+        /// </summary>
+        public QuaternionToAngleConverter() { }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="QuaternionToAngleConverter"/> class.
+        /// </summary>
+        /// <param name="axis">The axis the angle is read around.</param>
+        /// <param name="signed">Whether to report the angle as -180..180.</param>
+        public QuaternionToAngleConverter(RotationAxis axis, bool signed = true)
+        {
+            _axis = axis;
+            _signed = signed;
+        }
+
+        /// <summary>
+        /// Reads the angle off the specified rotation.
+        /// </summary>
+        /// <param name="value">The rotation to read.</param>
+        /// <returns>The angle, in degrees.</returns>
+        /// <exception cref="ArgumentOutOfRangeException">Thrown when the axis is not a declared value.</exception>
+        public float Convert(Quaternion value)
+        {
+            var euler = value.eulerAngles;
+
+            var angle = _axis switch
+            {
+                RotationAxis.X => euler.x,
+                RotationAxis.Y => euler.y,
+                RotationAxis.Z => euler.z,
+                RotationAxis.Custom => CustomAngle(value),
+                _ => throw new ArgumentOutOfRangeException(nameof(_axis), _axis, null)
+            };
+
+            var wrapped = Mathf.Repeat(angle, 360f);
+            return _signed && wrapped > 180f ? wrapped - 360f : wrapped;
+        }
+
+        // Same reading as AngleToQuaternionConverter performs: ToAngleAxis reports a positive turn
+        // around whichever axis makes it positive, so the dot decides whether that axis is the
+        // authored one or its opposite.
+        private float CustomAngle(Quaternion value)
+        {
+            if (_customAxis.sqrMagnitude <= Mathf.Epsilon) return 0f;
+
+            value.ToAngleAxis(out var angle, out var axis);
+            return Vector3.Dot(axis, _customAxis) < 0f ? -angle : angle;
+        }
+    }
+}

--- a/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Unity/Runtime/Converters/Rotations/QuaternionToAngleConverter.cs.meta
+++ b/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Unity/Runtime/Converters/Rotations/QuaternionToAngleConverter.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: b8307f26f1d5d7d2981b7b884bd9db4f

--- a/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Unity/Runtime/Converters/Rotations/QuaternionToVector4Converter.cs
+++ b/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Unity/Runtime/Converters/Rotations/QuaternionToVector4Converter.cs
@@ -1,0 +1,28 @@
+#nullable enable
+using Aspid.FastTools.Types;
+using System;
+using UnityEngine;
+
+// ReSharper disable once CheckNamespace
+namespace Aspid.MVVM.StarterKit
+{
+    /// <summary>
+    /// Reads a rotation as its four raw numbers.
+    /// </summary>
+    /// <remarks>
+    /// A shader property, a save record or a network packet takes a <see cref="Vector4"/> where the
+    /// game holds a <see cref="Quaternion"/>. The two carry the same four numbers, so nothing is
+    /// computed here — the point is that the picker offers the step at all.
+    /// </remarks>
+    [Serializable]
+    [TypeSelectorDisplay(Group = "Aspid/Rotation", Name = "Quaternion To Vector4", Tooltip = "Reads a rotation as its four raw numbers")]
+    public sealed class QuaternionToVector4Converter : IConverter<Quaternion, Vector4>
+    {
+        /// <summary>
+        /// Reads the specified rotation as four numbers.
+        /// </summary>
+        /// <param name="value">The rotation to read.</param>
+        /// <returns>The four numbers, in x, y, z, w order.</returns>
+        public Vector4 Convert(Quaternion value) => new(value.x, value.y, value.z, value.w);
+    }
+}

--- a/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Unity/Runtime/Converters/Rotations/QuaternionToVector4Converter.cs.meta
+++ b/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Unity/Runtime/Converters/Rotations/QuaternionToVector4Converter.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: e39821ef7ecb9d0a2fab5d7488ac58cf

--- a/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Unity/Runtime/Converters/Rotations/RadiansToDegreesConverter.cs
+++ b/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Unity/Runtime/Converters/Rotations/RadiansToDegreesConverter.cs
@@ -1,0 +1,36 @@
+#nullable enable
+using Aspid.FastTools.Types;
+using System;
+using UnityEngine;
+
+// ReSharper disable once CheckNamespace
+namespace Aspid.MVVM.StarterKit
+{
+    /// <summary>
+    /// Converts between radians and degrees.
+    /// </summary>
+    /// <remarks>
+    /// The same arithmetic as <see cref="DegreesToRadiansConverter"/> the other way round, and a
+    /// class of its own rather than that one's <c>ConvertBack</c> because a
+    /// <see cref="BindMode.OneWay"/> binding only ever calls <c>Convert</c> — a source that already
+    /// holds radians had no entry in the picker that would turn them into degrees.
+    /// </remarks>
+    [Serializable]
+    [TypeSelectorDisplay(Group = "Aspid/Rotation", Name = "Radians To Degrees", Tooltip = "Converts between radians and degrees")]
+    public sealed class RadiansToDegreesConverter : ITwoWayConverter<float, float>
+    {
+        /// <summary>
+        /// Converts the specified angle to degrees.
+        /// </summary>
+        /// <param name="value">The angle, in radians.</param>
+        /// <returns>The angle, in degrees.</returns>
+        public float Convert(float value) => value * Mathf.Rad2Deg;
+
+        /// <summary>
+        /// Converts the specified angle to radians.
+        /// </summary>
+        /// <param name="value">The angle, in degrees.</param>
+        /// <returns>The angle, in radians.</returns>
+        public float ConvertBack(float value) => value * Mathf.Deg2Rad;
+    }
+}

--- a/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Unity/Runtime/Converters/Rotations/RadiansToDegreesConverter.cs.meta
+++ b/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Unity/Runtime/Converters/Rotations/RadiansToDegreesConverter.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 63749e4cf02034a77557ba83541ef12d

--- a/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Unity/Runtime/Converters/Rotations/RotationAxis.cs
+++ b/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Unity/Runtime/Converters/Rotations/RotationAxis.cs
@@ -22,5 +22,13 @@ namespace Aspid.MVVM.StarterKit
         /// The Z axis — the one a 2D UI element spins on.
         /// </summary>
         Z,
+
+        // Appended rather than filed next to the other axes: the declaration order is the value
+        // Unity stores, so slotting a member in ahead of Z would repoint every field already
+        // authored as Z without saying so.
+        /// <summary>
+        /// An arbitrary axis the converter carries itself.
+        /// </summary>
+        Custom,
     }
 }

--- a/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Unity/Runtime/Converters/Rotations/Vector4ToQuaternionConverter.cs
+++ b/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Unity/Runtime/Converters/Rotations/Vector4ToQuaternionConverter.cs
@@ -20,14 +20,9 @@ namespace Aspid.MVVM.StarterKit
         [Tooltip("Scale the result back to unit length before handing it over.")]
         [SerializeField] private bool _normalize = true;
 
-        /// <summary>
-        /// Initializes a new instance of the <see cref="Vector4ToQuaternionConverter"/> class that normalises.
-        /// </summary>
+        /// <remarks>Default: normalising the result.</remarks>
         public Vector4ToQuaternionConverter() { }
 
-        /// <summary>
-        /// Initializes a new instance of the <see cref="Vector4ToQuaternionConverter"/> class.
-        /// </summary>
         /// <param name="normalize">Whether to scale the result back to unit length.</param>
         public Vector4ToQuaternionConverter(bool normalize)
         {

--- a/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Unity/Runtime/Converters/Rotations/Vector4ToQuaternionConverter.cs
+++ b/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Unity/Runtime/Converters/Rotations/Vector4ToQuaternionConverter.cs
@@ -1,0 +1,55 @@
+#nullable enable
+using Aspid.FastTools.Types;
+using System;
+using UnityEngine;
+
+// ReSharper disable once CheckNamespace
+namespace Aspid.MVVM.StarterKit
+{
+    /// <summary>
+    /// Builds a rotation out of four raw numbers.
+    /// </summary>
+    /// <remarks>
+    /// The way back from <see cref="QuaternionToVector4Converter"/>, for data that arrives as a
+    /// <see cref="Vector4"/> from a save file, a server or a shader.
+    /// </remarks>
+    [Serializable]
+    [TypeSelectorDisplay(Group = "Aspid/Rotation", Name = "Vector4 To Quaternion", Tooltip = "Builds a rotation out of four raw numbers")]
+    public sealed class Vector4ToQuaternionConverter : IConverter<Vector4, Quaternion>
+    {
+        [Tooltip("Scale the result back to unit length before handing it over.")]
+        [SerializeField] private bool _normalize = true;
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="Vector4ToQuaternionConverter"/> class that normalises.
+        /// </summary>
+        public Vector4ToQuaternionConverter() { }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="Vector4ToQuaternionConverter"/> class.
+        /// </summary>
+        /// <param name="normalize">Whether to scale the result back to unit length.</param>
+        public Vector4ToQuaternionConverter(bool normalize)
+        {
+            _normalize = normalize;
+        }
+
+        /// <summary>
+        /// Builds a rotation out of the specified numbers.
+        /// </summary>
+        /// <param name="value">The four numbers, in x, y, z, w order.</param>
+        /// <returns>The rotation, or the identity for four zeroes when normalising.</returns>
+        public Quaternion Convert(Vector4 value)
+        {
+            var rotation = new Quaternion(value.x, value.y, value.z, value.w);
+            if (!_normalize) return rotation;
+
+            // Numbers that came off a lerp, a text field or a lossy wire format are rarely unit
+            // length, and a rotation that is not unit length scales and shears whatever it lands on
+            // rather than only turning it. Four zeroes have no direction to scale back to at all;
+            // normalized already answers them with the identity, and the branch says so here rather
+            // than leaving the case to a Unity behaviour the reader has to go and confirm.
+            return value.sqrMagnitude <= Mathf.Epsilon ? Quaternion.identity : rotation.normalized;
+        }
+    }
+}

--- a/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Unity/Runtime/Converters/Rotations/Vector4ToQuaternionConverter.cs.meta
+++ b/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Unity/Runtime/Converters/Rotations/Vector4ToQuaternionConverter.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: a520299c8d9cad8c39f887938041c8a3

--- a/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Unity/Runtime/Converters/Textures/SpriteMapEntry.cs
+++ b/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Unity/Runtime/Converters/Textures/SpriteMapEntry.cs
@@ -1,0 +1,26 @@
+#nullable enable
+using System;
+using UnityEngine;
+
+// ReSharper disable once CheckNamespace
+namespace Aspid.MVVM.StarterKit
+{
+    /// <summary>
+    /// One key of a <see cref="StringToSpriteConverter"/> map, with the sprite it names.
+    /// </summary>
+    [Serializable]
+    public struct SpriteMapEntry
+    {
+        /// <summary>
+        /// The key the sprite is looked up by.
+        /// </summary>
+        [Tooltip("The key the sprite is looked up by.")]
+        public string Key;
+
+        /// <summary>
+        /// The sprite that key names. Leave it empty to map a key to nothing.
+        /// </summary>
+        [Tooltip("The sprite that key names. Leave it empty to map a key to nothing.")]
+        public Sprite? Sprite;
+    }
+}

--- a/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Unity/Runtime/Converters/Textures/SpriteMapEntry.cs.meta
+++ b/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Unity/Runtime/Converters/Textures/SpriteMapEntry.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 64c8e239336ffe489d7048dd5cb12f71

--- a/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Unity/Runtime/Converters/Textures/StringToSpriteConverter.cs
+++ b/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Unity/Runtime/Converters/Textures/StringToSpriteConverter.cs
@@ -10,21 +10,13 @@ namespace Aspid.MVVM.StarterKit
     /// Looks a sprite up by name.
     /// </summary>
     /// <remarks>
-    /// The item catalogue case: a backend sends <c>"sword_iron"</c> and the icon lives in the
-    /// project. The ViewModel would otherwise have to hold a <see cref="Sprite"/> — a reference to a
-    /// project asset in a layer that is meant not to know about them — or the scene would need one
-    /// switcher binder per icon.
+    /// The lookup is a scan of the authored array rather than a dictionary: the maps are short, the scan
+    /// allocates nothing, and a dictionary built once would go stale the moment the array is edited in
+    /// play mode.
     /// <para>
-    /// The lookup is a scan of the authored array rather than a dictionary. The maps are written by
-    /// hand and are short, the scan allocates nothing, and a dictionary built once from the array
-    /// would go stale the moment the array is edited in play mode — which is exactly when someone is
-    /// looking at it.
-    /// </para>
-    /// <para>
-    /// A <c>SpriteAtlas</c> is deliberately not a source here: <c>SpriteAtlas.GetSprite</c> returns a
-    /// fresh <see cref="Sprite"/> instance on every call, so a binder pushing on every notification
-    /// would leak one per push, and a cache keyed by string would grow without a bound. Point the
-    /// map at the sprites instead.
+    /// A <c>SpriteAtlas</c> is deliberately not a source: <c>SpriteAtlas.GetSprite</c> returns a fresh
+    /// <see cref="Sprite"/> on every call, so a binder pushing per notification would leak one per push.
+    /// Point the map at the sprites instead.
     /// </para>
     /// </remarks>
     [Serializable]

--- a/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Unity/Runtime/Converters/Textures/StringToSpriteConverter.cs
+++ b/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Unity/Runtime/Converters/Textures/StringToSpriteConverter.cs
@@ -38,14 +38,8 @@ namespace Aspid.MVVM.StarterKit
 
         [NonSerialized] private bool _loggedFailure;
 
-        /// <summary>
-        /// Initializes a new instance of the <see cref="StringToSpriteConverter"/> class with an empty map.
-        /// </summary>
         public StringToSpriteConverter() { }
 
-        /// <summary>
-        /// Initializes a new instance of the <see cref="StringToSpriteConverter"/> class.
-        /// </summary>
         /// <param name="map">The keys and the sprites they name.</param>
         /// <param name="fallback">Used when the key is blank, and when nothing matches it.</param>
         /// <param name="ignoreCase">Whether to match keys without regard to case.</param>

--- a/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Unity/Runtime/Converters/Textures/StringToSpriteConverter.cs
+++ b/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Unity/Runtime/Converters/Textures/StringToSpriteConverter.cs
@@ -1,0 +1,109 @@
+#nullable enable
+using Aspid.FastTools.Types;
+using System;
+using UnityEngine;
+
+// ReSharper disable once CheckNamespace
+namespace Aspid.MVVM.StarterKit
+{
+    /// <summary>
+    /// Looks a sprite up by name.
+    /// </summary>
+    /// <remarks>
+    /// The item catalogue case: a backend sends <c>"sword_iron"</c> and the icon lives in the
+    /// project. The ViewModel would otherwise have to hold a <see cref="Sprite"/> — a reference to a
+    /// project asset in a layer that is meant not to know about them — or the scene would need one
+    /// switcher binder per icon.
+    /// <para>
+    /// The lookup is a scan of the authored array rather than a dictionary. The maps are written by
+    /// hand and are short, the scan allocates nothing, and a dictionary built once from the array
+    /// would go stale the moment the array is edited in play mode — which is exactly when someone is
+    /// looking at it.
+    /// </para>
+    /// <para>
+    /// A <c>SpriteAtlas</c> is deliberately not a source here: <c>SpriteAtlas.GetSprite</c> returns a
+    /// fresh <see cref="Sprite"/> instance on every call, so a binder pushing on every notification
+    /// would leak one per push, and a cache keyed by string would grow without a bound. Point the
+    /// map at the sprites instead.
+    /// </para>
+    /// </remarks>
+    [Serializable]
+    [TypeSelectorDisplay(Group = "Aspid/Texture", Name = "String To Sprite", Tooltip = "Looks a sprite up by name")]
+    public sealed class StringToSpriteConverter : IConverter<string?, Sprite?>
+    {
+        [Tooltip("The keys and the sprites they name.")]
+        [SerializeField] private SpriteMapEntry[] _map = Array.Empty<SpriteMapEntry>();
+
+        [Tooltip("Match keys without regard to case.")]
+        [SerializeField] private bool _ignoreCase;
+
+        [Tooltip("Used when the key is blank, and when nothing matches it.")]
+        [SerializeField] private Sprite? _fallback;
+
+        [Tooltip("What to do with a key the map does not hold. ReturnInput is not available here — "
+            + "the input is a string and the output a sprite — and behaves as ReturnFallback.")]
+        [SerializeField] private ConverterFailureMode _onFailure = ConverterFailureMode.ReturnFallback;
+
+        [NonSerialized] private bool _loggedFailure;
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="StringToSpriteConverter"/> class with an empty map.
+        /// </summary>
+        public StringToSpriteConverter() { }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="StringToSpriteConverter"/> class.
+        /// </summary>
+        /// <param name="map">The keys and the sprites they name.</param>
+        /// <param name="fallback">Used when the key is blank, and when nothing matches it.</param>
+        /// <param name="ignoreCase">Whether to match keys without regard to case.</param>
+        public StringToSpriteConverter(SpriteMapEntry[]? map, Sprite? fallback = null, bool ignoreCase = false)
+        {
+            _map = map ?? Array.Empty<SpriteMapEntry>();
+            _fallback = fallback;
+            _ignoreCase = ignoreCase;
+        }
+
+        /// <summary>
+        /// Looks up the sprite the specified key names.
+        /// </summary>
+        /// <param name="value">The key to look up.</param>
+        /// <returns>
+        /// The sprite mapped to the key, or the fallback. A blank key is treated as no value rather
+        /// than as a failed lookup and returns the fallback silently.
+        /// </returns>
+        /// <exception cref="ArgumentException">
+        /// Thrown when the map does not hold the key and <c>_onFailure</c> is
+        /// <see cref="ConverterFailureMode.Throw"/>.
+        /// </exception>
+        public Sprite? Convert(string? value)
+        {
+            if (string.IsNullOrEmpty(value)) return _fallback;
+
+            if (_map is { Length: > 0 })
+            {
+                var comparison = _ignoreCase ? StringComparison.OrdinalIgnoreCase : StringComparison.Ordinal;
+
+                for (var i = 0; i < _map.Length; i++)
+                    if (string.Equals(_map[i].Key, value, comparison))
+                        return _map[i].Sprite;
+            }
+
+            if (_onFailure is ConverterFailureMode.Throw)
+                throw new ArgumentException($"No sprite is mapped to \"{value}\".", nameof(value));
+
+            LogFailure(value);
+            return _fallback;
+        }
+
+        private void LogFailure(string? value)
+        {
+            if (_loggedFailure) return;
+            _loggedFailure = true;
+
+            Debug.LogError(
+                $"{nameof(StringToSpriteConverter)}: no sprite is mapped to \"{value}\". "
+                + "Using the fallback sprite. Further failures on this converter are not reported.");
+        }
+    }
+}

--- a/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Unity/Runtime/Converters/Textures/StringToSpriteConverter.cs.meta
+++ b/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Unity/Runtime/Converters/Textures/StringToSpriteConverter.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: e9cea273ffbc8463f8cce6b86ebdb397

--- a/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Unity/Runtime/Converters/Textures/Texture2DToSpriteConverter.cs.meta
+++ b/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Unity/Runtime/Converters/Textures/Texture2DToSpriteConverter.cs.meta
@@ -1,2 +1,2 @@
 fileFormatVersion: 2
-guid: e9cea273ffbc8463f8cce6b86ebdb397
+guid: 79feeb9db5f6215bfd7935da39506fde

--- a/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Unity/Runtime/Converters/Textures/TextureToSpriteRectConverter.cs
+++ b/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Unity/Runtime/Converters/Textures/TextureToSpriteRectConverter.cs
@@ -1,0 +1,40 @@
+#nullable enable
+using Aspid.FastTools.Types;
+using System;
+using UnityEngine;
+
+// ReSharper disable once CheckNamespace
+namespace Aspid.MVVM.StarterKit
+{
+    /// <summary>
+    /// Measures the pixel rect of a texture.
+    /// </summary>
+    /// <remarks>
+    /// The rect <see cref="Sprite.Create(Texture2D, Rect, Vector2)"/> and the UV maths around an
+    /// atlas both want, taken from the texture itself rather than authored beside it and left to go
+    /// stale when the texture is replaced.
+    /// <para>
+    /// Typed on <see cref="Texture"/> rather than <see cref="Texture2D"/> because that is where
+    /// <see cref="Texture.width"/> and <see cref="Texture.height"/> are declared: a
+    /// <c>RawImage</c>-facing ViewModel holds the base type, and a <c>RenderTexture</c> measures the
+    /// same way. A field typed for <see cref="Texture2D"/> still takes it, because
+    /// <see cref="IConverter{TFrom, TTo}"/> is contravariant in its input.
+    /// </para>
+    /// </remarks>
+    [Serializable]
+    [TypeSelectorDisplay(Group = "Aspid/Texture", Name = "Texture To Sprite Rect", Tooltip = "Measures the pixel rect of a texture")]
+    public sealed class TextureToSpriteRectConverter : IConverter<Texture?, Rect>
+    {
+        /// <summary>
+        /// Measures the specified texture.
+        /// </summary>
+        /// <param name="value">The texture to measure.</param>
+        /// <returns>
+        /// A rect covering the whole texture in pixels, or <see cref="Rect.zero"/> when the texture
+        /// is missing.
+        /// </returns>
+        public Rect Convert(Texture? value) =>
+            // Unity's overloaded == also catches a destroyed texture, whose width access would throw.
+            value == null ? Rect.zero : new Rect(0f, 0f, value.width, value.height);
+    }
+}

--- a/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Unity/Runtime/Converters/Textures/TextureToSpriteRectConverter.cs
+++ b/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Unity/Runtime/Converters/Textures/TextureToSpriteRectConverter.cs
@@ -10,16 +10,10 @@ namespace Aspid.MVVM.StarterKit
     /// Measures the pixel rect of a texture.
     /// </summary>
     /// <remarks>
-    /// The rect <see cref="Sprite.Create(Texture2D, Rect, Vector2)"/> and the UV maths around an
-    /// atlas both want, taken from the texture itself rather than authored beside it and left to go
-    /// stale when the texture is replaced.
-    /// <para>
     /// Typed on <see cref="Texture"/> rather than <see cref="Texture2D"/> because that is where
-    /// <see cref="Texture.width"/> and <see cref="Texture.height"/> are declared: a
-    /// <c>RawImage</c>-facing ViewModel holds the base type, and a <c>RenderTexture</c> measures the
-    /// same way. A field typed for <see cref="Texture2D"/> still takes it, because
-    /// <see cref="IConverter{TFrom, TTo}"/> is contravariant in its input.
-    /// </para>
+    /// <see cref="Texture.width"/> and <see cref="Texture.height"/> are declared, so a
+    /// <c>RenderTexture</c> measures the same way. A field typed for <see cref="Texture2D"/> still takes
+    /// it, because <see cref="IConverter{TFrom, TTo}"/> is contravariant in its input.
     /// </remarks>
     [Serializable]
     [TypeSelectorDisplay(Group = "Aspid/Texture", Name = "Texture To Sprite Rect", Tooltip = "Measures the pixel rect of a texture")]

--- a/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Unity/Runtime/Converters/Textures/TextureToSpriteRectConverter.cs.meta
+++ b/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Unity/Runtime/Converters/Textures/TextureToSpriteRectConverter.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 8f5a63a9689071b56089293dcb81bae7

--- a/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Unity/Runtime/Converters/Vectors/BoundsCenterConverter.cs
+++ b/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Unity/Runtime/Converters/Vectors/BoundsCenterConverter.cs
@@ -1,0 +1,32 @@
+#nullable enable
+using Aspid.FastTools.Types;
+using System;
+using UnityEngine;
+
+// ReSharper disable once CheckNamespace
+namespace Aspid.MVVM.StarterKit
+{
+    /// <summary>
+    /// Reads the middle of a bounding box.
+    /// </summary>
+    /// <remarks>
+    /// Where a world-space label, a health bar or a selection ring goes: the middle of what is being
+    /// labelled rather than the origin of its transform, which on an imported model is often at its
+    /// feet or somewhere off to one side.
+    /// </remarks>
+    [Serializable]
+    [TypeSelectorDisplay(Group = "Aspid/Vector", Name = "Bounds Center", Tooltip = "Reads the middle of a bounding box")]
+    public sealed class BoundsCenterConverter : IConverter<Bounds, Vector3>
+    {
+        /// <summary>
+        /// Reads the middle of the specified box.
+        /// </summary>
+        /// <param name="value">The box to read.</param>
+        /// <returns>
+        /// The middle of the box, in whichever space it was measured in — a
+        /// <see cref="Renderer.bounds"/> is world space and a <see cref="Mesh.bounds"/> is local,
+        /// and the converter has no transform with which to move between them.
+        /// </returns>
+        public Vector3 Convert(Bounds value) => value.center;
+    }
+}

--- a/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Unity/Runtime/Converters/Vectors/BoundsCenterConverter.cs.meta
+++ b/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Unity/Runtime/Converters/Vectors/BoundsCenterConverter.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: ddf79e4c196d3790657bdc280e2e5a93

--- a/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Unity/Runtime/Converters/Vectors/BoundsPlane.cs
+++ b/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Unity/Runtime/Converters/Vectors/BoundsPlane.cs
@@ -1,0 +1,26 @@
+#nullable enable
+
+// ReSharper disable once CheckNamespace
+namespace Aspid.MVVM.StarterKit
+{
+    /// <summary>
+    /// Which pair of axes a bounding box is flattened onto.
+    /// </summary>
+    public enum BoundsPlane
+    {
+        /// <summary>
+        /// The X and Y axes — the plane a 2D game and a canvas live on.
+        /// </summary>
+        XY,
+
+        /// <summary>
+        /// The X and Z axes — the ground plane of a 3D game.
+        /// </summary>
+        XZ,
+
+        /// <summary>
+        /// The Y and Z axes.
+        /// </summary>
+        YZ,
+    }
+}

--- a/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Unity/Runtime/Converters/Vectors/BoundsPlane.cs.meta
+++ b/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Unity/Runtime/Converters/Vectors/BoundsPlane.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: e382d767d24818cc2dc604d02eb1b2d1

--- a/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Unity/Runtime/Converters/Vectors/BoundsSizeConverter.cs
+++ b/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Unity/Runtime/Converters/Vectors/BoundsSizeConverter.cs
@@ -1,0 +1,44 @@
+#nullable enable
+using Aspid.FastTools.Types;
+using System;
+using UnityEngine;
+
+// ReSharper disable once CheckNamespace
+namespace Aspid.MVVM.StarterKit
+{
+    /// <summary>
+    /// Reads how big a bounding box is.
+    /// </summary>
+    /// <remarks>
+    /// Sizing a frame, a footprint marker or a minimap icon to the thing it stands for, without the
+    /// ViewModel holding a renderer to ask.
+    /// </remarks>
+    [Serializable]
+    [TypeSelectorDisplay(Group = "Aspid/Vector", Name = "Bounds Size", Tooltip = "Reads how big a bounding box is")]
+    public sealed class BoundsSizeConverter : IConverter<Bounds, Vector3>
+    {
+        [Tooltip("Report the half-size instead, which is what a radius or an offset from the middle wants.")]
+        [SerializeField] private bool _extents;
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="BoundsSizeConverter"/> class reporting the full size.
+        /// </summary>
+        public BoundsSizeConverter() { }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="BoundsSizeConverter"/> class.
+        /// </summary>
+        /// <param name="extents">Whether to report the half-size.</param>
+        public BoundsSizeConverter(bool extents)
+        {
+            _extents = extents;
+        }
+
+        /// <summary>
+        /// Reads the size of the specified box.
+        /// </summary>
+        /// <param name="value">The box to read.</param>
+        /// <returns>The size of the box, or its half-size.</returns>
+        public Vector3 Convert(Bounds value) => _extents ? value.extents : value.size;
+    }
+}

--- a/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Unity/Runtime/Converters/Vectors/BoundsSizeConverter.cs
+++ b/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Unity/Runtime/Converters/Vectors/BoundsSizeConverter.cs
@@ -20,14 +20,9 @@ namespace Aspid.MVVM.StarterKit
         [Tooltip("Report the half-size instead, which is what a radius or an offset from the middle wants.")]
         [SerializeField] private bool _extents;
 
-        /// <summary>
-        /// Initializes a new instance of the <see cref="BoundsSizeConverter"/> class reporting the full size.
-        /// </summary>
+        /// <remarks>Default: reporting the full size.</remarks>
         public BoundsSizeConverter() { }
 
-        /// <summary>
-        /// Initializes a new instance of the <see cref="BoundsSizeConverter"/> class.
-        /// </summary>
         /// <param name="extents">Whether to report the half-size.</param>
         public BoundsSizeConverter(bool extents)
         {

--- a/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Unity/Runtime/Converters/Vectors/BoundsSizeConverter.cs.meta
+++ b/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Unity/Runtime/Converters/Vectors/BoundsSizeConverter.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 74ebf0be802ab00c0f640cfa03bfbdcb

--- a/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Unity/Runtime/Converters/Vectors/BoundsToRectConverter.cs
+++ b/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Unity/Runtime/Converters/Vectors/BoundsToRectConverter.cs
@@ -20,14 +20,9 @@ namespace Aspid.MVVM.StarterKit
         [Tooltip("Which two axes the box is flattened onto.")]
         [SerializeField] private BoundsPlane _plane = BoundsPlane.XY;
 
-        /// <summary>
-        /// Initializes a new instance of the <see cref="BoundsToRectConverter"/> class flattening onto XY.
-        /// </summary>
+        /// <remarks>Default: flattening onto XY.</remarks>
         public BoundsToRectConverter() { }
 
-        /// <summary>
-        /// Initializes a new instance of the <see cref="BoundsToRectConverter"/> class.
-        /// </summary>
         /// <param name="plane">Which two axes the box is flattened onto.</param>
         public BoundsToRectConverter(BoundsPlane plane)
         {

--- a/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Unity/Runtime/Converters/Vectors/BoundsToRectConverter.cs
+++ b/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Unity/Runtime/Converters/Vectors/BoundsToRectConverter.cs
@@ -1,0 +1,60 @@
+#nullable enable
+using Aspid.FastTools.Types;
+using System;
+using UnityEngine;
+
+// ReSharper disable once CheckNamespace
+namespace Aspid.MVVM.StarterKit
+{
+    /// <summary>
+    /// Flattens a bounding box onto a plane.
+    /// </summary>
+    /// <remarks>
+    /// A minimap footprint or a world-space panel sized to the object behind it: the third axis is
+    /// the one the map is looking down, so dropping it is the whole conversion.
+    /// </remarks>
+    [Serializable]
+    [TypeSelectorDisplay(Group = "Aspid/Vector", Name = "Bounds To Rect", Tooltip = "Flattens a bounding box onto a plane")]
+    public sealed class BoundsToRectConverter : IConverter<Bounds, Rect>
+    {
+        [Tooltip("Which two axes the box is flattened onto.")]
+        [SerializeField] private BoundsPlane _plane = BoundsPlane.XY;
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="BoundsToRectConverter"/> class flattening onto XY.
+        /// </summary>
+        public BoundsToRectConverter() { }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="BoundsToRectConverter"/> class.
+        /// </summary>
+        /// <param name="plane">Which two axes the box is flattened onto.</param>
+        public BoundsToRectConverter(BoundsPlane plane)
+        {
+            _plane = plane;
+        }
+
+        /// <summary>
+        /// Flattens the specified box.
+        /// </summary>
+        /// <param name="value">The box to flatten.</param>
+        /// <returns>
+        /// The rectangle, positioned at the box's lower corner on the chosen plane rather than at
+        /// its middle — that is the corner <see cref="Rect"/> measures its width and height from.
+        /// </returns>
+        /// <exception cref="ArgumentOutOfRangeException">Thrown when the plane is not a declared value.</exception>
+        public Rect Convert(Bounds value)
+        {
+            var min = value.min;
+            var size = value.size;
+
+            return _plane switch
+            {
+                BoundsPlane.XY => new Rect(min.x, min.y, size.x, size.y),
+                BoundsPlane.XZ => new Rect(min.x, min.z, size.x, size.z),
+                BoundsPlane.YZ => new Rect(min.y, min.z, size.y, size.z),
+                _ => throw new ArgumentOutOfRangeException(nameof(_plane), _plane, null)
+            };
+        }
+    }
+}

--- a/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Unity/Runtime/Converters/Vectors/BoundsToRectConverter.cs.meta
+++ b/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Unity/Runtime/Converters/Vectors/BoundsToRectConverter.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: f78f34b5d7b14afa366feaf4fe94f5ac

--- a/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Unity/Runtime/Converters/Vectors/BoxCollider2DOffsetCombineConverter.cs
+++ b/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Unity/Runtime/Converters/Vectors/BoxCollider2DOffsetCombineConverter.cs
@@ -1,0 +1,31 @@
+#nullable enable
+using Aspid.FastTools.Types;
+using System;
+using UnityEngine;
+
+// ReSharper disable once CheckNamespace
+namespace Aspid.MVVM.StarterKit
+{
+    /// <summary>
+    /// Combines a 2D vector with a 2D box collider's offset.
+    /// </summary>
+    /// <remarks>
+    /// Shifting a hitbox along one axis — a crouch that drops it, an attack that pushes it forward —
+    /// while the other axis keeps whatever the collider was authored with.
+    /// </remarks>
+    [Serializable]
+    [TypeSelectorDisplay(Group = "Aspid/Vector", Name = "Box Collider 2D Offset Combine", Tooltip = "Combines a 2D vector with a 2D box collider's offset")]
+    public sealed class BoxCollider2DOffsetCombineConverter : Vector2CombineConverter
+    {
+        [Tooltip("The collider whose offset the bound vector is combined with.")]
+        [SerializeField] private BoxCollider2D _collider;
+
+        /// <inheritdoc/>
+        protected override Component Target => _collider;
+
+        /// <summary>
+        /// Gets the reference vector to combine with, which is the collider's offset.
+        /// </summary>
+        protected override Vector2 VectorTo => _collider.offset;
+    }
+}

--- a/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Unity/Runtime/Converters/Vectors/BoxCollider2DOffsetCombineConverter.cs.meta
+++ b/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Unity/Runtime/Converters/Vectors/BoxCollider2DOffsetCombineConverter.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 2e81437894be44ec8e5a45c78dff0ae0
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Unity/Runtime/Converters/Vectors/BoxCollider2DSizeCombineConverter.cs
+++ b/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Unity/Runtime/Converters/Vectors/BoxCollider2DSizeCombineConverter.cs
@@ -1,0 +1,31 @@
+#nullable enable
+using Aspid.FastTools.Types;
+using System;
+using UnityEngine;
+
+// ReSharper disable once CheckNamespace
+namespace Aspid.MVVM.StarterKit
+{
+    /// <summary>
+    /// Combines a 2D vector with a 2D box collider's size.
+    /// </summary>
+    /// <remarks>
+    /// The 2D physics counterpart of <see cref="BoxColliderSizeCombineConverter"/>: a hitbox that
+    /// widens with a charge value while its height stays as authored.
+    /// </remarks>
+    [Serializable]
+    [TypeSelectorDisplay(Group = "Aspid/Vector", Name = "Box Collider 2D Size Combine", Tooltip = "Combines a 2D vector with a 2D box collider's size")]
+    public sealed class BoxCollider2DSizeCombineConverter : Vector2CombineConverter
+    {
+        [Tooltip("The collider whose size the bound vector is combined with.")]
+        [SerializeField] private BoxCollider2D _collider;
+
+        /// <inheritdoc/>
+        protected override Component Target => _collider;
+
+        /// <summary>
+        /// Gets the reference vector to combine with, which is the collider's size.
+        /// </summary>
+        protected override Vector2 VectorTo => _collider.size;
+    }
+}

--- a/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Unity/Runtime/Converters/Vectors/BoxCollider2DSizeCombineConverter.cs.meta
+++ b/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Unity/Runtime/Converters/Vectors/BoxCollider2DSizeCombineConverter.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: c5399bf0dce947939361aa0d27b715a0
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Unity/Runtime/Converters/Vectors/RectToVector4Converter.cs
+++ b/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Unity/Runtime/Converters/Vectors/RectToVector4Converter.cs
@@ -1,0 +1,27 @@
+#nullable enable
+using Aspid.FastTools.Types;
+using System;
+using UnityEngine;
+
+// ReSharper disable once CheckNamespace
+namespace Aspid.MVVM.StarterKit
+{
+    /// <summary>
+    /// Reads a rectangle as a four-component vector.
+    /// </summary>
+    /// <remarks>
+    /// The way back from <see cref="Vector4ToRectConverter"/>, and the form a shader property or a
+    /// saved layout takes.
+    /// </remarks>
+    [Serializable]
+    [TypeSelectorDisplay(Group = "Aspid/Vector", Name = "Rect To Vector4", Tooltip = "Reads a rectangle as a four-component vector")]
+    public sealed class RectToVector4Converter : IConverter<Rect, Vector4>
+    {
+        /// <summary>
+        /// Reads the specified rectangle as a vector.
+        /// </summary>
+        /// <param name="value">The rectangle to read.</param>
+        /// <returns>The vector, as x, y, width, height.</returns>
+        public Vector4 Convert(Rect value) => new(value.x, value.y, value.width, value.height);
+    }
+}

--- a/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Unity/Runtime/Converters/Vectors/RectToVector4Converter.cs.meta
+++ b/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Unity/Runtime/Converters/Vectors/RectToVector4Converter.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 06144c001a2be508e9d7f52bc4ebfaa8

--- a/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Unity/Runtime/Converters/Vectors/RectTransformAnchoredPosition2DCombineConverter.cs
+++ b/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Unity/Runtime/Converters/Vectors/RectTransformAnchoredPosition2DCombineConverter.cs
@@ -1,0 +1,32 @@
+#nullable enable
+using Aspid.FastTools.Types;
+using System;
+using UnityEngine;
+
+// ReSharper disable once CheckNamespace
+namespace Aspid.MVVM.StarterKit
+{
+    /// <summary>
+    /// Combines a 2D vector with a rect transform's anchored position.
+    /// </summary>
+    /// <remarks>
+    /// An anchored position is a <see cref="Vector2"/> to begin with, so this is the form the value
+    /// arrives in — binding one axis of a panel's placement and leaving the other to the layout no
+    /// longer means widening to three dimensions and back.
+    /// </remarks>
+    [Serializable]
+    [TypeSelectorDisplay(Group = "Aspid/Vector", Name = "Rect Transform Anchored Position 2D Combine", Tooltip = "Combines a 2D vector with a rect transform's anchored position")]
+    public sealed class RectTransformAnchoredPosition2DCombineConverter : Vector2CombineConverter
+    {
+        [Tooltip("The rect transform whose anchored position the bound vector is combined with.")]
+        [SerializeField] private RectTransform _transform;
+
+        /// <inheritdoc/>
+        protected override Component Target => _transform;
+
+        /// <summary>
+        /// Gets the reference vector to combine with, which is the rect transform's anchored position.
+        /// </summary>
+        protected override Vector2 VectorTo => _transform.anchoredPosition;
+    }
+}

--- a/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Unity/Runtime/Converters/Vectors/RectTransformAnchoredPosition2DCombineConverter.cs.meta
+++ b/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Unity/Runtime/Converters/Vectors/RectTransformAnchoredPosition2DCombineConverter.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: f3a00eb34cd74b61a4d12095343e9b05
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Unity/Runtime/Converters/Vectors/RectTransformSizeDeltaCombineConverter.cs
+++ b/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Unity/Runtime/Converters/Vectors/RectTransformSizeDeltaCombineConverter.cs
@@ -1,0 +1,31 @@
+#nullable enable
+using Aspid.FastTools.Types;
+using System;
+using UnityEngine;
+
+// ReSharper disable once CheckNamespace
+namespace Aspid.MVVM.StarterKit
+{
+    /// <summary>
+    /// Combines a 2D vector with a rect transform's size delta.
+    /// </summary>
+    /// <remarks>
+    /// A bar that grows in width while its height stays with the layout: the X selection does the
+    /// work and the Y comes back off the element itself, so nothing has to know the authored height.
+    /// </remarks>
+    [Serializable]
+    [TypeSelectorDisplay(Group = "Aspid/Vector", Name = "Rect Transform Size Delta Combine", Tooltip = "Combines a 2D vector with a rect transform's size delta")]
+    public sealed class RectTransformSizeDeltaCombineConverter : Vector2CombineConverter
+    {
+        [Tooltip("The rect transform whose size delta the bound vector is combined with.")]
+        [SerializeField] private RectTransform _transform;
+
+        /// <inheritdoc/>
+        protected override Component Target => _transform;
+
+        /// <summary>
+        /// Gets the reference vector to combine with, which is the rect transform's size delta.
+        /// </summary>
+        protected override Vector2 VectorTo => _transform.sizeDelta;
+    }
+}

--- a/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Unity/Runtime/Converters/Vectors/RectTransformSizeDeltaCombineConverter.cs.meta
+++ b/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Unity/Runtime/Converters/Vectors/RectTransformSizeDeltaCombineConverter.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 6d3837dcbed74575b942aac0531256d0
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Unity/Runtime/Converters/Vectors/TransformPosition2DCombineConverter.cs
+++ b/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Unity/Runtime/Converters/Vectors/TransformPosition2DCombineConverter.cs
@@ -1,0 +1,34 @@
+#nullable enable
+using Aspid.FastTools.Types;
+using System;
+using UnityEngine;
+
+// ReSharper disable once CheckNamespace
+namespace Aspid.MVVM.StarterKit
+{
+    /// <summary>
+    /// Combines a 2D vector with a transform's current position.
+    /// </summary>
+    /// <remarks>
+    /// The 2D reading of <see cref="TransformPositionCombineConverter"/>, for a sprite or a canvas
+    /// element whose depth is set once in the scene and never bound.
+    /// </remarks>
+    [Serializable]
+    [TypeSelectorDisplay(Group = "Aspid/Vector", Name = "Transform Position 2D Combine", Tooltip = "Combines a 2D vector with a transform's current position")]
+    public sealed class TransformPosition2DCombineConverter : Vector2CombineConverter
+    {
+        [Tooltip("The transform whose position the bound vector is combined with.")]
+        [SerializeField] private Transform _transform;
+        [Tooltip("Which space the position is read in.")]
+        [SerializeField] private Space _space = Space.World;
+
+        /// <inheritdoc/>
+        protected override Component Target => _transform;
+
+        /// <summary>
+        /// Gets the reference vector to combine with, which is the transform's position with its
+        /// depth dropped.
+        /// </summary>
+        protected override Vector2 VectorTo => _transform.GetPosition(_space);
+    }
+}

--- a/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Unity/Runtime/Converters/Vectors/TransformPosition2DCombineConverter.cs.meta
+++ b/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Unity/Runtime/Converters/Vectors/TransformPosition2DCombineConverter.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 8b38f7358d784fa786007d71e0aac341
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Unity/Runtime/Converters/Vectors/Vector2ArithmeticConverter.cs
+++ b/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Unity/Runtime/Converters/Vectors/Vector2ArithmeticConverter.cs
@@ -29,14 +29,8 @@ namespace Aspid.MVVM.StarterKit
         [Tooltip("The vector the bound one is combined with.")]
         [SerializeField] private Vector2 _operand;
 
-        /// <summary>
-        /// Initializes a new instance of the <see cref="Vector2ArithmeticConverter"/> class that adds nothing.
-        /// </summary>
         public Vector2ArithmeticConverter() { }
 
-        /// <summary>
-        /// Initializes a new instance of the <see cref="Vector2ArithmeticConverter"/> class.
-        /// </summary>
         /// <param name="operation">What to do with the operand.</param>
         /// <param name="operand">The vector the bound one is combined with.</param>
         public Vector2ArithmeticConverter(VectorOperation operation, Vector2 operand)

--- a/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Unity/Runtime/Converters/Vectors/Vector2ArithmeticConverter.cs
+++ b/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Unity/Runtime/Converters/Vectors/Vector2ArithmeticConverter.cs
@@ -1,0 +1,70 @@
+#nullable enable
+using Aspid.FastTools.Types;
+using System;
+using UnityEngine;
+
+// The named converter aliases are [Obsolete]. The converters below keep implementing them for
+// one release so that a [SerializeReference] field a project declares as one still
+// deserializes; the base lists go with the aliases in the next major.
+#pragma warning disable CS0618 // Type or member is obsolete
+
+// ReSharper disable once CheckNamespace
+namespace Aspid.MVVM.StarterKit
+{
+    /// <summary>
+    /// Combines a bound 2D vector with an authored one.
+    /// </summary>
+    /// <remarks>
+    /// The 2D counterpart of <see cref="Vector3ArithmeticConverter"/>. Anything authored in two
+    /// dimensions — an anchored position, a size delta, a sprite offset — had to widen to
+    /// <see cref="Vector3"/> and back to do arithmetic at all.
+    /// </remarks>
+    [Serializable]
+    [TypeSelectorDisplay(Group = "Aspid/Vector", Name = "Vector2 Arithmetic", Tooltip = "Combines a bound 2D vector with an authored one")]
+    public sealed class Vector2ArithmeticConverter : IConverterVector2
+    {
+        [Tooltip("What to do with the operand.")]
+        [SerializeField] private VectorOperation _operation = VectorOperation.Add;
+
+        [Tooltip("The vector the bound one is combined with.")]
+        [SerializeField] private Vector2 _operand;
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="Vector2ArithmeticConverter"/> class that adds nothing.
+        /// </summary>
+        public Vector2ArithmeticConverter() { }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="Vector2ArithmeticConverter"/> class.
+        /// </summary>
+        /// <param name="operation">What to do with the operand.</param>
+        /// <param name="operand">The vector the bound one is combined with.</param>
+        public Vector2ArithmeticConverter(VectorOperation operation, Vector2 operand)
+        {
+            _operation = operation;
+            _operand = operand;
+        }
+
+        /// <summary>
+        /// Combines the specified vector with the authored operand.
+        /// </summary>
+        /// <param name="value">The vector to combine.</param>
+        /// <returns>The combined vector.</returns>
+        /// <exception cref="ArgumentOutOfRangeException">Thrown when the operation is not a declared value.</exception>
+        public Vector2 Convert(Vector2 value) => _operation switch
+        {
+            VectorOperation.Add => value + _operand,
+            VectorOperation.Subtract => value - _operand,
+            VectorOperation.Scale => Vector2.Scale(value, _operand),
+            VectorOperation.Divide => Divide(value, _operand),
+            VectorOperation.Reflect => Vector2.Reflect(value, _operand),
+            _ => throw new ArgumentOutOfRangeException(nameof(_operation), _operation, null)
+        };
+
+        // Matches the Vector3 converter: a zero axis in the operand leaves that axis alone rather
+        // than producing an infinity.
+        private static Vector2 Divide(Vector2 value, Vector2 operand) => new(
+            operand.x == 0f ? value.x : value.x / operand.x,
+            operand.y == 0f ? value.y : value.y / operand.y);
+    }
+}

--- a/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Unity/Runtime/Converters/Vectors/Vector2ArithmeticConverter.cs.meta
+++ b/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Unity/Runtime/Converters/Vectors/Vector2ArithmeticConverter.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 2394f0ac39b0abe8cf625b9438d5bb5f

--- a/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Unity/Runtime/Converters/Vectors/Vector2ClampComponentsConverter.cs
+++ b/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Unity/Runtime/Converters/Vectors/Vector2ClampComponentsConverter.cs
@@ -1,0 +1,57 @@
+#nullable enable
+using Aspid.FastTools.Types;
+using System;
+using UnityEngine;
+
+// The named converter aliases are [Obsolete]. The converters below keep implementing them for
+// one release so that a [SerializeReference] field a project declares as one still
+// deserializes; the base lists go with the aliases in the next major.
+#pragma warning disable CS0618 // Type or member is obsolete
+
+// ReSharper disable once CheckNamespace
+namespace Aspid.MVVM.StarterKit
+{
+    /// <summary>
+    /// Keeps both axes of a 2D vector between two bounds.
+    /// </summary>
+    /// <remarks>
+    /// The 2D counterpart of <see cref="VectorClampComponentsConverter"/>: holding a dragged icon
+    /// inside its panel, or an anchored position inside the safe area — a limit that is a rectangle
+    /// rather than the radius <see cref="Vector2ClampMagnitudeConverter"/> applies.
+    /// </remarks>
+    [Serializable]
+    [TypeSelectorDisplay(Group = "Aspid/Vector", Name = "Vector2 Clamp Components", Tooltip = "Keeps both axes of a 2D vector between two bounds")]
+    public sealed class Vector2ClampComponentsConverter : IConverterVector2
+    {
+        [Tooltip("The lowest each axis is allowed to be.")]
+        [SerializeField] private Vector2 _min = new(-1f, -1f);
+
+        [Tooltip("The highest each axis is allowed to be.")]
+        [SerializeField] private Vector2 _max = Vector2.one;
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="Vector2ClampComponentsConverter"/> class clamping to ±1.
+        /// </summary>
+        public Vector2ClampComponentsConverter() { }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="Vector2ClampComponentsConverter"/> class.
+        /// </summary>
+        /// <param name="min">The lowest each axis is allowed to be.</param>
+        /// <param name="max">The highest each axis is allowed to be.</param>
+        public Vector2ClampComponentsConverter(Vector2 min, Vector2 max)
+        {
+            _min = min;
+            _max = max;
+        }
+
+        /// <summary>
+        /// Clamps both axes of the specified vector.
+        /// </summary>
+        /// <param name="value">The vector to clamp.</param>
+        /// <returns>The clamped vector.</returns>
+        public Vector2 Convert(Vector2 value) => new(
+            VectorClampComponentsConverter.ClampComponent(value.x, _min.x, _max.x),
+            VectorClampComponentsConverter.ClampComponent(value.y, _min.y, _max.y));
+    }
+}

--- a/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Unity/Runtime/Converters/Vectors/Vector2ClampComponentsConverter.cs
+++ b/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Unity/Runtime/Converters/Vectors/Vector2ClampComponentsConverter.cs
@@ -29,14 +29,9 @@ namespace Aspid.MVVM.StarterKit
         [Tooltip("The highest each axis is allowed to be.")]
         [SerializeField] private Vector2 _max = Vector2.one;
 
-        /// <summary>
-        /// Initializes a new instance of the <see cref="Vector2ClampComponentsConverter"/> class clamping to ±1.
-        /// </summary>
+        /// <remarks>Default: clamping to ±1.</remarks>
         public Vector2ClampComponentsConverter() { }
 
-        /// <summary>
-        /// Initializes a new instance of the <see cref="Vector2ClampComponentsConverter"/> class.
-        /// </summary>
         /// <param name="min">The lowest each axis is allowed to be.</param>
         /// <param name="max">The highest each axis is allowed to be.</param>
         public Vector2ClampComponentsConverter(Vector2 min, Vector2 max)

--- a/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Unity/Runtime/Converters/Vectors/Vector2ClampComponentsConverter.cs.meta
+++ b/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Unity/Runtime/Converters/Vectors/Vector2ClampComponentsConverter.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 3e07d7ef5b460ee4d8f42e447addae2b

--- a/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Unity/Runtime/Converters/Vectors/Vector2ClampMagnitudeConverter.cs
+++ b/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Unity/Runtime/Converters/Vectors/Vector2ClampMagnitudeConverter.cs
@@ -28,14 +28,9 @@ namespace Aspid.MVVM.StarterKit
         [Tooltip("The shortest the vector is allowed to be. Zero disables the lower bound.")]
         [SerializeField] private float _minMagnitude;
 
-        /// <summary>
-        /// Initializes a new instance of the <see cref="Vector2ClampMagnitudeConverter"/> class clamping to one.
-        /// </summary>
+        /// <remarks>Default: clamping to one.</remarks>
         public Vector2ClampMagnitudeConverter() { }
 
-        /// <summary>
-        /// Initializes a new instance of the <see cref="Vector2ClampMagnitudeConverter"/> class.
-        /// </summary>
         /// <param name="maxMagnitude">The longest the vector is allowed to be.</param>
         /// <param name="minMagnitude">The shortest the vector is allowed to be.</param>
         public Vector2ClampMagnitudeConverter(float maxMagnitude, float minMagnitude = 0f)

--- a/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Unity/Runtime/Converters/Vectors/Vector2ClampMagnitudeConverter.cs
+++ b/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Unity/Runtime/Converters/Vectors/Vector2ClampMagnitudeConverter.cs
@@ -1,0 +1,67 @@
+#nullable enable
+using Aspid.FastTools.Types;
+using System;
+using UnityEngine;
+
+// The named converter aliases are [Obsolete]. The converters below keep implementing them for
+// one release so that a [SerializeReference] field a project declares as one still
+// deserializes; the base lists go with the aliases in the next major.
+#pragma warning disable CS0618 // Type or member is obsolete
+
+// ReSharper disable once CheckNamespace
+namespace Aspid.MVVM.StarterKit
+{
+    /// <summary>
+    /// Keeps a 2D vector inside a length.
+    /// </summary>
+    /// <remarks>
+    /// The 2D counterpart of <see cref="VectorClampMagnitudeConverter"/>, and the form a joystick
+    /// or a drag offset actually arrives in.
+    /// </remarks>
+    [Serializable]
+    [TypeSelectorDisplay(Group = "Aspid/Vector", Name = "Vector2 Clamp Magnitude", Tooltip = "Keeps a 2D vector inside a length")]
+    public sealed class Vector2ClampMagnitudeConverter : IConverterVector2
+    {
+        [Tooltip("The longest the vector is allowed to be.")]
+        [SerializeField] private float _maxMagnitude = 1f;
+
+        [Tooltip("The shortest the vector is allowed to be. Zero disables the lower bound.")]
+        [SerializeField] private float _minMagnitude;
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="Vector2ClampMagnitudeConverter"/> class clamping to one.
+        /// </summary>
+        public Vector2ClampMagnitudeConverter() { }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="Vector2ClampMagnitudeConverter"/> class.
+        /// </summary>
+        /// <param name="maxMagnitude">The longest the vector is allowed to be.</param>
+        /// <param name="minMagnitude">The shortest the vector is allowed to be.</param>
+        public Vector2ClampMagnitudeConverter(float maxMagnitude, float minMagnitude = 0f)
+        {
+            _maxMagnitude = maxMagnitude;
+            _minMagnitude = minMagnitude;
+        }
+
+        /// <summary>
+        /// Clamps the length of the specified vector.
+        /// </summary>
+        /// <param name="value">The vector to clamp.</param>
+        /// <returns>
+        /// The clamped vector. A pair typed the wrong way round is read in the order that holds the
+        /// vector inside both bounds, and a negative ceiling reads as zero.
+        /// </returns>
+        public Vector2 Convert(Vector2 value)
+        {
+            var magnitude = value.magnitude;
+
+            // A zero vector has no direction to stretch along, so the lower bound cannot be applied
+            // to it — the same choice the Vector3 converter makes.
+            if (magnitude == 0f) return value;
+
+            // Shared with the Vector3 converter so the bounds of the pair are ordered the same way.
+            return value * VectorClampMagnitudeConverter.ClampScale(magnitude, _minMagnitude, _maxMagnitude);
+        }
+    }
+}

--- a/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Unity/Runtime/Converters/Vectors/Vector2ClampMagnitudeConverter.cs.meta
+++ b/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Unity/Runtime/Converters/Vectors/Vector2ClampMagnitudeConverter.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 5ddd8c5d0d239a2e287a9195b5a06714

--- a/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Unity/Runtime/Converters/Vectors/Vector2CombineConverter.cs
+++ b/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Unity/Runtime/Converters/Vectors/Vector2CombineConverter.cs
@@ -1,19 +1,46 @@
 #nullable enable
-using Aspid.FastTools.Types;
 using System;
 using UnityEngine;
 using Converter = Aspid.MVVM.StarterKit.IConverter<UnityEngine.Vector2, UnityEngine.Vector2>;
+
+// The named converter aliases are [Obsolete]. The converters below keep implementing them for
+// one release so that a [SerializeReference] field a project declares as one still
+// deserializes; the base lists go with the aliases in the next major.
+#pragma warning disable CS0618 // Type or member is obsolete
 
 // ReSharper disable once CheckNamespace
 namespace Aspid.MVVM.StarterKit
 {
     /// <summary>
-    /// Combines two <see cref="Vector2"/> values by selecting which components to use from each vector.
-    /// Supports optional pre- and post-conversion transformations.
+    /// Base class for converters that combine a bound 2D vector with one read from a scene component
+    /// by selecting components. Supports optional pre- and post-conversion transformations.
     /// </summary>
+    /// <remarks>
+    /// Binding one axis and leaving the other where the designer put it: a bar that grows in width
+    /// only, a marker that slides along X while its Y stays with the layout.
+    /// <para>
+    /// The 3D half of this pair has had eight subclasses since 1.0. The 2D half had none, and the
+    /// class itself did not implement <see cref="IConverter{TFrom, TTo}"/> — a
+    /// <c>Convert(Vector2, Vector2)</c> nothing in the package calls, so none of it was reachable
+    /// from a binder. Everything authored in two dimensions had to widen to <see cref="Vector3"/>
+    /// and back, or do the selection in the ViewModel.
+    /// </para>
+    /// <para>
+    /// Breaking change: this class shipped <see langword="sealed"/> and concrete, and becoming a
+    /// base class takes its <c>Default</c> property and its <c>Convert(Vector2, Vector2)</c>
+    /// overload with it. Code that constructed one directly, or a <c>[SerializeReference]</c> field
+    /// holding one, now names a type that cannot be instantiated: pick the concrete converter for
+    /// the component the reference vector is read from — <see cref="TransformPosition2DCombineConverter"/>,
+    /// <see cref="RectTransformAnchoredPosition2DCombineConverter"/>,
+    /// <see cref="RectTransformSizeDeltaCombineConverter"/>,
+    /// <see cref="BoxCollider2DSizeCombineConverter"/> or
+    /// <see cref="BoxCollider2DOffsetCombineConverter"/>.
+    /// </para>
+    /// </remarks>
     [Serializable]
-    [TypeSelectorDisplay(Group = "Aspid/Vector", Name = "Vector2 Combine", Tooltip = "Combines two Vector2 values by selecting which components to use from each vector")]
-    public sealed class Vector2CombineConverter
+    public abstract class Vector2CombineConverter :
+        IConverterVector2,
+        IConverterVector3ToVector2
     {
         [Tooltip("Which components come from the bound vector; the rest come from the reference one.")]
         [SerializeField] private Mode _mode;
@@ -23,6 +50,8 @@ namespace Aspid.MVVM.StarterKit
 
         [Tooltip("Applied to the combined result.")]
         [SerializeReference] private Converter? _postConvertor;
+
+        [NonSerialized] private bool _loggedMissingTarget;
 
         /// <summary>
         /// Initializes a new instance of the <see cref="Vector2CombineConverter"/> class with XY mode.
@@ -79,12 +108,62 @@ namespace Aspid.MVVM.StarterKit
         }
 
         /// <summary>
+        /// Gets the scene component <see cref="VectorTo"/> is read from. Derived classes must provide
+        /// this value so an unassigned or destroyed Inspector reference can be detected before use.
+        /// </summary>
+        protected abstract Component? Target { get; }
+
+        /// <summary>
+        /// Gets the reference vector to combine with. Derived classes must provide this value.
+        /// </summary>
+        /// <remarks>Only read once <see cref="Target"/> is known to be alive.</remarks>
+        protected abstract Vector2 VectorTo { get; }
+
+        /// <summary>
+        /// Combines a <see cref="Vector2"/> with the reference vector by selecting components.
+        /// </summary>
+        /// <param name="value">The vector to convert.</param>
+        /// <returns>The combined vector, or the input unchanged when <see cref="Target"/> is missing.</returns>
+        public Vector2 Convert(Vector2 value) =>
+            Combine(value);
+
+        /// <summary>
+        /// Combines a <see cref="Vector3"/> with the reference vector, dropping its Z.
+        /// </summary>
+        /// <param name="value">The 3D vector to convert.</param>
+        /// <returns>The combined vector, or the narrowed input when <see cref="Target"/> is missing.</returns>
+        public Vector2 Convert(Vector3 value) =>
+            Combine(value);
+
+        /// <summary>
+        /// Reads the reference vector and combines with it, degrading to the input when the target
+        /// reference was never assigned or has since been destroyed.
+        /// </summary>
+        private Vector2 Combine(Vector2 from)
+        {
+            // Unity's overloaded == is deliberate: `is null` reports false for a destroyed object,
+            // whose managed reference is still alive. Same idiom as Vector3CombineConverter.
+            if (Target == null)
+            {
+                LogMissingTarget();
+                return from;
+            }
+
+            return Combine(from, VectorTo);
+        }
+
+        private void LogMissingTarget()
+        {
+            if (_loggedMissingTarget) return;
+            _loggedMissingTarget = true;
+
+            Debug.LogError($"{GetType().Name}: no target assigned. Returning the input value unchanged.");
+        }
+
+        /// <summary>
         /// Combines two vectors by selecting components from each based on the configured mode.
         /// </summary>
-        /// <param name="from">The first vector, whose components are selected based on the mode.</param>
-        /// <param name="to">The second vector, whose components fill in the remaining parts.</param>
-        /// <returns>The combined vector.</returns>
-        public Vector2 Convert(Vector2 from, Vector2 to)
+        private Vector2 Combine(Vector2 from, Vector2 to)
         {
             from = _preConvertor?.Convert(from) ?? from;
 
@@ -98,11 +177,6 @@ namespace Aspid.MVVM.StarterKit
 
             return _postConvertor?.Convert(from) ?? from;
         }
-
-        /// <summary>
-        /// Gets a default converter instance that uses XY mode.
-        /// </summary>
-        public static Vector2CombineConverter Default => new(Mode.XY);
 
         /// <summary>
         /// Specifies which components to take from the first vector when combining.

--- a/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Unity/Runtime/Converters/Vectors/Vector2CombineConverter.cs
+++ b/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Unity/Runtime/Converters/Vectors/Vector2CombineConverter.cs
@@ -16,21 +16,14 @@ namespace Aspid.MVVM.StarterKit
     /// by selecting components. Supports optional pre- and post-conversion transformations.
     /// </summary>
     /// <remarks>
-    /// Binding one axis and leaving the other where the designer put it: a bar that grows in width
-    /// only, a marker that slides along X while its Y stays with the layout.
+    /// Binding one axis and leaving the other where the designer put it: a bar that grows in width only,
+    /// a marker that slides along X while its Y stays with the layout.
     /// <para>
-    /// The 3D half of this pair has had eight subclasses since 1.0. The 2D half had none, and the
-    /// class itself did not implement <see cref="IConverter{TFrom, TTo}"/> — a
-    /// <c>Convert(Vector2, Vector2)</c> nothing in the package calls, so none of it was reachable
-    /// from a binder. Everything authored in two dimensions had to widen to <see cref="Vector3"/>
-    /// and back, or do the selection in the ViewModel.
-    /// </para>
-    /// <para>
-    /// Breaking change: this class shipped <see langword="sealed"/> and concrete, and becoming a
-    /// base class takes its <c>Default</c> property and its <c>Convert(Vector2, Vector2)</c>
-    /// overload with it. Code that constructed one directly, or a <c>[SerializeReference]</c> field
-    /// holding one, now names a type that cannot be instantiated: pick the concrete converter for
-    /// the component the reference vector is read from — <see cref="TransformPosition2DCombineConverter"/>,
+    /// Breaking change: this class shipped <see langword="sealed"/> and concrete, and becoming a base
+    /// class takes its <c>Default</c> property and its <c>Convert(Vector2, Vector2)</c> overload with it.
+    /// Code that constructed one directly, or a <c>[SerializeReference]</c> field holding one, now names
+    /// a type that cannot be instantiated: pick the concrete converter for the component the reference
+    /// vector is read from — <see cref="TransformPosition2DCombineConverter"/>,
     /// <see cref="RectTransformAnchoredPosition2DCombineConverter"/>,
     /// <see cref="RectTransformSizeDeltaCombineConverter"/>,
     /// <see cref="BoxCollider2DSizeCombineConverter"/> or

--- a/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Unity/Runtime/Converters/Vectors/Vector2Component.cs
+++ b/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Unity/Runtime/Converters/Vectors/Vector2Component.cs
@@ -1,0 +1,40 @@
+#nullable enable
+
+// ReSharper disable once CheckNamespace
+namespace Aspid.MVVM.StarterKit
+{
+    /// <summary>
+    /// What <see cref="Vector2ToFloatConverter"/> measures.
+    /// </summary>
+    /// <remarks>
+    /// A separate enum from <see cref="VectorComponent"/> so the Inspector does not offer a Z axis
+    /// on a value that has none.
+    /// </remarks>
+    public enum Vector2Component
+    {
+        /// <summary>
+        /// The X axis.
+        /// </summary>
+        X,
+
+        /// <summary>
+        /// The Y axis.
+        /// </summary>
+        Y,
+
+        /// <summary>
+        /// The length of the vector.
+        /// </summary>
+        Magnitude,
+
+        /// <summary>
+        /// The squared length, which needs no square root.
+        /// </summary>
+        SqrMagnitude,
+
+        /// <summary>
+        /// How far the vector reaches along an authored direction.
+        /// </summary>
+        Dot,
+    }
+}

--- a/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Unity/Runtime/Converters/Vectors/Vector2Component.cs.meta
+++ b/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Unity/Runtime/Converters/Vectors/Vector2Component.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 041dd720ccbaa982063bf3f2082f7ca7

--- a/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Unity/Runtime/Converters/Vectors/Vector2NormalizeConverter.cs
+++ b/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Unity/Runtime/Converters/Vectors/Vector2NormalizeConverter.cs
@@ -1,0 +1,36 @@
+#nullable enable
+using Aspid.FastTools.Types;
+using System;
+using UnityEngine;
+
+// The named converter aliases are [Obsolete]. The converters below keep implementing them for
+// one release so that a [SerializeReference] field a project declares as one still
+// deserializes; the base lists go with the aliases in the next major.
+#pragma warning disable CS0618 // Type or member is obsolete
+
+// ReSharper disable once CheckNamespace
+namespace Aspid.MVVM.StarterKit
+{
+    /// <summary>
+    /// Reduces a 2D vector to its direction.
+    /// </summary>
+    /// <remarks>
+    /// The 2D counterpart of <see cref="VectorNormalizeConverter"/>: taking the direction of a
+    /// joystick or a drag with its throw dropped, so a stick pushed halfway aims a marker exactly
+    /// where one pushed to the rim does.
+    /// </remarks>
+    [Serializable]
+    [TypeSelectorDisplay(Group = "Aspid/Vector", Name = "Vector2 Normalize", Tooltip = "Reduces a 2D vector to its direction")]
+    public sealed class Vector2NormalizeConverter : IConverterVector2
+    {
+        /// <summary>
+        /// Normalises the specified vector.
+        /// </summary>
+        /// <param name="value">The vector to normalise.</param>
+        /// <returns>
+        /// The unit vector pointing the same way, or zero for a zero-length input — Unity's own
+        /// <c>normalized</c> does the same rather than producing a NaN.
+        /// </returns>
+        public Vector2 Convert(Vector2 value) => value.normalized;
+    }
+}

--- a/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Unity/Runtime/Converters/Vectors/Vector2NormalizeConverter.cs.meta
+++ b/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Unity/Runtime/Converters/Vectors/Vector2NormalizeConverter.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: cbd6ff82d8c8dbebcd8bdff5b92d155a

--- a/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Unity/Runtime/Converters/Vectors/Vector2RoundConverter.cs
+++ b/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Unity/Runtime/Converters/Vectors/Vector2RoundConverter.cs
@@ -28,14 +28,9 @@ namespace Aspid.MVVM.StarterKit
         [Tooltip("The size of one grid step. Zero rounds to whole numbers.")]
         [SerializeField] private float _step;
 
-        /// <summary>
-        /// Initializes a new instance of the <see cref="Vector2RoundConverter"/> class rounding to whole numbers.
-        /// </summary>
+        /// <remarks>Default: rounding to whole numbers.</remarks>
         public Vector2RoundConverter() { }
 
-        /// <summary>
-        /// Initializes a new instance of the <see cref="Vector2RoundConverter"/> class.
-        /// </summary>
         /// <param name="mode">Which way to drop the fraction.</param>
         /// <param name="step">The size of one grid step.</param>
         public Vector2RoundConverter(RoundMode mode, float step = 0f)

--- a/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Unity/Runtime/Converters/Vectors/Vector2RoundConverter.cs
+++ b/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Unity/Runtime/Converters/Vectors/Vector2RoundConverter.cs
@@ -1,0 +1,74 @@
+#nullable enable
+using Aspid.FastTools.Types;
+using System;
+using UnityEngine;
+
+// The named converter aliases are [Obsolete]. The converters below keep implementing them for
+// one release so that a [SerializeReference] field a project declares as one still
+// deserializes; the base lists go with the aliases in the next major.
+#pragma warning disable CS0618 // Type or member is obsolete
+
+// ReSharper disable once CheckNamespace
+namespace Aspid.MVVM.StarterKit
+{
+    /// <summary>
+    /// Rounds both axes of a 2D vector.
+    /// </summary>
+    /// <remarks>
+    /// The 2D counterpart of <see cref="VectorRoundConverter"/>, and the form a tile coordinate or a
+    /// snapped anchored position arrives in.
+    /// </remarks>
+    [Serializable]
+    [TypeSelectorDisplay(Group = "Aspid/Vector", Name = "Vector2 Round", Tooltip = "Rounds both axes of a 2D vector")]
+    public sealed class Vector2RoundConverter : IConverterVector2
+    {
+        [Tooltip("Which way to drop the fraction.")]
+        [SerializeField] private RoundMode _mode;
+
+        [Tooltip("The size of one grid step. Zero rounds to whole numbers.")]
+        [SerializeField] private float _step;
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="Vector2RoundConverter"/> class rounding to whole numbers.
+        /// </summary>
+        public Vector2RoundConverter() { }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="Vector2RoundConverter"/> class.
+        /// </summary>
+        /// <param name="mode">Which way to drop the fraction.</param>
+        /// <param name="step">The size of one grid step.</param>
+        public Vector2RoundConverter(RoundMode mode, float step = 0f)
+        {
+            _mode = mode;
+            _step = step;
+        }
+
+        /// <summary>
+        /// Rounds both axes of the specified vector.
+        /// </summary>
+        /// <param name="value">The vector to round.</param>
+        /// <returns>The rounded vector.</returns>
+        public Vector2 Convert(Vector2 value) => new(Apply(value.x), Apply(value.y));
+
+        /// <exception cref="ArgumentOutOfRangeException">Thrown when the mode is not a declared value.</exception>
+        private float Apply(float value)
+        {
+            // A step of zero would divide the value away, so it reads as "no grid" — which is the
+            // only thing an unset step can sensibly mean.
+            var step = _step == 0f ? 1f : _step;
+            var scaled = value / step;
+
+            var rounded = _mode switch
+            {
+                RoundMode.Round => Mathf.Round(scaled),
+                RoundMode.Floor => Mathf.Floor(scaled),
+                RoundMode.Ceil => Mathf.Ceil(scaled),
+                RoundMode.Truncate => (float)Math.Truncate(scaled),
+                _ => throw new ArgumentOutOfRangeException(nameof(_mode), _mode, null)
+            };
+
+            return rounded * step;
+        }
+    }
+}

--- a/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Unity/Runtime/Converters/Vectors/Vector2RoundConverter.cs.meta
+++ b/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Unity/Runtime/Converters/Vectors/Vector2RoundConverter.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: da790b77746443e7cc5f800818de129b

--- a/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Unity/Runtime/Converters/Vectors/Vector2ToFloatConverter.cs
+++ b/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Unity/Runtime/Converters/Vectors/Vector2ToFloatConverter.cs
@@ -25,24 +25,16 @@ namespace Aspid.MVVM.StarterKit
         [Tooltip("The direction Dot measures along. Keep it unit length to read a plain distance.")]
         [SerializeField] private Vector2 _dotAgainst = Vector2.up;
 
-        /// <summary>
-        /// Initializes a new instance of the <see cref="Vector2ToFloatConverter"/> class measuring length.
-        /// </summary>
+        /// <remarks>Default: measuring length.</remarks>
         public Vector2ToFloatConverter() { }
 
-        /// <summary>
-        /// Initializes a new instance of the <see cref="Vector2ToFloatConverter"/> class.
-        /// </summary>
         /// <param name="component">Which number to take.</param>
         public Vector2ToFloatConverter(Vector2Component component)
         {
             _component = component;
         }
 
-        /// <summary>
-        /// Initializes a new instance of the <see cref="Vector2ToFloatConverter"/> class measuring
-        /// along a direction.
-        /// </summary>
+        /// <remarks>Default: measuring along a direction.</remarks>
         /// <param name="dotAgainst">The direction to measure along.</param>
         public Vector2ToFloatConverter(Vector2 dotAgainst)
         {

--- a/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Unity/Runtime/Converters/Vectors/Vector2ToFloatConverter.cs
+++ b/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Unity/Runtime/Converters/Vectors/Vector2ToFloatConverter.cs
@@ -1,0 +1,72 @@
+#nullable enable
+using Aspid.FastTools.Types;
+using System;
+using UnityEngine;
+
+// ReSharper disable once CheckNamespace
+namespace Aspid.MVVM.StarterKit
+{
+    /// <summary>
+    /// Measures one number out of a 2D vector.
+    /// </summary>
+    /// <remarks>
+    /// The 2D counterpart of <see cref="Vector3ToFloatConverter"/>: a joystick's throw driving a
+    /// speed readout, a drag offset driving a bar.
+    /// </remarks>
+    [Serializable]
+    [TypeSelectorDisplay(Group = "Aspid/Vector", Name = "Vector2 To Float", Tooltip = "Measures one number out of a 2D vector")]
+    public sealed class Vector2ToFloatConverter : IConverter<Vector2, float>
+    {
+        [Tooltip("Which number to take.")]
+        [SerializeField] private Vector2Component _component = Vector2Component.Magnitude;
+
+        // Up rather than right, so the same-named setting on the 3D converter and on this one starts
+        // pointing the same way.
+        [Tooltip("The direction Dot measures along. Keep it unit length to read a plain distance.")]
+        [SerializeField] private Vector2 _dotAgainst = Vector2.up;
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="Vector2ToFloatConverter"/> class measuring length.
+        /// </summary>
+        public Vector2ToFloatConverter() { }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="Vector2ToFloatConverter"/> class.
+        /// </summary>
+        /// <param name="component">Which number to take.</param>
+        public Vector2ToFloatConverter(Vector2Component component)
+        {
+            _component = component;
+        }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="Vector2ToFloatConverter"/> class measuring
+        /// along a direction.
+        /// </summary>
+        /// <param name="dotAgainst">The direction to measure along.</param>
+        public Vector2ToFloatConverter(Vector2 dotAgainst)
+        {
+            _component = Vector2Component.Dot;
+            _dotAgainst = dotAgainst;
+        }
+
+        /// <summary>
+        /// Measures the specified vector.
+        /// </summary>
+        /// <param name="value">The vector to measure.</param>
+        /// <returns>
+        /// The measurement. <see cref="Vector2Component.Dot"/> is the raw dot product, so a unit
+        /// direction reads as the signed distance along it and a longer one scales that reading.
+        /// </returns>
+        /// <exception cref="ArgumentOutOfRangeException">Thrown when the component is not a declared value.</exception>
+        public float Convert(Vector2 value) => _component switch
+        {
+            Vector2Component.X => value.x,
+            Vector2Component.Y => value.y,
+            Vector2Component.Magnitude => value.magnitude,
+            Vector2Component.SqrMagnitude => value.sqrMagnitude,
+            Vector2Component.Dot => Vector2.Dot(value, _dotAgainst),
+            _ => throw new ArgumentOutOfRangeException(nameof(_component), _component, null)
+        };
+    }
+}

--- a/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Unity/Runtime/Converters/Vectors/Vector2ToFloatConverter.cs.meta
+++ b/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Unity/Runtime/Converters/Vectors/Vector2ToFloatConverter.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 4410b556582be6bee0bd2f6f0f4f98e5

--- a/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Unity/Runtime/Converters/Vectors/Vector2ToVector3Converter.cs
+++ b/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Unity/Runtime/Converters/Vectors/Vector2ToVector3Converter.cs
@@ -53,17 +53,31 @@ namespace Aspid.MVVM.StarterKit
             Mode.XY => new Vector3(value.x, value.y, _thirdValue),
             Mode.XZ => new Vector3(value.x, _thirdValue, value.y),
             Mode.YZ => new Vector3(_thirdValue, value.x, value.y),
+            Mode.YX => new Vector3(value.y, value.x, _thirdValue),
+            Mode.ZX => new Vector3(value.y, _thirdValue, value.x),
+            Mode.ZY => new Vector3(_thirdValue, value.y, value.x),
             _ => throw new ArgumentOutOfRangeException(nameof(_values), _values, null)
         };
 
         /// <summary>
-        /// Specifies which components of the 2D vector to map to the 3D vector.
+        /// Specifies which components of the 2D vector to map to the 3D vector. The letters name the
+        /// destination axes, in the order the 2D components are read.
         /// </summary>
+        /// <remarks>
+        /// The last three complete the set <see cref="Vector3ToVector2Converter"/> has always
+        /// offered, so the pair round-trips whichever order was picked there. They are appended
+        /// rather than filed in alphabetical order because the declaration order is the value Unity
+        /// stores — inserting YX between XZ and YZ would silently repoint every field authored as
+        /// YZ.
+        /// </remarks>
         public enum Mode
         {
             XY,
             XZ,
             YZ,
+            YX,
+            ZX,
+            ZY,
         }
     }
 }

--- a/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Unity/Runtime/Converters/Vectors/Vector3ArithmeticConverter.cs.meta
+++ b/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Unity/Runtime/Converters/Vectors/Vector3ArithmeticConverter.cs.meta
@@ -1,2 +1,2 @@
 fileFormatVersion: 2
-guid: 6b6c4fb72048047f798f87c093d641d5
+guid: ed644c1b9c6645fcb33c0f4fd25ef82a

--- a/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Unity/Runtime/Converters/Vectors/Vector3ToFloatConverter.cs
+++ b/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Unity/Runtime/Converters/Vectors/Vector3ToFloatConverter.cs
@@ -17,6 +17,9 @@ namespace Aspid.MVVM.StarterKit
         [Tooltip("Which number to take.")]
         [SerializeField] private VectorComponent _component = VectorComponent.Magnitude;
 
+        [Tooltip("The direction Dot measures along. Keep it unit length to read a plain distance.")]
+        [SerializeField] private Vector3 _dotAgainst = Vector3.up;
+
         /// <remarks>Default: measuring length.</remarks>
         public Vector3ToFloatConverter() { }
 
@@ -27,10 +30,24 @@ namespace Aspid.MVVM.StarterKit
         }
 
         /// <summary>
+        /// Initializes a new instance of the <see cref="Vector3ToFloatConverter"/> class measuring
+        /// along a direction.
+        /// </summary>
+        /// <param name="dotAgainst">The direction to measure along.</param>
+        public Vector3ToFloatConverter(Vector3 dotAgainst)
+        {
+            _component = VectorComponent.Dot;
+            _dotAgainst = dotAgainst;
+        }
+
+        /// <summary>
         /// Measures the specified vector.
         /// </summary>
         /// <param name="value">The vector to measure.</param>
-        /// <returns>The measurement.</returns>
+        /// <returns>
+        /// The measurement. <see cref="VectorComponent.Dot"/> is the raw dot product, so a unit
+        /// direction reads as the signed distance along it and a longer one scales that reading.
+        /// </returns>
         /// <exception cref="ArgumentOutOfRangeException">Thrown when the component is not a declared value.</exception>
         public float Convert(Vector3 value) => _component switch
         {
@@ -39,6 +56,7 @@ namespace Aspid.MVVM.StarterKit
             VectorComponent.Z => value.z,
             VectorComponent.Magnitude => value.magnitude,
             VectorComponent.SqrMagnitude => value.sqrMagnitude,
+            VectorComponent.Dot => Vector3.Dot(value, _dotAgainst),
             _ => throw new ArgumentOutOfRangeException(nameof(_component), _component, null)
         };
     }

--- a/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Unity/Runtime/Converters/Vectors/Vector3ToFloatConverter.cs
+++ b/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Unity/Runtime/Converters/Vectors/Vector3ToFloatConverter.cs
@@ -29,10 +29,7 @@ namespace Aspid.MVVM.StarterKit
             _component = component;
         }
 
-        /// <summary>
-        /// Initializes a new instance of the <see cref="Vector3ToFloatConverter"/> class measuring
-        /// along a direction.
-        /// </summary>
+        /// <remarks>Default: measuring along a direction.</remarks>
         /// <param name="dotAgainst">The direction to measure along.</param>
         public Vector3ToFloatConverter(Vector3 dotAgainst)
         {

--- a/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Unity/Runtime/Converters/Vectors/Vector3ToVector4Converter.cs
+++ b/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Unity/Runtime/Converters/Vectors/Vector3ToVector4Converter.cs
@@ -21,14 +21,9 @@ namespace Aspid.MVVM.StarterKit
         [Tooltip("The value written into the fourth component.")]
         [SerializeField] private float _w;
 
-        /// <summary>
-        /// Initializes a new instance of the <see cref="Vector3ToVector4Converter"/> class with a zero fourth component.
-        /// </summary>
+        /// <remarks>Default: with a zero fourth component.</remarks>
         public Vector3ToVector4Converter() { }
 
-        /// <summary>
-        /// Initializes a new instance of the <see cref="Vector3ToVector4Converter"/> class.
-        /// </summary>
         /// <param name="w">The value written into the fourth component.</param>
         public Vector3ToVector4Converter(float w)
         {

--- a/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Unity/Runtime/Converters/Vectors/Vector3ToVector4Converter.cs
+++ b/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Unity/Runtime/Converters/Vectors/Vector3ToVector4Converter.cs
@@ -1,0 +1,45 @@
+#nullable enable
+using Aspid.FastTools.Types;
+using System;
+using UnityEngine;
+
+// ReSharper disable once CheckNamespace
+namespace Aspid.MVVM.StarterKit
+{
+    /// <summary>
+    /// Widens a vector to four components.
+    /// </summary>
+    /// <remarks>
+    /// A shader property is a <see cref="Vector4"/> whatever it holds, so binding a position, a
+    /// direction or a tiling pair to one meant widening it in the ViewModel — which pushed a detail
+    /// of the material into the model.
+    /// </remarks>
+    [Serializable]
+    [TypeSelectorDisplay(Group = "Aspid/Vector", Name = "Vector3 To Vector4", Tooltip = "Widens a vector to four components")]
+    public sealed class Vector3ToVector4Converter : IConverter<Vector3, Vector4>
+    {
+        [Tooltip("The value written into the fourth component.")]
+        [SerializeField] private float _w;
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="Vector3ToVector4Converter"/> class with a zero fourth component.
+        /// </summary>
+        public Vector3ToVector4Converter() { }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="Vector3ToVector4Converter"/> class.
+        /// </summary>
+        /// <param name="w">The value written into the fourth component.</param>
+        public Vector3ToVector4Converter(float w)
+        {
+            _w = w;
+        }
+
+        /// <summary>
+        /// Widens the specified vector.
+        /// </summary>
+        /// <param name="value">The vector to widen.</param>
+        /// <returns>The four-component vector.</returns>
+        public Vector4 Convert(Vector3 value) => new(value.x, value.y, value.z, _w);
+    }
+}

--- a/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Unity/Runtime/Converters/Vectors/Vector3ToVector4Converter.cs.meta
+++ b/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Unity/Runtime/Converters/Vectors/Vector3ToVector4Converter.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: e94e1fdaf306b3367f6e057a5ccdf2f7

--- a/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Unity/Runtime/Converters/Vectors/Vector4Component.cs
+++ b/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Unity/Runtime/Converters/Vectors/Vector4Component.cs
@@ -1,0 +1,31 @@
+#nullable enable
+
+// ReSharper disable once CheckNamespace
+namespace Aspid.MVVM.StarterKit
+{
+    /// <summary>
+    /// Which component of a four-component vector a converter reads.
+    /// </summary>
+    public enum Vector4Component
+    {
+        /// <summary>
+        /// The X component.
+        /// </summary>
+        X,
+
+        /// <summary>
+        /// The Y component.
+        /// </summary>
+        Y,
+
+        /// <summary>
+        /// The Z component.
+        /// </summary>
+        Z,
+
+        /// <summary>
+        /// The W component.
+        /// </summary>
+        W,
+    }
+}

--- a/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Unity/Runtime/Converters/Vectors/Vector4Component.cs.meta
+++ b/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Unity/Runtime/Converters/Vectors/Vector4Component.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: c85a3ddcb6edabee18ed5a660889b51d

--- a/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Unity/Runtime/Converters/Vectors/Vector4SwizzleConverter.cs
+++ b/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Unity/Runtime/Converters/Vectors/Vector4SwizzleConverter.cs
@@ -30,14 +30,8 @@ namespace Aspid.MVVM.StarterKit
         [Tooltip("Which incoming component the W of the result is read from.")]
         [SerializeField] private Vector4Component _w = Vector4Component.W;
 
-        /// <summary>
-        /// Initializes a new instance of the <see cref="Vector4SwizzleConverter"/> class that reorders nothing.
-        /// </summary>
         public Vector4SwizzleConverter() { }
 
-        /// <summary>
-        /// Initializes a new instance of the <see cref="Vector4SwizzleConverter"/> class.
-        /// </summary>
         /// <param name="x">Which incoming component the X of the result is read from.</param>
         /// <param name="y">Which incoming component the Y of the result is read from.</param>
         /// <param name="z">Which incoming component the Z of the result is read from.</param>

--- a/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Unity/Runtime/Converters/Vectors/Vector4SwizzleConverter.cs
+++ b/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Unity/Runtime/Converters/Vectors/Vector4SwizzleConverter.cs
@@ -1,0 +1,80 @@
+#nullable enable
+using Aspid.FastTools.Types;
+using System;
+using UnityEngine;
+
+// ReSharper disable once CheckNamespace
+namespace Aspid.MVVM.StarterKit
+{
+    /// <summary>
+    /// Reorders the components of a four-component vector.
+    /// </summary>
+    /// <remarks>
+    /// Completes the permutation family the 2D and 3D converters already cover. Shader authors and
+    /// importers order the four numbers however the tool that produced them saw fit, and reordering
+    /// them in the ViewModel puts a format detail in the model.
+    /// </remarks>
+    [Serializable]
+    [TypeSelectorDisplay(Group = "Aspid/Vector", Name = "Vector4 Swizzle", Tooltip = "Reorders the components of a four-component vector")]
+    public sealed class Vector4SwizzleConverter : IConverter<Vector4, Vector4>
+    {
+        [Tooltip("Which incoming component the X of the result is read from.")]
+        [SerializeField] private Vector4Component _x = Vector4Component.X;
+
+        [Tooltip("Which incoming component the Y of the result is read from.")]
+        [SerializeField] private Vector4Component _y = Vector4Component.Y;
+
+        [Tooltip("Which incoming component the Z of the result is read from.")]
+        [SerializeField] private Vector4Component _z = Vector4Component.Z;
+
+        [Tooltip("Which incoming component the W of the result is read from.")]
+        [SerializeField] private Vector4Component _w = Vector4Component.W;
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="Vector4SwizzleConverter"/> class that reorders nothing.
+        /// </summary>
+        public Vector4SwizzleConverter() { }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="Vector4SwizzleConverter"/> class.
+        /// </summary>
+        /// <param name="x">Which incoming component the X of the result is read from.</param>
+        /// <param name="y">Which incoming component the Y of the result is read from.</param>
+        /// <param name="z">Which incoming component the Z of the result is read from.</param>
+        /// <param name="w">Which incoming component the W of the result is read from.</param>
+        public Vector4SwizzleConverter(
+            Vector4Component x,
+            Vector4Component y,
+            Vector4Component z,
+            Vector4Component w)
+        {
+            _x = x;
+            _y = y;
+            _z = z;
+            _w = w;
+        }
+
+        /// <summary>
+        /// Reorders the specified vector.
+        /// </summary>
+        /// <param name="value">The vector to reorder.</param>
+        /// <returns>The reordered vector.</returns>
+        /// <exception cref="ArgumentOutOfRangeException">Thrown when a component is not a declared value.</exception>
+        public Vector4 Convert(Vector4 value) => new(
+            Read(value, _x),
+            Read(value, _y),
+            Read(value, _z),
+            Read(value, _w));
+
+        // Nothing stops the same source component being read into two destinations — a swizzle that
+        // broadcasts one number across the vector is a normal thing to want, not a misconfiguration.
+        private static float Read(Vector4 value, Vector4Component component) => component switch
+        {
+            Vector4Component.X => value.x,
+            Vector4Component.Y => value.y,
+            Vector4Component.Z => value.z,
+            Vector4Component.W => value.w,
+            _ => throw new ArgumentOutOfRangeException(nameof(component), component, null)
+        };
+    }
+}

--- a/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Unity/Runtime/Converters/Vectors/Vector4SwizzleConverter.cs.meta
+++ b/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Unity/Runtime/Converters/Vectors/Vector4SwizzleConverter.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: f22e143755e34ae68b59694f9236ee4b

--- a/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Unity/Runtime/Converters/Vectors/Vector4ToRectConverter.cs
+++ b/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Unity/Runtime/Converters/Vectors/Vector4ToRectConverter.cs
@@ -1,0 +1,29 @@
+#nullable enable
+using Aspid.FastTools.Types;
+using System;
+using UnityEngine;
+
+// ReSharper disable once CheckNamespace
+namespace Aspid.MVVM.StarterKit
+{
+    /// <summary>
+    /// Reads a four-component vector as a rectangle.
+    /// </summary>
+    /// <remarks>
+    /// A ViewModel that already holds four packed numbers — a shader property, a saved layout, a
+    /// record that arrived as x, y, width, height — meeting a View API typed as
+    /// <see cref="Rect"/>: a <see cref="RectTransform"/>, a camera viewport, a sprite border. The
+    /// package supported neither direction, so <see cref="Rect"/> could not be bound at all.
+    /// </remarks>
+    [Serializable]
+    [TypeSelectorDisplay(Group = "Aspid/Vector", Name = "Vector4 To Rect", Tooltip = "Reads a four-component vector as a rectangle")]
+    public sealed class Vector4ToRectConverter : IConverter<Vector4, Rect>
+    {
+        /// <summary>
+        /// Reads the specified vector as a rectangle.
+        /// </summary>
+        /// <param name="value">The vector to read, as x, y, width, height.</param>
+        /// <returns>The rectangle.</returns>
+        public Rect Convert(Vector4 value) => new(value.x, value.y, value.z, value.w);
+    }
+}

--- a/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Unity/Runtime/Converters/Vectors/Vector4ToRectConverter.cs.meta
+++ b/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Unity/Runtime/Converters/Vectors/Vector4ToRectConverter.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 70afb5a6460221a92757a38707cb344e

--- a/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Unity/Runtime/Converters/Vectors/Vector4ToVector3Converter.cs
+++ b/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Unity/Runtime/Converters/Vectors/Vector4ToVector3Converter.cs
@@ -1,0 +1,52 @@
+#nullable enable
+using Aspid.FastTools.Types;
+using System;
+using UnityEngine;
+
+// ReSharper disable once CheckNamespace
+namespace Aspid.MVVM.StarterKit
+{
+    /// <summary>
+    /// Narrows a four-component vector to three by dropping one of them.
+    /// </summary>
+    /// <remarks>
+    /// The way back from <see cref="Vector3ToVector4Converter"/>, for a shader property or a
+    /// serialized record read back into something a transform can use.
+    /// </remarks>
+    [Serializable]
+    [TypeSelectorDisplay(Group = "Aspid/Vector", Name = "Vector4 To Vector3", Tooltip = "Narrows a four-component vector to three by dropping one of them")]
+    public sealed class Vector4ToVector3Converter : IConverter<Vector4, Vector3>
+    {
+        [Tooltip("Which component is left out. The other three keep their order.")]
+        [SerializeField] private Vector4Component _drop = Vector4Component.W;
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="Vector4ToVector3Converter"/> class dropping W.
+        /// </summary>
+        public Vector4ToVector3Converter() { }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="Vector4ToVector3Converter"/> class.
+        /// </summary>
+        /// <param name="drop">Which component is left out.</param>
+        public Vector4ToVector3Converter(Vector4Component drop)
+        {
+            _drop = drop;
+        }
+
+        /// <summary>
+        /// Narrows the specified vector.
+        /// </summary>
+        /// <param name="value">The vector to narrow.</param>
+        /// <returns>The three-component vector.</returns>
+        /// <exception cref="ArgumentOutOfRangeException">Thrown when the component is not a declared value.</exception>
+        public Vector3 Convert(Vector4 value) => _drop switch
+        {
+            Vector4Component.X => new Vector3(value.y, value.z, value.w),
+            Vector4Component.Y => new Vector3(value.x, value.z, value.w),
+            Vector4Component.Z => new Vector3(value.x, value.y, value.w),
+            Vector4Component.W => new Vector3(value.x, value.y, value.z),
+            _ => throw new ArgumentOutOfRangeException(nameof(_drop), _drop, null)
+        };
+    }
+}

--- a/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Unity/Runtime/Converters/Vectors/Vector4ToVector3Converter.cs
+++ b/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Unity/Runtime/Converters/Vectors/Vector4ToVector3Converter.cs
@@ -20,14 +20,9 @@ namespace Aspid.MVVM.StarterKit
         [Tooltip("Which component is left out. The other three keep their order.")]
         [SerializeField] private Vector4Component _drop = Vector4Component.W;
 
-        /// <summary>
-        /// Initializes a new instance of the <see cref="Vector4ToVector3Converter"/> class dropping W.
-        /// </summary>
+        /// <remarks>Default: dropping W.</remarks>
         public Vector4ToVector3Converter() { }
 
-        /// <summary>
-        /// Initializes a new instance of the <see cref="Vector4ToVector3Converter"/> class.
-        /// </summary>
         /// <param name="drop">Which component is left out.</param>
         public Vector4ToVector3Converter(Vector4Component drop)
         {

--- a/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Unity/Runtime/Converters/Vectors/Vector4ToVector3Converter.cs.meta
+++ b/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Unity/Runtime/Converters/Vectors/Vector4ToVector3Converter.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 2146bf70bcf40be4a15190a99e7f6235

--- a/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Unity/Runtime/Converters/Vectors/VectorClampComponentsConverter.cs
+++ b/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Unity/Runtime/Converters/Vectors/VectorClampComponentsConverter.cs
@@ -1,0 +1,63 @@
+#nullable enable
+using Aspid.FastTools.Types;
+using System;
+using UnityEngine;
+
+// The named converter aliases are [Obsolete]. The converters below keep implementing them for
+// one release so that a [SerializeReference] field a project declares as one still
+// deserializes; the base lists go with the aliases in the next major.
+#pragma warning disable CS0618 // Type or member is obsolete
+
+// ReSharper disable once CheckNamespace
+namespace Aspid.MVVM.StarterKit
+{
+    /// <summary>
+    /// Keeps every axis of a vector between two bounds.
+    /// </summary>
+    /// <remarks>
+    /// Holding a dragged marker inside a panel, or a camera target inside the level — a limit that
+    /// is a box rather than the radius <see cref="VectorClampMagnitudeConverter"/> applies.
+    /// </remarks>
+    [Serializable]
+    [TypeSelectorDisplay(Group = "Aspid/Vector", Name = "Vector Clamp Components", Tooltip = "Keeps every axis of a vector between two bounds")]
+    public sealed class VectorClampComponentsConverter : IConverterVector3
+    {
+        [Tooltip("The lowest each axis is allowed to be.")]
+        [SerializeField] private Vector3 _min = new(-1f, -1f, -1f);
+
+        [Tooltip("The highest each axis is allowed to be.")]
+        [SerializeField] private Vector3 _max = Vector3.one;
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="VectorClampComponentsConverter"/> class clamping to ±1.
+        /// </summary>
+        public VectorClampComponentsConverter() { }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="VectorClampComponentsConverter"/> class.
+        /// </summary>
+        /// <param name="min">The lowest each axis is allowed to be.</param>
+        /// <param name="max">The highest each axis is allowed to be.</param>
+        public VectorClampComponentsConverter(Vector3 min, Vector3 max)
+        {
+            _min = min;
+            _max = max;
+        }
+
+        /// <summary>
+        /// Clamps every axis of the specified vector.
+        /// </summary>
+        /// <param name="value">The vector to clamp.</param>
+        /// <returns>The clamped vector.</returns>
+        public Vector3 Convert(Vector3 value) => new(
+            ClampComponent(value.x, _min.x, _max.x),
+            ClampComponent(value.y, _min.y, _max.y),
+            ClampComponent(value.z, _min.z, _max.z));
+
+        // Mathf.Clamp with the bounds the wrong way round returns the minimum for every input, so a
+        // pair typed in the wrong order reads as "the binding stopped working" rather than as a
+        // mistake in the Inspector. Ordering them costs a comparison and removes the trap.
+        internal static float ClampComponent(float value, float min, float max) =>
+            min <= max ? Mathf.Clamp(value, min, max) : Mathf.Clamp(value, max, min);
+    }
+}

--- a/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Unity/Runtime/Converters/Vectors/VectorClampComponentsConverter.cs
+++ b/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Unity/Runtime/Converters/Vectors/VectorClampComponentsConverter.cs
@@ -28,14 +28,9 @@ namespace Aspid.MVVM.StarterKit
         [Tooltip("The highest each axis is allowed to be.")]
         [SerializeField] private Vector3 _max = Vector3.one;
 
-        /// <summary>
-        /// Initializes a new instance of the <see cref="VectorClampComponentsConverter"/> class clamping to ±1.
-        /// </summary>
+        /// <remarks>Default: clamping to ±1.</remarks>
         public VectorClampComponentsConverter() { }
 
-        /// <summary>
-        /// Initializes a new instance of the <see cref="VectorClampComponentsConverter"/> class.
-        /// </summary>
         /// <param name="min">The lowest each axis is allowed to be.</param>
         /// <param name="max">The highest each axis is allowed to be.</param>
         public VectorClampComponentsConverter(Vector3 min, Vector3 max)

--- a/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Unity/Runtime/Converters/Vectors/VectorClampComponentsConverter.cs.meta
+++ b/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Unity/Runtime/Converters/Vectors/VectorClampComponentsConverter.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: e62902888bcdd5ad7ef05deca0016561

--- a/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Unity/Runtime/Converters/Vectors/VectorClampMagnitudeConverter.cs
+++ b/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Unity/Runtime/Converters/Vectors/VectorClampMagnitudeConverter.cs
@@ -40,16 +40,33 @@ namespace Aspid.MVVM.StarterKit
         /// Clamps the length of the specified vector.
         /// </summary>
         /// <param name="value">The vector to clamp.</param>
-        /// <returns>The clamped vector.</returns>
+        /// <returns>
+        /// The clamped vector. A pair typed the wrong way round is read in the order that holds the
+        /// vector inside both bounds, and a negative ceiling reads as zero.
+        /// </returns>
         public Vector3 Convert(Vector3 value)
         {
             var magnitude = value.magnitude;
             if (magnitude == 0f) return value;
 
-            if (magnitude > _maxMagnitude) return value * (_maxMagnitude / magnitude);
-            if (_minMagnitude > 0f && magnitude < _minMagnitude) return value * (_minMagnitude / magnitude);
+            return value * ClampScale(magnitude, _minMagnitude, _maxMagnitude);
+        }
 
-            return value;
+        // Taken raw, a ceiling below the floor shrinks a long vector past the floor and stretches a
+        // short one past the ceiling — one instance breaking both of its own bounds, which reads as
+        // "the binding stopped working" rather than as a mistake in the Inspector. A negative
+        // ceiling is worse: scaling by it turns the vector around, from a converter whose whole job
+        // is to keep a length. Ordering the pair and holding it at zero costs two comparisons and
+        // removes both traps, the way VectorClampComponentsConverter.ClampComponent does.
+        internal static float ClampScale(float magnitude, float minMagnitude, float maxMagnitude)
+        {
+            var lower = Mathf.Max(0f, Mathf.Min(minMagnitude, maxMagnitude));
+            var upper = Mathf.Max(0f, Mathf.Max(minMagnitude, maxMagnitude));
+
+            if (magnitude > upper) return upper / magnitude;
+            if (lower > 0f && magnitude < lower) return lower / magnitude;
+
+            return 1f;
         }
     }
 }

--- a/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Unity/Runtime/Converters/Vectors/VectorComponent.cs
+++ b/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Unity/Runtime/Converters/Vectors/VectorComponent.cs
@@ -32,5 +32,13 @@ namespace Aspid.MVVM.StarterKit
         /// The squared length, which needs no square root.
         /// </summary>
         SqrMagnitude,
+
+        // Appended rather than filed next to the axes: the declaration order is the value Unity
+        // stores, so slotting a member in ahead of the others would repoint every field already
+        // authored against them.
+        /// <summary>
+        /// How far the vector reaches along an authored direction.
+        /// </summary>
+        Dot,
     }
 }

--- a/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Unity/Runtime/Converters/Vectors/VectorDistanceConverter.cs
+++ b/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Unity/Runtime/Converters/Vectors/VectorDistanceConverter.cs
@@ -1,0 +1,74 @@
+#nullable enable
+using Aspid.FastTools.Types;
+using System;
+using UnityEngine;
+
+// ReSharper disable once CheckNamespace
+namespace Aspid.MVVM.StarterKit
+{
+    /// <summary>
+    /// Measures how far a position is from a target.
+    /// </summary>
+    /// <remarks>
+    /// The "300 m" on a waypoint marker, or a proximity bar that fills as the player closes in.
+    /// Without it the ViewModel has to hold a <see cref="Transform"/> and read the scene every time
+    /// the distance is asked for, which is the one thing a ViewModel is meant not to do.
+    /// </remarks>
+    [Serializable]
+    [TypeSelectorDisplay(Group = "Aspid/Vector", Name = "Vector Distance", Tooltip = "Measures how far a position is from a target")]
+    public sealed class VectorDistanceConverter : IConverter<Vector3, float>
+    {
+        [Tooltip("The transform the distance is measured to. Leave it empty to measure to the point below.")]
+        [SerializeField] private Transform? _target;
+
+        [Tooltip("The position the distance is measured to when no transform is assigned.")]
+        [SerializeField] private Vector3 _point;
+
+        [Tooltip("Ignore the height difference, measuring along the ground only.")]
+        [SerializeField] private bool _flattenY;
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="VectorDistanceConverter"/> class measuring to the origin.
+        /// </summary>
+        public VectorDistanceConverter() { }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="VectorDistanceConverter"/> class measuring to a point.
+        /// </summary>
+        /// <param name="point">The position the distance is measured to.</param>
+        /// <param name="flattenY">Whether to ignore the height difference.</param>
+        public VectorDistanceConverter(Vector3 point, bool flattenY = false)
+        {
+            _point = point;
+            _flattenY = flattenY;
+        }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="VectorDistanceConverter"/> class measuring to a transform.
+        /// </summary>
+        /// <param name="target">The transform the distance is measured to.</param>
+        /// <param name="flattenY">Whether to ignore the height difference.</param>
+        public VectorDistanceConverter(Transform target, bool flattenY = false)
+        {
+            _target = target;
+            _flattenY = flattenY;
+        }
+
+        /// <summary>
+        /// Measures the specified position against the target.
+        /// </summary>
+        /// <param name="value">The position to measure from.</param>
+        /// <returns>The distance to the target, in world units.</returns>
+        public float Convert(Vector3 value)
+        {
+            // Unity's overloaded == is deliberate: `is null` reports false for a destroyed object,
+            // whose managed reference is still alive. An empty field is not a failure either — the
+            // authored point is what the converter measures to then, so nothing is reported.
+            var to = _target == null ? _point : _target.position;
+            var offset = value - to;
+
+            if (_flattenY) offset.y = 0f;
+            return offset.magnitude;
+        }
+    }
+}

--- a/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Unity/Runtime/Converters/Vectors/VectorDistanceConverter.cs
+++ b/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Unity/Runtime/Converters/Vectors/VectorDistanceConverter.cs
@@ -27,14 +27,10 @@ namespace Aspid.MVVM.StarterKit
         [Tooltip("Ignore the height difference, measuring along the ground only.")]
         [SerializeField] private bool _flattenY;
 
-        /// <summary>
-        /// Initializes a new instance of the <see cref="VectorDistanceConverter"/> class measuring to the origin.
-        /// </summary>
+        /// <remarks>Default: measuring to the origin.</remarks>
         public VectorDistanceConverter() { }
 
-        /// <summary>
-        /// Initializes a new instance of the <see cref="VectorDistanceConverter"/> class measuring to a point.
-        /// </summary>
+        /// <remarks>Default: measuring to a point.</remarks>
         /// <param name="point">The position the distance is measured to.</param>
         /// <param name="flattenY">Whether to ignore the height difference.</param>
         public VectorDistanceConverter(Vector3 point, bool flattenY = false)
@@ -43,9 +39,7 @@ namespace Aspid.MVVM.StarterKit
             _flattenY = flattenY;
         }
 
-        /// <summary>
-        /// Initializes a new instance of the <see cref="VectorDistanceConverter"/> class measuring to a transform.
-        /// </summary>
+        /// <remarks>Default: measuring to a transform.</remarks>
         /// <param name="target">The transform the distance is measured to.</param>
         /// <param name="flattenY">Whether to ignore the height difference.</param>
         public VectorDistanceConverter(Transform target, bool flattenY = false)

--- a/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Unity/Runtime/Converters/Vectors/VectorDistanceConverter.cs.meta
+++ b/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Unity/Runtime/Converters/Vectors/VectorDistanceConverter.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 6b6c4fb72048047f798f87c093d641d5

--- a/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Unity/Runtime/Converters/Vectors/VectorLerpConverter.cs
+++ b/Aspid.MVVM/Packages/tech.aspid.mvvm/StarterKit/Unity/Runtime/Converters/Vectors/VectorLerpConverter.cs
@@ -9,7 +9,12 @@ namespace Aspid.MVVM.StarterKit
     /// <summary>
     /// Moves between two vectors by a 0..1 amount.
     /// </summary>
-    /// <remarks>A marker travelling along a track as progress advances.</remarks>
+    /// <remarks>
+    /// A marker travelling along a track as progress advances. The easing curve is a field here
+    /// rather than a separate <see cref="AnimationCurveConverter"/> chained in front, because it
+    /// belongs to the move it shapes — an author changing the two ends should not have to remember
+    /// that the shape of the travel lives somewhere else.
+    /// </remarks>
     [Serializable]
     [TypeSelectorDisplay(Group = "Aspid/Vector", Name = "Vector Lerp", Tooltip = "Moves between two vectors by a 0..1 amount")]
     public sealed class VectorLerpConverter : IConverter<float, Vector3>
@@ -20,6 +25,9 @@ namespace Aspid.MVVM.StarterKit
         [Tooltip("The vector at 1.")]
         [SerializeField] private Vector3 _to = Vector3.one;
 
+        [Tooltip("Shapes the amount before the move. Leave it empty for an even one.")]
+        [SerializeField] private AnimationCurve? _curve;
+
         [Tooltip("Hold the incoming amount inside 0..1.")]
         [SerializeField] private bool _clamp = true;
 
@@ -28,10 +36,12 @@ namespace Aspid.MVVM.StarterKit
 
         /// <param name="from">The vector at 0.</param>
         /// <param name="to">The vector at 1.</param>
-        public VectorLerpConverter(Vector3 from, Vector3 to)
+        /// <param name="curve">Shapes the amount before the move, or <see langword="null"/> for an even one.</param>
+        public VectorLerpConverter(Vector3 from, Vector3 to, AnimationCurve? curve = null)
         {
             _from = from;
             _to = to;
+            _curve = curve;
         }
 
         /// <summary>
@@ -39,7 +49,14 @@ namespace Aspid.MVVM.StarterKit
         /// </summary>
         /// <param name="value">The 0..1 amount.</param>
         /// <returns>The vector there.</returns>
-        public Vector3 Convert(float value) =>
-            _clamp ? Vector3.Lerp(_from, _to, value) : Vector3.LerpUnclamped(_from, _to, value);
+        public Vector3 Convert(float value)
+        {
+            // An unassigned curve deserializes as an empty one rather than as null, and evaluating
+            // an empty curve returns zero — which would pin the result at _from instead of leaving
+            // the amount alone. Both spellings of "no curve" have to mean the same thing.
+            var amount = _curve is null || _curve.length == 0 ? value : _curve.Evaluate(value);
+
+            return _clamp ? Vector3.Lerp(_from, _to, amount) : Vector3.LerpUnclamped(_from, _to, amount);
+        }
     }
 }

--- a/Aspid.MVVM/Packages/tech.aspid.mvvm/Tests/Editor/Converters/Collections.meta
+++ b/Aspid.MVVM/Packages/tech.aspid.mvvm/Tests/Editor/Converters/Collections.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 2e95cfd3c15fb42448632c6fdccb0416
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Aspid.MVVM/Packages/tech.aspid.mvvm/Tests/Editor/Converters/Collections/CollectionAdditionsTests.cs
+++ b/Aspid.MVVM/Packages/tech.aspid.mvvm/Tests/Editor/Converters/Collections/CollectionAdditionsTests.cs
@@ -11,28 +11,14 @@ namespace Aspid.MVVM.StarterKit.Tests
     /// and <see cref="DictionaryLookupConverter{TKey, TValue}"/>.
     /// </summary>
     /// <remarks>
-    /// Three classes of mistake are guarded against here.
+    /// Each sequence converter branches on <see cref="IReadOnlyList{T}"/> and walks the sequence
+    /// otherwise, so every behavioural assertion is made against both paths, and the walking path is
+    /// pinned on how many items it pulls — the property a rewrite silently loses.
     /// <para>
-    /// The first is the fast path disagreeing with the slow one. Each of the sequence converters
-    /// branches on <see cref="IReadOnlyList{T}"/> and walks the sequence otherwise, so an array and a
-    /// lazily generated sequence holding the same items run through different code. Every behavioural
-    /// assertion below is therefore made against both, and the walking path is additionally pinned on
-    /// how many items it pulls — the property that keeps a converter bound to a long feed cheap, and
-    /// the one a rewrite silently loses.
-    /// </para>
-    /// <para>
-    /// The second is the shared mutable state these converters carry for the sake of not allocating on
-    /// every binder push: the list <see cref="CollectionTakeConverter{T}"/> hands out and the phrase
-    /// <see cref="CollectionCountToStringConverter{T}"/> caches. Both are asserted by reference, since
-    /// an implementation that quietly starts returning fresh instances is still correct by value and
-    /// only shows up as a per-frame allocation.
-    /// </para>
-    /// <para>
-    /// The third is a word going missing. <see cref="CollectionCountToStringConverter{T}"/> ships with
-    /// its few form empty, so a converter authored in the Inspector under
-    /// <see cref="PluralRule.Slavic"/> reaches the 2-4 branch with nothing to write; the fix falls back
-    /// to the many form, and the assertions on it are written against the whole phrase so that a blank
-    /// word cannot pass unnoticed.
+    /// The shared mutable state these converters carry to avoid allocating per push — the list
+    /// <see cref="CollectionTakeConverter{T}"/> hands out, the phrase
+    /// <see cref="CollectionCountToStringConverter{T}"/> caches — is asserted by reference, since
+    /// returning fresh instances is still correct by value and only shows up as an allocation.
     /// </para>
     /// </remarks>
     [TestFixture]

--- a/Aspid.MVVM/Packages/tech.aspid.mvvm/Tests/Editor/Converters/Collections/CollectionAdditionsTests.cs
+++ b/Aspid.MVVM/Packages/tech.aspid.mvvm/Tests/Editor/Converters/Collections/CollectionAdditionsTests.cs
@@ -1,0 +1,643 @@
+using System;
+using NUnit.Framework;
+using System.Collections.Generic;
+
+namespace Aspid.MVVM.StarterKit.Tests
+{
+    /// <summary>
+    /// Coverage for the collection converters added after the first wave:
+    /// <see cref="CollectionFirstConverter{T}"/>, <see cref="CollectionLastConverter{T}"/>,
+    /// <see cref="CollectionTakeConverter{T}"/>, <see cref="CollectionCountToStringConverter{T}"/>
+    /// and <see cref="DictionaryLookupConverter{TKey, TValue}"/>.
+    /// </summary>
+    /// <remarks>
+    /// Three classes of mistake are guarded against here.
+    /// <para>
+    /// The first is the fast path disagreeing with the slow one. Each of the sequence converters
+    /// branches on <see cref="IReadOnlyList{T}"/> and walks the sequence otherwise, so an array and a
+    /// lazily generated sequence holding the same items run through different code. Every behavioural
+    /// assertion below is therefore made against both, and the walking path is additionally pinned on
+    /// how many items it pulls — the property that keeps a converter bound to a long feed cheap, and
+    /// the one a rewrite silently loses.
+    /// </para>
+    /// <para>
+    /// The second is the shared mutable state these converters carry for the sake of not allocating on
+    /// every binder push: the list <see cref="CollectionTakeConverter{T}"/> hands out and the phrase
+    /// <see cref="CollectionCountToStringConverter{T}"/> caches. Both are asserted by reference, since
+    /// an implementation that quietly starts returning fresh instances is still correct by value and
+    /// only shows up as a per-frame allocation.
+    /// </para>
+    /// <para>
+    /// The third is a word going missing. <see cref="CollectionCountToStringConverter{T}"/> ships with
+    /// its few form empty, so a converter authored in the Inspector under
+    /// <see cref="PluralRule.Slavic"/> reaches the 2-4 branch with nothing to write; the fix falls back
+    /// to the many form, and the assertions on it are written against the whole phrase so that a blank
+    /// word cannot pass unnoticed.
+    /// </para>
+    /// </remarks>
+    [TestFixture]
+    internal sealed class CollectionAdditionsTests
+    {
+        private static readonly string[] Three = { "a", "b", "c" };
+        private static readonly int[] Five = { 1, 2, 3, 4, 5 };
+
+        // ---------------------------------------------------------------------------------------
+        // CollectionFirstConverter
+        // ---------------------------------------------------------------------------------------
+
+        [Test]
+        public void First_List_ReturnsTheHead() =>
+            Assert.AreEqual("a", new CollectionFirstConverter<string>("?").Convert(Three));
+
+        // The same three items behind an enumerator with no indexer take the foreach branch instead.
+        [Test]
+        public void First_WalkedSequence_ReturnsTheHead() =>
+            Assert.AreEqual("a", new CollectionFirstConverter<string>("?").Convert(Streamed("a", "b", "c")));
+
+        // A queue is the shape the class documentation names: a real collection that stops at
+        // IReadOnlyCollection and so never reaches the indexed branch.
+        [Test]
+        public void First_Queue_ReturnsTheHead() =>
+            Assert.AreEqual("a", new CollectionFirstConverter<string>("?").Convert(new Queue<string>(Three)));
+
+        [Test]
+        public void First_EmptyList_ReturnsTheFallback() =>
+            Assert.AreEqual("?", new CollectionFirstConverter<string>("?").Convert(Array.Empty<string>()));
+
+        [Test]
+        public void First_EmptyWalkedSequence_ReturnsTheFallback() =>
+            Assert.AreEqual("?", new CollectionFirstConverter<string>("?").Convert(Streamed<string>()));
+
+        [Test]
+        public void First_Null_ReturnsTheFallback() =>
+            Assert.AreEqual("?", new CollectionFirstConverter<string>("?").Convert(null));
+
+        [Test]
+        public void First_DefaultConstructed_EmptySequence_ReturnsTheTypeDefault() =>
+            Assert.IsNull(new CollectionFirstConverter<string>().Convert(Array.Empty<string>()));
+
+        // The fallback answers an empty sequence, not an empty item. A sequence whose head is null is
+        // not empty, so the null travels to the binder — the caller that authored a fallback to avoid
+        // exactly that still gets it.
+        [Test]
+        public void First_NullHead_ReturnsNullRatherThanTheFallback()
+        {
+            Assert.IsNull(new CollectionFirstConverter<string>("?").Convert(new[] { null, "b" }));
+            Assert.IsNull(new CollectionFirstConverter<string>("?").Convert(Streamed(null, "b")));
+        }
+
+        // The point of the converter: the head is answered without the length of the sequence
+        // mattering. One pull, on a hundred available items.
+        [Test]
+        public void First_WalkedSequence_PullsOnlyTheHead()
+        {
+            var probe = new Probe();
+
+            Assert.AreEqual(1, new CollectionFirstConverter<int>(-1).Convert(Counted(100, probe)));
+            Assert.AreEqual(1, probe.Pulls);
+        }
+
+        // Returning out of a foreach still runs the enumerator's Dispose, which a bare MoveNext would
+        // skip — and an iterator holding a file handle or a pooled buffer frees it there.
+        [Test]
+        public void First_WalkedSequence_DisposesTheEnumeratorOnTheEarlyReturn()
+        {
+            var probe = new Probe();
+
+            new CollectionFirstConverter<int>(-1).Convert(Counted(100, probe));
+
+            Assert.IsTrue(probe.Disposed);
+        }
+
+        // ---------------------------------------------------------------------------------------
+        // CollectionLastConverter
+        // ---------------------------------------------------------------------------------------
+
+        [Test]
+        public void Last_List_ReturnsTheTail() =>
+            Assert.AreEqual("c", new CollectionLastConverter<string>("?").Convert(Three));
+
+        [Test]
+        public void Last_WalkedSequence_ReturnsTheTail() =>
+            Assert.AreEqual("c", new CollectionLastConverter<string>("?").Convert(Streamed("a", "b", "c")));
+
+        [Test]
+        public void Last_Queue_ReturnsTheTail() =>
+            Assert.AreEqual("c", new CollectionLastConverter<string>("?").Convert(new Queue<string>(Three)));
+
+        [Test]
+        public void Last_EmptyList_ReturnsTheFallback() =>
+            Assert.AreEqual("?", new CollectionLastConverter<string>("?").Convert(Array.Empty<string>()));
+
+        // The walked branch never assigns when there is nothing to walk, so the fallback it started
+        // from is what comes back. A branch seeded with default(T) would answer null here instead.
+        [Test]
+        public void Last_EmptyWalkedSequence_ReturnsTheFallback() =>
+            Assert.AreEqual("?", new CollectionLastConverter<string>("?").Convert(Streamed<string>()));
+
+        [Test]
+        public void Last_Null_ReturnsTheFallback() =>
+            Assert.AreEqual("?", new CollectionLastConverter<string>("?").Convert(null));
+
+        [Test]
+        public void Last_SingleItem_ReturnsIt()
+        {
+            Assert.AreEqual("a", new CollectionLastConverter<string>("?").Convert(new[] { "a" }));
+            Assert.AreEqual("a", new CollectionLastConverter<string>("?").Convert(Streamed("a")));
+        }
+
+        // The mirror of the head case: a null tail overwrites the fallback the walk started from, so
+        // "no last item" and "a last item that is null" are not the same answer.
+        [Test]
+        public void Last_NullTail_ReturnsNullRatherThanTheFallback()
+        {
+            Assert.IsNull(new CollectionLastConverter<string>("?").Convert(new[] { "a", null }));
+            Assert.IsNull(new CollectionLastConverter<string>("?").Convert(Streamed("a", null)));
+        }
+
+        // The cost the documentation admits to: nothing short of walking the whole sequence can name
+        // its last item. Pinned so that a later "optimisation" that stops early is caught.
+        [Test]
+        public void Last_WalkedSequence_PullsEveryItem()
+        {
+            var probe = new Probe();
+
+            Assert.AreEqual(100, new CollectionLastConverter<int>(-1).Convert(Counted(100, probe)));
+            Assert.AreEqual(100, probe.Pulls);
+        }
+
+        // ---------------------------------------------------------------------------------------
+        // CollectionTakeConverter — what comes back
+        // ---------------------------------------------------------------------------------------
+
+        [Test]
+        public void Take_List_KeepsTheItemsOffTheStart() =>
+            CollectionAssert.AreEqual(new[] { 1, 2 }, new CollectionTakeConverter<int>(2).Convert(Five));
+
+        [Test]
+        public void Take_WalkedSequence_KeepsTheItemsOffTheStart() =>
+            CollectionAssert.AreEqual(new[] { 1, 2 }, new CollectionTakeConverter<int>(2).Convert(Streamed(1, 2, 3, 4, 5)));
+
+        // Off the end, but still in the sequence's own order — not reversed, which is the shape a
+        // "last five lines of a log" view would be wrong in without anyone noticing for a while.
+        [Test]
+        public void Take_List_FromEnd_KeepsTheTailInItsOriginalOrder() =>
+            CollectionAssert.AreEqual(new[] { 4, 5 }, new CollectionTakeConverter<int>(2, fromEnd: true).Convert(Five));
+
+        [Test]
+        public void Take_WalkedSequence_FromEnd_KeepsTheTailInItsOriginalOrder() =>
+            CollectionAssert.AreEqual(
+                new[] { 4, 5 },
+                new CollectionTakeConverter<int>(2, fromEnd: true).Convert(Streamed(1, 2, 3, 4, 5)));
+
+        [TestCase(false)]
+        [TestCase(true)]
+        public void Take_CountAboveTheLength_KeepsEverything(bool fromEnd)
+        {
+            CollectionAssert.AreEqual(Five, new CollectionTakeConverter<int>(50, fromEnd).Convert(Five));
+            CollectionAssert.AreEqual(Five, new CollectionTakeConverter<int>(50, fromEnd).Convert(Streamed(1, 2, 3, 4, 5)));
+        }
+
+        // Zero is the value a count field is left at while it is being typed into, and a negative one
+        // is what an arithmetic mistake upstream produces. Neither may index past the front.
+        [TestCase(0, false)]
+        [TestCase(0, true)]
+        [TestCase(-1, false)]
+        [TestCase(-1, true)]
+        public void Take_CountOfZeroOrLess_KeepsNothing(int count, bool fromEnd)
+        {
+            CollectionAssert.IsEmpty(new CollectionTakeConverter<int>(count, fromEnd).Convert(Five));
+            CollectionAssert.IsEmpty(new CollectionTakeConverter<int>(count, fromEnd).Convert(Streamed(1, 2, 3, 4, 5)));
+        }
+
+        [TestCase(false)]
+        [TestCase(true)]
+        public void Take_Null_KeepsNothing(bool fromEnd) =>
+            CollectionAssert.IsEmpty(new CollectionTakeConverter<int>(2, fromEnd).Convert(null));
+
+        [TestCase(false)]
+        [TestCase(true)]
+        public void Take_EmptySequence_KeepsNothing(bool fromEnd)
+        {
+            CollectionAssert.IsEmpty(new CollectionTakeConverter<int>(2, fromEnd).Convert(Array.Empty<int>()));
+            CollectionAssert.IsEmpty(new CollectionTakeConverter<int>(2, fromEnd).Convert(Streamed<int>()));
+        }
+
+        [Test]
+        public void Take_DefaultConstructed_KeepsThreeOffTheStart() =>
+            CollectionAssert.AreEqual(new[] { 1, 2, 3 }, new CollectionTakeConverter<int>().Convert(Five));
+
+        // Off the start, the walk stops as soon as it has enough — the whole reason a "top three" over
+        // a long feed is affordable. A converter that buffered everything first would read 100 here.
+        [Test]
+        public void Take_WalkedSequence_StopsPullingOnceItHasEnough()
+        {
+            var probe = new Probe();
+
+            CollectionAssert.AreEqual(new[] { 1, 2 }, new CollectionTakeConverter<int>(2).Convert(Counted(100, probe)));
+            Assert.AreEqual(2, probe.Pulls);
+        }
+
+        // Off the end it cannot: where the last two items begin is unknown until the sequence ends, so
+        // the tail case pays for the whole walk. Asserted because it is the asymmetry that decides
+        // whether this converter belongs on a long feed at all.
+        [Test]
+        public void Take_WalkedSequence_FromEnd_PullsEveryItem()
+        {
+            var probe = new Probe();
+
+            CollectionAssert.AreEqual(
+                new[] { 99, 100 },
+                new CollectionTakeConverter<int>(2, fromEnd: true).Convert(Counted(100, probe)));
+
+            Assert.AreEqual(100, probe.Pulls);
+        }
+
+        // ---------------------------------------------------------------------------------------
+        // CollectionTakeConverter — the reused buffer
+        // ---------------------------------------------------------------------------------------
+
+        // The contract that makes this converter allocation-free on a binder that pushes every frame.
+        [Test]
+        public void Take_ReturnsTheSameListInstanceOnEveryCall()
+        {
+            var converter = new CollectionTakeConverter<int>(2);
+
+            Assert.AreSame(converter.Convert(new[] { 1, 2, 3 }), converter.Convert(new[] { 7, 8, 9 }));
+        }
+
+        // The early return for a null or a non-positive count leaves through a different line, and it
+        // has to hand back the same list rather than a fresh empty one.
+        [Test]
+        public void Take_ReturnsTheSameListInstanceAcrossTheNullAndEmptyPaths()
+        {
+            var converter = new CollectionTakeConverter<int>(2);
+
+            Assert.AreSame(converter.Convert(null), converter.Convert(Five));
+            Assert.AreSame(converter.Convert(Five), converter.Convert(Streamed(1, 2, 3)));
+        }
+
+        // The price of that reuse, stated as a test so nobody has to discover it: a result held past
+        // the push it arrived on is a view of whatever came last, not a snapshot.
+        [Test]
+        public void Take_ResultHeldAcrossCalls_ShowsTheLatestConversion()
+        {
+            var converter = new CollectionTakeConverter<int>(2);
+            var held = converter.Convert(new[] { 1, 2, 3 });
+
+            converter.Convert(new[] { 7, 8, 9 });
+
+            CollectionAssert.AreEqual(new[] { 7, 8 }, held);
+        }
+
+        // ...and a null push does not leave the old items standing: the buffer is cleared first.
+        [Test]
+        public void Take_ResultHeldAcrossANullConversion_IsEmptied()
+        {
+            var converter = new CollectionTakeConverter<int>(2);
+            var held = converter.Convert(new[] { 1, 2, 3 });
+
+            converter.Convert(null);
+
+            CollectionAssert.IsEmpty(held);
+        }
+
+        // The buffer is per instance, not static. Two binders sharing one would overwrite each other
+        // and the symptom would depend on which one pushed last.
+        [Test]
+        public void Take_SeparateInstances_DoNotShareABuffer()
+        {
+            var first = new CollectionTakeConverter<int>(2);
+            var second = new CollectionTakeConverter<int>(2);
+
+            var firstResult = first.Convert(new[] { 1, 2, 3 });
+            var secondResult = second.Convert(new[] { 7, 8, 9 });
+
+            Assert.AreNotSame(firstResult, secondResult);
+            CollectionAssert.AreEqual(new[] { 1, 2 }, firstResult);
+        }
+
+        // ---------------------------------------------------------------------------------------
+        // CollectionCountToStringConverter — English
+        // ---------------------------------------------------------------------------------------
+
+        [TestCase(1, "1 one")]
+        [TestCase(2, "2 many")]
+        [TestCase(5, "5 many")]
+        public void Count_English_PicksTheFormForTheCount(int count, string expected) =>
+            Assert.AreEqual(expected, English().Convert(Items(count)));
+
+        // The constructor's zero text defaults to null, which means "no separate empty caption" — so a
+        // converter built in code writes an empty collection like any other count rather than
+        // suppressing the number.
+        [Test]
+        public void Count_NoZeroTextAuthored_EmptyCollectionIsFormattedLikeAnyOtherCount() =>
+            Assert.AreEqual("0 many", English().Convert(Array.Empty<string>()));
+
+        [Test]
+        public void Count_Null_IsCountedAsZero() =>
+            Assert.AreEqual("0 many", English().Convert(null));
+
+        // The reason the class exists rather than a Count converter chained into Pluralize: the empty
+        // caption is a phrase of its own, with no count in front of it.
+        [Test]
+        public void Count_ZeroTextAuthored_IsWrittenWithoutTheCount()
+        {
+            var converter = new CollectionCountToStringConverter<string>("one", "many", zeroText: "Empty");
+
+            Assert.AreEqual("Empty", converter.Convert(Array.Empty<string>()));
+        }
+
+        [Test]
+        public void Count_ZeroTextAuthored_NullCollection_AlsoWritesIt() =>
+            Assert.AreEqual("Empty", new CollectionCountToStringConverter<string>("one", "many", "Empty").Convert(null));
+
+        // The parameterless constructor is what an Inspector-authored converter starts as, and its
+        // defaults differ from the code path above: a zero text of "Empty" is already filled in.
+        [TestCase(0, "Empty")]
+        [TestCase(1, "1 item")]
+        [TestCase(2, "2 items")]
+        public void Count_DefaultConstructed_UsesTheInspectorDefaults(int count, string expected) =>
+            Assert.AreEqual(expected, new CollectionCountToStringConverter<string>().Convert(Items(count)));
+
+        // ---------------------------------------------------------------------------------------
+        // CollectionCountToStringConverter — Slavic
+        // ---------------------------------------------------------------------------------------
+
+        [TestCase(1, "1 one")]
+        [TestCase(2, "2 few")]
+        [TestCase(3, "3 few")]
+        [TestCase(4, "4 few")]
+        [TestCase(5, "5 many")]
+        [TestCase(10, "10 many")]
+        // The teens are the exception the rule is famous for: they take the many form no matter what
+        // their last digit is, so 11 does not follow 1 and 12-14 do not follow 2-4.
+        [TestCase(11, "11 many")]
+        [TestCase(12, "12 many")]
+        [TestCase(14, "14 many")]
+        [TestCase(15, "15 many")]
+        // Above twenty the last digit rules again, which is what makes the teens a special case rather
+        // than a range that simply carries on.
+        [TestCase(21, "21 one")]
+        [TestCase(22, "22 few")]
+        [TestCase(25, "25 many")]
+        // Past a hundred the teen window is found on the last two digits, so 111 is a teen and 101 is
+        // not — the pair a check written against the last digit alone gets wrong.
+        [TestCase(101, "101 one")]
+        [TestCase(111, "111 many")]
+        [TestCase(112, "112 many")]
+        [TestCase(121, "121 one")]
+        public void Count_Slavic_PicksTheFormForTheCount(int count, string expected) =>
+            Assert.AreEqual(expected, Slavic("few").Convert(Items(count)));
+
+        // Zero ends in zero, so it is not a teen and not a one — it lands on the many form, which is
+        // the correct Russian reading and the only answer available when no empty caption is authored.
+        [Test]
+        public void Count_Slavic_ZeroWithoutAZeroText_UsesTheManyForm() =>
+            Assert.AreEqual("0 many", Slavic("few").Convert(Array.Empty<string>()));
+
+        // THE REVIEW FIX. The few form is a serialized field that starts empty, so a converter set up
+        // in the Inspector and switched to Slavic reaches the 2-4 branch with no word to write. Before
+        // the fix the phrase came out as "2 " with the noun missing; it falls back to the many form.
+        // The assertion is on the whole phrase on purpose — a blank word would still be a string.
+        [TestCase(2, "2 many")]
+        [TestCase(3, "3 many")]
+        [TestCase(4, "4 many")]
+        [TestCase(22, "22 many")]
+        [TestCase(104, "104 many")]
+        public void Count_Slavic_EmptyFewForm_FallsBackToTheManyForm(int count, string expected) =>
+            Assert.AreEqual(expected, Slavic(string.Empty).Convert(Items(count)));
+
+        // Only the 2-4 branch reads the few form, so an empty one must not disturb the others.
+        [TestCase(1, "1 one")]
+        [TestCase(5, "5 many")]
+        [TestCase(11, "11 many")]
+        public void Count_Slavic_EmptyFewForm_LeavesTheOtherFormsAlone(int count, string expected) =>
+            Assert.AreEqual(expected, Slavic(string.Empty).Convert(Items(count)));
+
+        // A null few form is handled a step earlier, in the constructor, rather than by the fallback
+        // above — two separate lines that have to agree, and this is the one code callers hit.
+        [TestCase(2, "2 many")]
+        [TestCase(3, "3 many")]
+        public void Count_Slavic_NullFewForm_UsesTheManyForm(int count, string expected) =>
+            Assert.AreEqual(expected, Slavic(null).Convert(Items(count)));
+
+        // ---------------------------------------------------------------------------------------
+        // CollectionCountToStringConverter — the cached phrase and the rule guard
+        // ---------------------------------------------------------------------------------------
+
+        // A binder pushes on every notification, not on every change, so the phrase is kept while the
+        // count holds. Asserted by reference: string.Format hands back a fresh string each call, so
+        // the same instance can only come from the cache.
+        [Test]
+        public void Count_SameCountTwice_ReturnsTheCachedPhrase()
+        {
+            var converter = English();
+
+            Assert.AreSame(converter.Convert(Items(3)), converter.Convert(Items(3)));
+        }
+
+        // The cache is keyed on the count alone. Two different collections of the same size are one
+        // and the same question to this converter — worth stating, since the items are never read.
+        [Test]
+        public void Count_DifferentCollectionOfTheSameSize_ReturnsTheCachedPhrase()
+        {
+            var converter = English();
+
+            Assert.AreSame(converter.Convert(new string[3]), converter.Convert(Three));
+        }
+
+        // The cache is a value plus a has-it flag, not a sentinel count: zero is a real answer and
+        // must not read as "nothing cached yet", nor block the counts that follow it.
+        [Test]
+        public void Count_CountChanges_RebuildsThePhrase()
+        {
+            var converter = English();
+
+            Assert.AreEqual("0 many", converter.Convert(Array.Empty<string>()));
+            Assert.AreEqual("1 one", converter.Convert(Items(1)));
+            Assert.AreEqual("3 many", converter.Convert(Items(3)));
+            Assert.AreEqual("1 one", converter.Convert(Items(1)));
+        }
+
+        // A rule outside the enum is what a renamed or reordered member deserializes into. It throws
+        // rather than picking a form at random.
+        [Test]
+        public void Count_UndeclaredRule_Throws() =>
+            Assert.Throws<ArgumentOutOfRangeException>(
+                () => new CollectionCountToStringConverter<string>("one", "many", null, (PluralRule)42).Convert(Items(1)));
+
+        // The documented exception is conditional, which the doc comment does not say: an authored
+        // empty caption returns before any form is picked, so the same broken converter answers an
+        // empty collection quite happily and only throws once something is put in it.
+        [Test]
+        public void Count_UndeclaredRule_EmptyCollectionWithAZeroText_ReturnsTheZeroTextInstead() =>
+            Assert.AreEqual(
+                "Empty",
+                new CollectionCountToStringConverter<string>("one", "many", "Empty", (PluralRule)42)
+                    .Convert(Array.Empty<string>()));
+
+        // ---------------------------------------------------------------------------------------
+        // DictionaryLookupConverter
+        // ---------------------------------------------------------------------------------------
+
+        [TestCase("Fire", "Red")]
+        [TestCase("Ice", "Blue")]
+        public void Lookup_KeyInTheTable_ReturnsItsValue(string key, string expected) =>
+            Assert.AreEqual(expected, Elements().Convert(key));
+
+        [TestCase("Shock")]
+        [TestCase("")]
+        public void Lookup_KeyNotInTheTable_ReturnsTheFallback(string key) =>
+            Assert.AreEqual("Grey", Elements().Convert(key));
+
+        // String keys are compared with the type's own equality, which is ordinal and case-sensitive.
+        // An id that arrives from a save file or a server in the wrong case finds nothing.
+        [TestCase("fire")]
+        [TestCase("FIRE")]
+        [TestCase("Fire ")]
+        public void Lookup_StringKeys_AreMatchedCaseAndWhitespaceSensitively(string key) =>
+            Assert.AreEqual("Grey", Elements().Convert(key));
+
+        [Test]
+        public void Lookup_EmptyTable_ReturnsTheFallback() =>
+            Assert.AreEqual(
+                "Grey",
+                new DictionaryLookupConverter<string, string>(Array.Empty<LookupEntry<string, string>>(), "Grey")
+                    .Convert("Fire"));
+
+        // A null map is coerced to an empty one by the constructor rather than throwing on the first
+        // push, which is what an unassigned array field deserializes as.
+        [Test]
+        public void Lookup_NullTable_ReturnsTheFallback() =>
+            Assert.AreEqual("Grey", new DictionaryLookupConverter<string, string>(null, "Grey").Convert("Fire"));
+
+        [Test]
+        public void Lookup_DefaultConstructed_ReturnsTheTypeDefault() =>
+            Assert.IsNull(new DictionaryLookupConverter<string, string>().Convert("Fire"));
+
+        // The scan stops at the first match, so a table with a key entered twice answers with the
+        // upper row. Authoring order decides, and nothing warns about the duplicate.
+        [Test]
+        public void Lookup_DuplicateKeys_TheFirstRowWins()
+        {
+            var converter = new DictionaryLookupConverter<string, string>(
+                new[]
+                {
+                    Row("Fire", "Red"),
+                    Row("Fire", "Orange"),
+                },
+                "Grey");
+
+            Assert.AreEqual("Red", converter.Convert("Fire"));
+        }
+
+        // A row whose value happens to equal default(TValue) is a listed key, not a missing one. An
+        // implementation that used the value to signal "not found" would answer -1 here.
+        [Test]
+        public void Lookup_ValueEqualToTheTypeDefault_IsReturnedRatherThanTheFallback()
+        {
+            var converter = new DictionaryLookupConverter<string, int>(new[] { Row("None", 0) }, -1);
+
+            Assert.AreEqual(0, converter.Convert("None"));
+            Assert.AreEqual(-1, converter.Convert("Fire"));
+        }
+
+        // The default comparer says two nulls are equal, so a row left with its key unassigned is not
+        // inert: it answers every push of a null id, ahead of the fallback the author expected.
+        [Test]
+        public void Lookup_NullKey_IsMatchedByARowWithAnUnassignedKey()
+        {
+            var converter = new DictionaryLookupConverter<string, string>(
+                new[]
+                {
+                    Row<string, string>(null, "Unset"),
+                    Row("Fire", "Red"),
+                },
+                "Grey");
+
+            Assert.AreEqual("Unset", converter.Convert(null));
+        }
+
+        [Test]
+        public void Lookup_NullKey_WithNoSuchRow_ReturnsTheFallback() =>
+            Assert.AreEqual("Grey", Elements().Convert(null));
+
+        // The default comparer calls Equals, not ==, and float.Equals reports two NaNs as equal. A
+        // NaN key is therefore matchable — the opposite of what the operator would do, and the reason
+        // a NaN pushed by a broken calculation lands on a row instead of the fallback.
+        [Test]
+        public void Lookup_NaNKey_IsMatchedByARowKeyedByNaN()
+        {
+            var converter = new DictionaryLookupConverter<float, string>(
+                new[]
+                {
+                    Row(float.NaN, "Broken"),
+                    Row(1f, "One"),
+                },
+                "Grey");
+
+            Assert.AreEqual("Broken", converter.Convert(float.NaN));
+            Assert.AreEqual("One", converter.Convert(1f));
+        }
+
+        [TestCase(0, "None")]
+        [TestCase(2, "Silver")]
+        public void Lookup_IntKeys_AreMatchedByValue(int key, string expected) =>
+            Assert.AreEqual(
+                expected,
+                new DictionaryLookupConverter<int, string>(new[] { Row(0, "None"), Row(2, "Silver") }, "?")
+                    .Convert(key));
+
+        // ---------------------------------------------------------------------------------------
+        // Helpers
+        // ---------------------------------------------------------------------------------------
+
+        // Only Count is read off the collection, so the items themselves are of no interest here.
+        private static string[] Items(int count) => new string[count];
+
+        private static CollectionCountToStringConverter<string> English() =>
+            new("one", "many");
+
+        private static CollectionCountToStringConverter<string> Slavic(string fewForm) =>
+            new("one", "many", zeroText: null, rule: PluralRule.Slavic, fewForm: fewForm);
+
+        private static DictionaryLookupConverter<string, string> Elements() =>
+            new(new[] { Row("Fire", "Red"), Row("Ice", "Blue") }, "Grey");
+
+        private static LookupEntry<TKey, TValue> Row<TKey, TValue>(TKey key, TValue value) =>
+            new() { Key = key, Value = value };
+
+        // An iterator, so the result is an IEnumerable and nothing more — the converters' indexed fast
+        // path cannot see it and the walking branch is the one under test.
+        private static IEnumerable<T> Streamed<T>(params T[] items)
+        {
+            foreach (var item in items)
+                yield return item;
+        }
+
+        // The same, with the pulls counted and the disposal recorded, for the assertions about how
+        // much of a sequence a converter actually reads.
+        private static IEnumerable<int> Counted(int length, Probe probe)
+        {
+            try
+            {
+                for (var i = 1; i <= length; i++)
+                {
+                    probe.Pulls++;
+                    yield return i;
+                }
+            }
+            finally
+            {
+                probe.Disposed = true;
+            }
+        }
+
+        private sealed class Probe
+        {
+            public int Pulls;
+            public bool Disposed;
+        }
+    }
+}

--- a/Aspid.MVVM/Packages/tech.aspid.mvvm/Tests/Editor/Converters/Collections/CollectionAdditionsTests.cs.meta
+++ b/Aspid.MVVM/Packages/tech.aspid.mvvm/Tests/Editor/Converters/Collections/CollectionAdditionsTests.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: a6b24fc5f0821493ebfd888a9a2a6be7

--- a/Aspid.MVVM/Packages/tech.aspid.mvvm/Tests/Editor/Converters/Colors/ColorBlockAdditionsTests.cs
+++ b/Aspid.MVVM/Packages/tech.aspid.mvvm/Tests/Editor/Converters/Colors/ColorBlockAdditionsTests.cs
@@ -1,0 +1,351 @@
+using System;
+using UnityEngine;
+using NUnit.Framework;
+using UnityEngine.UI;
+using System.Reflection;
+
+namespace Aspid.MVVM.StarterKit.Tests
+{
+    /// <summary>
+    /// Coverage for the <see cref="SelectableStates"/> mask on <see cref="ColorBlockTintConverter"/>
+    /// and <see cref="ColorBlockStateConverter"/> — which of the five state colours each writes, and
+    /// that the four it does not write survive bit for bit.
+    /// </summary>
+    /// <remarks>
+    /// A mask converter fails in two ways a "does it tint?" test never sees: it writes a state the
+    /// mask excluded, or it reads the wrong field and writes the right colour into the wrong state.
+    /// Both need a source block whose five colours are all different, which is why nothing here
+    /// starts from <see cref="ColorBlock.defaultColorBlock"/> — that block gives highlighted and
+    /// selected the same colour, so a converter swapping the two would pass.
+    /// <para>
+    /// The second thing guarded is the default. The mask arrived after the converters shipped, so
+    /// <see cref="SelectableStates.All"/> has to stay the default in both the constructor and the
+    /// field initializer; any narrower default silently stops tinting a state that used to be
+    /// tinted, and nothing about the binder would look broken.
+    /// </para>
+    /// <para>
+    /// Neither converter logs or allocates a Unity object, so there is no <c>LogAssert</c> and
+    /// nothing to destroy — <see cref="ColorBlock"/> is a struct and both converters are pure.
+    /// </para>
+    /// </remarks>
+    [TestFixture]
+    internal sealed class ColorBlockAdditionsTests
+    {
+        private const float Tolerance = 1e-6f;
+
+        /// <summary>The five single-flag states, in the order <c>Convert</c> writes them.</summary>
+        private static readonly SelectableStates[] EveryState =
+        {
+            SelectableStates.Normal,
+            SelectableStates.Highlighted,
+            SelectableStates.Pressed,
+            SelectableStates.Selected,
+            SelectableStates.Disabled,
+        };
+
+        /// <summary>Half grey at quarter alpha: every channel is a power of two, so a multiply is exact.</summary>
+        private static readonly Color Tint = new(0.5f, 0.5f, 0.5f, 0.25f);
+
+        /// <summary>The colour <see cref="ColorBlockStateConverter"/> writes — not grey, not any authored state.</summary>
+        private static readonly Color Written = new(0.25f, 0.75f, 0.125f, 0.375f);
+
+        // ---- ColorBlockTintConverter: the default mask ----
+
+        // The expected column is the authored state multiplied by the tint, written out rather than
+        // computed, so a converter that stopped multiplying alpha cannot agree with the test.
+        [TestCase(SelectableStates.Normal, 0.5f, 0f, 0f, 0.25f)]
+        [TestCase(SelectableStates.Highlighted, 0f, 0.5f, 0f, 0.225f)]
+        [TestCase(SelectableStates.Pressed, 0f, 0f, 0.5f, 0.2f)]
+        [TestCase(SelectableStates.Selected, 0.5f, 0.5f, 0f, 0.175f)]
+        [TestCase(SelectableStates.Disabled, 0f, 0.5f, 0.5f, 0.15f)]
+        public void TintConverter_DefaultMask_MultipliesEveryStateIncludingDisabled(
+            SelectableStates state,
+            float r,
+            float g,
+            float b,
+            float a)
+        {
+            var result = new ColorBlockTintConverter(Tint).Convert(Authored());
+
+            AssertSameColor(new Color(r, g, b, a), ColorOf(result, state), $"{state}");
+        }
+
+        [Test]
+        public void TintConverter_DefaultedStatesArgument_MatchesAnExplicitAllMask()
+        {
+            var defaulted = new ColorBlockTintConverter(Tint, ColorBlend.Multiply).Convert(Authored());
+            var explicitAll = new ColorBlockTintConverter(Tint, ColorBlend.Multiply, SelectableStates.All).Convert(Authored());
+
+            foreach (var state in EveryState)
+                Assert.AreEqual(ColorOf(explicitAll, state), ColorOf(defaulted, state), $"{state} differs from an explicit All mask.");
+        }
+
+        // The parameterless converter tints with white, which is an identity whatever the mask is, so
+        // Convert cannot show what the mask defaults to. The field initializer is what a converter
+        // picked in the Inspector gets, and it is the only place that default is written down.
+        [Test]
+        public void TintConverter_FieldInitializer_DefaultsToAll()
+        {
+            const BindingFlags flags = BindingFlags.Instance | BindingFlags.NonPublic;
+
+            var field = typeof(ColorBlockTintConverter).GetField("_states", flags);
+            if (field is null) throw new InvalidOperationException("ColorBlockTintConverter has no _states field.");
+
+            Assert.AreEqual(SelectableStates.All, field.GetValue(new ColorBlockTintConverter()));
+        }
+
+        [Test]
+        public void TintConverter_ParameterlessConstructor_IsAnIdentity()
+        {
+            var result = new ColorBlockTintConverter().Convert(Authored());
+
+            foreach (var state in EveryState)
+                Assert.AreEqual(ColorOf(Authored(), state), ColorOf(result, state), $"{state} was changed by a converter that should change nothing.");
+        }
+
+        // ---- ColorBlockTintConverter: what the mask spares ----
+
+        [Test]
+        public void TintConverter_InteractiveMask_LeavesTheDisabledStateExactlyAsAuthored()
+        {
+            var result = new ColorBlockTintConverter(Tint, ColorBlend.Multiply, SelectableStates.Interactive).Convert(Authored());
+
+            // Bit-identical rather than close: a theme pushed on every notification would drift a
+            // "nearly untouched" disabled colour a little further off with each push.
+            Assert.AreEqual(Authored().disabledColor, result.disabledColor, "Disabled sits outside the Interactive mask.");
+
+            foreach (var state in EveryState)
+            {
+                if (state == SelectableStates.Disabled) continue;
+
+                Assert.AreNotEqual(ColorOf(Authored(), state), ColorOf(result, state), $"{state} sits inside Interactive and should have been tinted.");
+            }
+        }
+
+        [TestCase(SelectableStates.Normal, 0.25f)]
+        [TestCase(SelectableStates.Highlighted, 0.225f)]
+        [TestCase(SelectableStates.Pressed, 0.2f)]
+        [TestCase(SelectableStates.Selected, 0.175f)]
+        [TestCase(SelectableStates.Disabled, 0.15f)]
+        public void TintConverter_SingleStateMask_WritesOnlyThatState(SelectableStates state, float tintedAlpha)
+        {
+            var result = new ColorBlockTintConverter(Tint, ColorBlend.Multiply, state).Convert(Authored());
+
+            Assert.AreEqual(tintedAlpha, ColorOf(result, state).a, Tolerance, $"{state} sits inside the mask and should have been tinted.");
+            AssertUntouchedOutside(state, result);
+        }
+
+        // Same tint that changes all five under All, so this pins the mask rather than the colour.
+        [Test]
+        public void TintConverter_NoneMask_ChangesNothing()
+        {
+            var result = new ColorBlockTintConverter(Tint, ColorBlend.Multiply, SelectableStates.None).Convert(Authored());
+
+            AssertUntouchedOutside(SelectableStates.None, result);
+        }
+
+        // The converter owns neither field, so it can only keep them by returning the block it was
+        // given. A rewrite that builds a fresh ColorBlock would reset the fade to zero and the
+        // multiplier to zero, and a Selectable with a zero multiplier renders black.
+        [Test]
+        public void TintConverter_LeavesFadeDurationAndMultiplierAlone()
+        {
+            var result = new ColorBlockTintConverter(Tint).Convert(Authored());
+
+            Assert.AreEqual(Authored().fadeDuration, result.fadeDuration, Tolerance, "fadeDuration");
+            Assert.AreEqual(Authored().colorMultiplier, result.colorMultiplier, Tolerance, "colorMultiplier");
+        }
+
+        // ---- ColorBlockTintConverter: the blends, reached through the mask ----
+
+        // Add clamps the channels and keeps the authored alpha, where Multiply scales it — the same
+        // tint therefore leaves this state fully opaque and the multiplied one at a quarter alpha.
+        [Test]
+        public void TintConverter_AddBlend_ClampsAndKeepsTheAuthoredAlpha()
+        {
+            var result = new ColorBlockTintConverter(Tint, ColorBlend.Add, SelectableStates.Normal).Convert(Authored());
+
+            AssertSameColor(new Color(1f, 0.5f, 0.5f, 1f), result.normalColor, "Normal, added");
+            AssertUntouchedOutside(SelectableStates.Normal, result);
+        }
+
+        // ColorTintConverter takes the Lerp amount as a constructor argument; this one does not, so
+        // code-constructed Lerp always travels the whole way — including to the tint's own alpha,
+        // which is what separates it from Replace.
+        [Test]
+        public void TintConverter_LerpBlend_TravelsAllTheWayBecauseTheConstructorHasNoAmount()
+        {
+            var result = new ColorBlockTintConverter(Tint, ColorBlend.Lerp, SelectableStates.Highlighted).Convert(Authored());
+
+            AssertSameColor(Tint, result.highlightedColor, "Highlighted, lerped");
+            Assert.AreNotEqual(Authored().highlightedColor.a, result.highlightedColor.a, "Lerp should have taken the tint's alpha.");
+        }
+
+        [Test]
+        public void TintConverter_ReplaceBlend_KeepsTheAuthoredAlpha()
+        {
+            var result = new ColorBlockTintConverter(Tint, ColorBlend.Replace, SelectableStates.Pressed).Convert(Authored());
+
+            AssertSameColor(new Color(Tint.r, Tint.g, Tint.b, Authored().pressedColor.a), result.pressedColor, "Pressed, replaced");
+        }
+
+        // An undeclared blend throws rather than passing the colour through, and the mask decides
+        // whether the throw happens at all — the states are filtered before the blend runs, not
+        // after. A converter that blended first and filtered second would throw for both masks.
+        [Test]
+        public void TintConverter_UndeclaredBlend_ThrowsOnlyForStatesInsideTheMask()
+        {
+            const ColorBlend undeclared = (ColorBlend)99;
+
+            Assert.Throws<ArgumentOutOfRangeException>(
+                () => new ColorBlockTintConverter(Tint, undeclared, SelectableStates.All).Convert(Authored()));
+
+            Assert.DoesNotThrow(
+                () => new ColorBlockTintConverter(Tint, undeclared, SelectableStates.None).Convert(Authored()));
+        }
+
+        // ---- ColorBlockStateConverter ----
+
+        // ColorChannelConverter defaults to a multiply by white so that a freshly picked converter
+        // passes the bound value through; this one does not follow that rule. Its defaults are
+        // Disabled plus grey, so picking it in the Inspector already recolours a state before
+        // anything is authored — deliberate, since that is the state it exists to pin, but the
+        // asymmetry is what this pins down.
+        [Test]
+        public void StateConverter_ParameterlessConstructor_WritesGrayIntoDisabledOnly()
+        {
+            var result = new ColorBlockStateConverter().Convert(Authored());
+
+            Assert.AreEqual(Color.gray, result.disabledColor, "The default converter should write grey into Disabled.");
+            AssertUntouchedOutside(SelectableStates.Disabled, result);
+        }
+
+        [TestCase(SelectableStates.Normal)]
+        [TestCase(SelectableStates.Highlighted)]
+        [TestCase(SelectableStates.Pressed)]
+        [TestCase(SelectableStates.Selected)]
+        [TestCase(SelectableStates.Disabled)]
+        public void StateConverter_SingleStateMask_WritesThatStateAndLeavesTheOtherFour(SelectableStates state)
+        {
+            var result = new ColorBlockStateConverter(state, Written).Convert(Authored());
+
+            Assert.AreEqual(Written, ColorOf(result, state), $"{state} sits inside the mask and should carry the authored colour.");
+            AssertUntouchedOutside(state, result);
+        }
+
+        // "This toggle stays lit once chosen": one converter pinning two states to one colour is the
+        // reason the field is a mask rather than a single choice.
+        [Test]
+        public void StateConverter_CombinedMask_PinsBothStatesToTheSameColour()
+        {
+            const SelectableStates mask = SelectableStates.Normal | SelectableStates.Selected;
+
+            var result = new ColorBlockStateConverter(mask, Written).Convert(Authored());
+
+            Assert.AreEqual(Written, result.normalColor, "Normal sits inside the mask.");
+            Assert.AreEqual(Written, result.selectedColor, "Selected sits inside the mask.");
+            AssertUntouchedOutside(mask, result);
+        }
+
+        [Test]
+        public void StateConverter_AllMask_FlattensEveryState()
+        {
+            var result = new ColorBlockStateConverter(SelectableStates.All, Written).Convert(Authored());
+
+            foreach (var state in EveryState)
+                Assert.AreEqual(Written, ColorOf(result, state), $"{state} sits inside the All mask.");
+        }
+
+        [Test]
+        public void StateConverter_NoneMask_ChangesNothing()
+        {
+            var result = new ColorBlockStateConverter(SelectableStates.None, Written).Convert(Authored());
+
+            AssertUntouchedOutside(SelectableStates.None, result);
+        }
+
+        [Test]
+        public void StateConverter_LeavesFadeDurationAndMultiplierAlone()
+        {
+            var result = new ColorBlockStateConverter(SelectableStates.All, Written).Convert(Authored());
+
+            Assert.AreEqual(Authored().fadeDuration, result.fadeDuration, Tolerance, "fadeDuration");
+            Assert.AreEqual(Authored().colorMultiplier, result.colorMultiplier, Tolerance, "colorMultiplier");
+        }
+
+        // The documented pairing: a theme tints the whole block, then this puts back the one state
+        // the theme had no business recolouring. The order matters — the state converter has to run
+        // second, or the tint multiplies the authored colour it just wrote.
+        [Test]
+        public void StateConverter_ChainedAfterTheTint_RestoresTheDisabledColourTheThemeTook()
+        {
+            var themed = new ColorBlockTintConverter(Tint).Convert(Authored());
+            var result = new ColorBlockStateConverter(SelectableStates.Disabled, Written).Convert(themed);
+
+            Assert.AreEqual(Written, result.disabledColor, "The disabled colour should be the authored one, not the tinted one.");
+            AssertSameColor(new Color(0.5f, 0f, 0f, 0.25f), result.normalColor, "Normal keeps the theme");
+        }
+
+        // ---- The converter next door, which has no mask ----
+
+        // ColorBlockAlphaConverter writes all five states unconditionally, so it cannot spare the
+        // disabled one the way the two masked converters can. Asserted rather than assumed: this
+        // fails the day a mask is added with anything but All behind it.
+        [Test]
+        public void AlphaConverter_HasNoMask_SoItDimsTheDisabledStateToo()
+        {
+            var result = new ColorBlockAlphaConverter(0.5f, AlphaMode.Set).Convert(Authored());
+
+            AssertSameColor(new Color(0f, 1f, 1f, 0.5f), result.disabledColor, "Disabled, dimmed");
+        }
+
+        /// <summary>
+        /// A block whose five state colours are all different, none of them grey, white or the tint.
+        /// </summary>
+        private static ColorBlock Authored() => new()
+        {
+            normalColor = new Color(1f, 0f, 0f, 1f),
+            highlightedColor = new Color(0f, 1f, 0f, 0.9f),
+            pressedColor = new Color(0f, 0f, 1f, 0.8f),
+            selectedColor = new Color(1f, 1f, 0f, 0.7f),
+            disabledColor = new Color(0f, 1f, 1f, 0.6f),
+            colorMultiplier = 3f,
+            fadeDuration = 0.25f,
+        };
+
+        /// <exception cref="ArgumentOutOfRangeException">Thrown for anything but a single state.</exception>
+        private static Color ColorOf(ColorBlock block, SelectableStates state) => state switch
+        {
+            SelectableStates.Normal => block.normalColor,
+            SelectableStates.Highlighted => block.highlightedColor,
+            SelectableStates.Pressed => block.pressedColor,
+            SelectableStates.Selected => block.selectedColor,
+            SelectableStates.Disabled => block.disabledColor,
+            _ => throw new ArgumentOutOfRangeException(nameof(state), state, "Not a single state.")
+        };
+
+        /// <summary>
+        /// Asserts that every state the mask excludes came through with the authored colour untouched.
+        /// </summary>
+        private static void AssertUntouchedOutside(SelectableStates written, ColorBlock result)
+        {
+            foreach (var state in EveryState)
+            {
+                if (written.HasFlag(state)) continue;
+
+                Assert.AreEqual(
+                    ColorOf(Authored(), state),
+                    ColorOf(result, state),
+                    $"{state} sits outside the {written} mask and should have passed through untouched.");
+            }
+        }
+
+        private static void AssertSameColor(Color expected, Color actual, string message)
+        {
+            Assert.AreEqual(expected.r, actual.r, Tolerance, $"{message}: red.");
+            Assert.AreEqual(expected.g, actual.g, Tolerance, $"{message}: green.");
+            Assert.AreEqual(expected.b, actual.b, Tolerance, $"{message}: blue.");
+            Assert.AreEqual(expected.a, actual.a, Tolerance, $"{message}: alpha.");
+        }
+    }
+}

--- a/Aspid.MVVM/Packages/tech.aspid.mvvm/Tests/Editor/Converters/Colors/ColorBlockAdditionsTests.cs
+++ b/Aspid.MVVM/Packages/tech.aspid.mvvm/Tests/Editor/Converters/Colors/ColorBlockAdditionsTests.cs
@@ -12,20 +12,14 @@ namespace Aspid.MVVM.StarterKit.Tests
     /// that the four it does not write survive bit for bit.
     /// </summary>
     /// <remarks>
-    /// A mask converter fails in two ways a "does it tint?" test never sees: it writes a state the
-    /// mask excluded, or it reads the wrong field and writes the right colour into the wrong state.
-    /// Both need a source block whose five colours are all different, which is why nothing here
-    /// starts from <see cref="ColorBlock.defaultColorBlock"/> — that block gives highlighted and
-    /// selected the same colour, so a converter swapping the two would pass.
+    /// A mask converter fails in two ways a "does it tint?" test never sees: it writes a state the mask
+    /// excluded, or it reads the wrong field and writes the right colour into the wrong state. Both need
+    /// a source block whose five colours all differ, which is why nothing here starts from
+    /// <see cref="ColorBlock.defaultColorBlock"/> — it gives highlighted and selected the same colour.
     /// <para>
-    /// The second thing guarded is the default. The mask arrived after the converters shipped, so
-    /// <see cref="SelectableStates.All"/> has to stay the default in both the constructor and the
-    /// field initializer; any narrower default silently stops tinting a state that used to be
-    /// tinted, and nothing about the binder would look broken.
-    /// </para>
-    /// <para>
-    /// Neither converter logs or allocates a Unity object, so there is no <c>LogAssert</c> and
-    /// nothing to destroy — <see cref="ColorBlock"/> is a struct and both converters are pure.
+    /// The second thing guarded is the default: <see cref="SelectableStates.All"/> has to stay the default
+    /// in both the constructor and the field initializer, since any narrower one silently stops tinting a
+    /// state that used to be tinted.
     /// </para>
     /// </remarks>
     [TestFixture]

--- a/Aspid.MVVM/Packages/tech.aspid.mvvm/Tests/Editor/Converters/Colors/ColorBlockAdditionsTests.cs.meta
+++ b/Aspid.MVVM/Packages/tech.aspid.mvvm/Tests/Editor/Converters/Colors/ColorBlockAdditionsTests.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 0e459a459cef74e81aa19cc4ce4e5a88

--- a/Aspid.MVVM/Packages/tech.aspid.mvvm/Tests/Editor/Converters/Colors/ColorConverterAdditionsTests.cs
+++ b/Aspid.MVVM/Packages/tech.aspid.mvvm/Tests/Editor/Converters/Colors/ColorConverterAdditionsTests.cs
@@ -1,0 +1,462 @@
+using System;
+using UnityEngine;
+using NUnit.Framework;
+using System.Reflection;
+
+namespace Aspid.MVVM.StarterKit.Tests
+{
+    /// <summary>
+    /// Coverage for the colour converters added in this wave — <see cref="ColorChannelConverter"/>
+    /// across every <see cref="ChannelOp"/>, every <see cref="ColorChannels"/> mask and the clamp
+    /// flag, the <see cref="ColorLerpConverter"/> curve together with its unclamped extrapolation,
+    /// and <see cref="ThresholdColorConverter"/> blending over stops authored out of order.
+    /// </summary>
+    /// <remarks>
+    /// The mistake this fixture guards against is always "a channel that should not have moved,
+    /// moved": a mask compared with <c>==</c> instead of <c>HasFlag</c>, a clamp applied to channels
+    /// the mask never wrote, a curve consulted for an amount it cannot answer for, and a threshold
+    /// search that assumes the Inspector left the stops sorted.
+    /// <para>
+    /// Several assertions pin behaviour the XML docs do not describe, or describe loosely — the
+    /// clamp reaching only written channels, a curve keeping the endpoints away from the two stops,
+    /// and the fallback never taking part in a blend. Those cases carry a comment saying which claim
+    /// they are measured against.
+    /// </para>
+    /// </remarks>
+    [TestFixture]
+    internal sealed class ColorConverterAdditionsTests
+    {
+        private const float Delta = 1e-5f;
+        private const float CurveDelta = 1e-4f;
+
+        #region ColorChannelConverter
+
+        // A mask written as `_channels == flag` instead of HasFlag passes R, G, B and A but fails
+        // every composite mask; a mask written as `(_channels & flag) != 0` with None==0 would be
+        // right, so None is here to catch the inverted guard rather than the composite one.
+        [TestCase(ColorChannels.None, 0.4f, 0.4f, 0.4f, 0.4f)]
+        [TestCase(ColorChannels.R, 0.5f, 0.4f, 0.4f, 0.4f)]
+        [TestCase(ColorChannels.G, 0.4f, 0.5f, 0.4f, 0.4f)]
+        [TestCase(ColorChannels.B, 0.4f, 0.4f, 0.5f, 0.4f)]
+        [TestCase(ColorChannels.A, 0.4f, 0.4f, 0.4f, 0.5f)]
+        [TestCase(ColorChannels.R | ColorChannels.A, 0.5f, 0.4f, 0.4f, 0.5f)]
+        [TestCase(ColorChannels.Rgb, 0.5f, 0.5f, 0.5f, 0.4f)]
+        [TestCase(ColorChannels.All, 0.5f, 0.5f, 0.5f, 0.5f)]
+        public void Convert_Set_WritesOnlyTheMaskedChannels(
+            ColorChannels channels,
+            float red,
+            float green,
+            float blue,
+            float alpha)
+        {
+            var converter = new ColorChannelConverter(ChannelOp.Set, Uniform(0.5f), channels);
+
+            AssertColor(new Color(red, green, blue, alpha), converter.Convert(Uniform(0.4f)));
+        }
+
+        // Red operates on red, green on green. A transposed operand would still pass every uniform
+        // case above, so the operand here has a different value in each channel.
+        [Test]
+        public void Convert_Set_PairsEachOperandChannelWithItsOwn()
+        {
+            var operand = new Color(0.1f, 0.2f, 0.3f, 0.4f);
+            var converter = new ColorChannelConverter(ChannelOp.Set, operand, ColorChannels.All);
+
+            AssertColor(operand, converter.Convert(new Color(0f, 0f, 0f, 0f)));
+        }
+
+        // 0.8 + 0.5 leaves the unit range, which is the only place the clamp flag is observable for
+        // these three operations: Set and Multiply stay inside it for this operand.
+        [TestCase(ChannelOp.Set, true, 0.5f)]
+        [TestCase(ChannelOp.Set, false, 0.5f)]
+        [TestCase(ChannelOp.Multiply, true, 0.4f)]
+        [TestCase(ChannelOp.Multiply, false, 0.4f)]
+        [TestCase(ChannelOp.Add, true, 1f)]
+        [TestCase(ChannelOp.Add, false, 1.3f)]
+        public void Convert_EachOperation_AgainstTheClampFlag(ChannelOp operation, bool clamp, float expected)
+        {
+            var converter = new ColorChannelConverter(operation, Uniform(0.5f), ColorChannels.All, clamp);
+
+            AssertColor(Uniform(expected), converter.Convert(Uniform(0.8f)));
+        }
+
+        // The clamp is Clamp01, not an upper bound: clearing it lets a channel go negative, which a
+        // subtractive damage flash relies on and a Mathf.Min-shaped clamp would hide.
+        [TestCase(true, 0f)]
+        [TestCase(false, -0.3f)]
+        public void Convert_Add_NegativeOperand_ClampFlagDecidesTheFloor(bool clamp, float expected)
+        {
+            var converter = new ColorChannelConverter(ChannelOp.Add, Uniform(-0.5f), ColorChannels.All, clamp);
+
+            AssertColor(Uniform(expected), converter.Convert(Uniform(0.2f)));
+        }
+
+        // Set clamps the operand itself, so an HDR colour cannot be authored into the operand field
+        // while the flag is on.
+        [TestCase(true, 1f)]
+        [TestCase(false, 4f)]
+        public void Convert_Set_OperandAboveOne_ClampFlagDecidesTheCeiling(bool clamp, float expected)
+        {
+            var converter = new ColorChannelConverter(ChannelOp.Set, Uniform(4f), ColorChannels.All, clamp);
+
+            AssertColor(Uniform(expected), converter.Convert(Uniform(0.2f)));
+        }
+
+        [Test]
+        public void Convert_Unclamped_MultipliesHdrPastOne()
+        {
+            var converter = new ColorChannelConverter(
+                ChannelOp.Multiply,
+                new Color(3f, 3f, 3f, 1f),
+                ColorChannels.Rgb,
+                clamp: false);
+
+            AssertColor(new Color(6f, 6f, 6f, 1f), converter.Convert(new Color(2f, 2f, 2f, 1f)));
+        }
+
+        // The clamp reaches written channels only — an unmasked channel is returned as it arrived,
+        // HDR value and all. The tooltip says "Hold every written channel inside 0..1", so this is
+        // the documented behaviour, but the surprise is worth pinning: one converter can emit a
+        // colour that is clamped in RGB and above one in alpha at the same time.
+        [Test]
+        public void Convert_Clamped_LeavesUnmaskedHdrChannelsAlone()
+        {
+            var converter = new ColorChannelConverter(
+                ChannelOp.Multiply,
+                Color.white,
+                ColorChannels.Rgb,
+                clamp: true);
+
+            AssertColor(new Color(1f, 1f, 1f, 4f), converter.Convert(new Color(2f, 2f, 2f, 4f)));
+        }
+
+        [Test]
+        public void Convert_DefaultConstructed_IsAnIdentityForAnLdrColour()
+        {
+            var value = new Color(0.2f, 0.4f, 0.6f, 0.8f);
+
+            AssertColor(value, new ColorChannelConverter().Convert(value));
+        }
+
+        // The source comment claims the defaults exist so "a freshly picked converter passes the
+        // bound colour through". It does for LDR only: the default clamp is on and the default mask
+        // is Rgb, so a freshly picked converter silently crushes an HDR colour to white while
+        // leaving its alpha untouched.
+        [Test]
+        public void Convert_DefaultConstructed_IsNotAnIdentityForHdr() =>
+            AssertColor(
+                new Color(1f, 0.5f, 0f, 3f),
+                new ColorChannelConverter().Convert(new Color(2f, 0.5f, 0f, 3f)));
+
+        [Test]
+        public void Convert_UndeclaredOperation_Throws()
+        {
+            var converter = new ColorChannelConverter((ChannelOp)42, Color.white, ColorChannels.All);
+
+            Assert.Throws<ArgumentOutOfRangeException>(() => converter.Convert(Color.white));
+        }
+
+        // The operation is validated per channel and only after the mask test, so an unreachable
+        // operation is never reported. A converter left in this state looks like it works.
+        [Test]
+        public void Convert_UndeclaredOperation_WithNoChannelMasked_DoesNotThrow()
+        {
+            var converter = new ColorChannelConverter((ChannelOp)42, Color.white, ColorChannels.None);
+
+            AssertColor(Color.cyan, converter.Convert(Color.cyan));
+        }
+
+        #endregion
+
+        #region ColorLerpConverter
+
+        // A straight line to 0.25 makes the curve's contribution readable: an ignored curve would
+        // answer 0.5 here, the curve's own value at 0.5 is 0.125.
+        [Test]
+        public void Convert_WithCurve_ShapesTheAmount()
+        {
+            var converter = new ColorLerpConverter(Color.black, Color.white, AnimationCurve.Linear(0f, 0f, 1f, 0.25f));
+
+            Assert.AreEqual(0.125f, converter.Convert(0.5f).r, CurveDelta);
+        }
+
+        // The curve replaces the amount outright rather than modulating it, so an authored curve
+        // that does not pass through (0,0) and (1,1) means Convert(0) is not _from and Convert(1) is
+        // not _to. Nothing in the class normalises the curve.
+        [TestCase(0f)]
+        [TestCase(0.5f)]
+        [TestCase(1f)]
+        public void Convert_WithConstantCurve_NeverReachesEitherStop(float amount)
+        {
+            var converter = new ColorLerpConverter(Color.black, Color.white, AnimationCurve.Constant(0f, 1f, 0.25f));
+
+            Assert.AreEqual(0.25f, converter.Convert(amount).r, CurveDelta);
+        }
+
+        // A one-key curve evaluates to that key's value everywhere, which would pin every amount to
+        // 0.75. The length guard is `> 1`, so the curve is skipped instead.
+        [Test]
+        public void Convert_WithCurveOfOneKey_IgnoresTheCurve()
+        {
+            var converter = new ColorLerpConverter(Color.black, Color.white, new AnimationCurve(new Keyframe(0f, 0.75f)));
+
+            Assert.AreEqual(0.5f, converter.Convert(0.5f).r, Delta);
+        }
+
+        // A curve field that was never authored deserializes with no keys rather than as null, and
+        // evaluating that answers zero — which would pin every amount to _from.
+        [Test]
+        public void Convert_WithEmptyCurve_IgnoresTheCurve()
+        {
+            var converter = new ColorLerpConverter(Color.black, Color.white, new AnimationCurve());
+
+            Assert.AreEqual(0.5f, converter.Convert(0.5f).r, Delta);
+        }
+
+        [TestCase(3f, 0.6f)]
+        [TestCase(-1f, 0.2f)]
+        [TestCase(0.5f, 0.4f)]
+        public void Convert_Clamped_HoldsAtBothStops(float amount, float expectedRed)
+        {
+            // The empty curve keeps the shaping out of the way, so the clamp is what is measured.
+            var converter = new ColorLerpConverter(Uniform(0.2f), Uniform(0.6f), new AnimationCurve());
+
+            Assert.AreEqual(expectedRed, converter.Convert(amount).r, Delta);
+        }
+
+        // The review fix. With the clamp cleared the amount reaches Color.LerpUnclamped as it
+        // arrived, so 3 carries a third of the way past _to and past one, and -1 goes below zero.
+        // A clamped implementation answers 0.6 and 0.2 for the first two rows.
+        [TestCase(3f, 1.4f)]
+        [TestCase(-1f, -0.2f)]
+        [TestCase(0.5f, 0.4f)]
+        public void Convert_Unclamped_CarriesPastBothStops(float amount, float expectedRed) =>
+            Assert.AreEqual(expectedRed, Unclamped(Uniform(0.2f), Uniform(0.6f)).Convert(amount).r, Delta);
+
+        // Extrapolation is not RGB-only: alpha rides the same unclamped lerp, so a fade-out pair
+        // driven past one produces a negative alpha rather than a transparent colour.
+        [Test]
+        public void Convert_Unclamped_ExtrapolatesAlphaToo()
+        {
+            var converter = Unclamped(new Color(0f, 0f, 0f, 1f), new Color(0f, 0f, 0f, 0f));
+
+            Assert.AreEqual(-1f, converter.Convert(2f).a, Delta);
+        }
+
+        // The other half of the fix: unclamped skips the curve entirely, because a curve answers
+        // with its end key past either end of its own range and would clamp the amount back. Under
+        // the pre-fix routing both rows would read 0.3 — the constant curve's 0.25 of the span.
+        [TestCase(0f, 0.2f)]
+        [TestCase(1f, 0.6f)]
+        public void Convert_Unclamped_IgnoresTheCurve(float amount, float expectedRed)
+        {
+            var converter = Unclamped(Uniform(0.2f), Uniform(0.6f), AnimationCurve.Constant(0f, 1f, 0.25f));
+
+            Assert.AreEqual(expectedRed, converter.Convert(amount).r, Delta);
+        }
+
+        #endregion
+
+        #region ThresholdColorConverter
+
+        // The stops are authored in whatever order the Inspector left them; the array below is
+        // deliberately scrambled. A search that trusts the order returns the last qualifying stop
+        // rather than the highest one, which is cyan at 0.5 for a value of 0.8.
+        [TestCase(0.8f, 0f, 1f, 0f)]
+        [TestCase(0.75f, 0f, 1f, 0f)]
+        [TestCase(0.6f, 0f, 1f, 1f)]
+        [TestCase(0.3f, 0f, 0f, 1f)]
+        [TestCase(0.25f, 0f, 0f, 1f)]
+        [TestCase(0.1f, 1f, 0f, 0f)]
+        public void Convert_UnsortedStops_PicksTheHighestQualifying(
+            float value,
+            float red,
+            float green,
+            float blue)
+        {
+            var converter = new ThresholdColorConverter(
+                new[]
+                {
+                    Stop(0.75f, Color.green),
+                    Stop(0.25f, Color.blue),
+                    Stop(0.5f, Color.cyan),
+                },
+                fallback: Color.red);
+
+            AssertColor(new Color(red, green, blue, 1f), converter.Convert(value));
+        }
+
+        // The running lower bound starts at 0 and is guarded by a separate `hasLower` flag. Drop the
+        // flag and a stop below zero never qualifies, so this returns the fallback instead.
+        [Test]
+        public void Convert_NegativeThreshold_StillQualifies()
+        {
+            var converter = new ThresholdColorConverter(new[] { Stop(-1f, Color.green) }, fallback: Color.red);
+
+            AssertColor(Color.green, converter.Convert(-0.5f));
+        }
+
+        [Test]
+        public void Convert_NotInterpolating_HoldsTheStopColourUntilTheNextThreshold()
+        {
+            var converter = new ThresholdColorConverter(
+                new[] { Stop(0f, Color.red), Stop(1f, Color.green) },
+                fallback: Color.white);
+
+            AssertColor(Color.red, converter.Convert(0.5f));
+        }
+
+        [Test]
+        public void Convert_Interpolating_UnsortedStops_BlendsTowardsTheNextUp()
+        {
+            var converter = new ThresholdColorConverter(
+                new[] { Stop(1f, Color.green), Stop(0f, Color.red) },
+                fallback: Color.white,
+                interpolate: true);
+
+            AssertColor(new Color(0.75f, 0.25f, 0f, 1f), converter.Convert(0.25f));
+        }
+
+        // Both neighbours are found in one pass rather than by sorting. Picking the outermost pair
+        // instead of the immediate one gives 0.75 grey here.
+        [Test]
+        public void Convert_Interpolating_UsesOnlyTheImmediateNeighbours()
+        {
+            var converter = new ThresholdColorConverter(
+                new[] { Stop(1f, Color.white), Stop(0f, Color.black), Stop(0.5f, Color.red) },
+                fallback: Color.green,
+                interpolate: true);
+
+            AssertColor(new Color(1f, 0.5f, 0.5f, 1f), converter.Convert(0.75f));
+        }
+
+        // The fallback never takes part in a blend: below every threshold there is no lower stop, so
+        // the converter returns it flat. The docs say blending gives "the colour between that stop
+        // and the next one up" and never mention the fallback, so a reader could reasonably expect a
+        // ramp out of it. There is none — the first stop still arrives as a step.
+        [Test]
+        public void Convert_Interpolating_BelowEveryStop_ReturnsTheFallbackUnblended()
+        {
+            var converter = new ThresholdColorConverter(
+                new[] { Stop(0.5f, Color.green) },
+                fallback: Color.red,
+                interpolate: true);
+
+            AssertColor(Color.red, converter.Convert(0.1f));
+        }
+
+        // Above the top stop there is no upper neighbour, so blending stops rather than
+        // extrapolating past it.
+        [TestCase(1f)]
+        [TestCase(1.5f)]
+        public void Convert_Interpolating_AboveTheTopStop_HoldsThatStop(float value)
+        {
+            var converter = new ThresholdColorConverter(
+                new[] { Stop(0f, Color.red), Stop(1f, Color.green) },
+                fallback: Color.white,
+                interpolate: true);
+
+            AssertColor(Color.green, converter.Convert(value));
+        }
+
+        // t is zero at the lower stop, so blending does not shift the colour of a value sitting
+        // exactly on a threshold — the step boundary stays where it was authored.
+        [Test]
+        public void Convert_Interpolating_AtAStop_IsExactlyThatStop()
+        {
+            var converter = new ThresholdColorConverter(
+                new[] { Stop(0f, Color.red), Stop(1f, Color.green) },
+                fallback: Color.white,
+                interpolate: true);
+
+            AssertColor(Color.red, converter.Convert(0f));
+        }
+
+        // The span is upper - lower, not a normalised 0..1 distance, so a negative lower bound has
+        // to survive the division.
+        [Test]
+        public void Convert_Interpolating_AcrossANegativeSpan()
+        {
+            var converter = new ThresholdColorConverter(
+                new[] { Stop(-2f, Color.red), Stop(2f, Color.green) },
+                fallback: Color.white,
+                interpolate: true);
+
+            AssertColor(new Color(0.5f, 0.5f, 0f, 1f), converter.Convert(0f));
+        }
+
+        // Equal thresholds are resolved by `threshold <= lower` -> skip, so the first stop authored
+        // at a threshold wins and the later duplicate is dead. Two stops swapped in the Inspector
+        // therefore change the output even though they describe the same threshold.
+        [Test]
+        public void Convert_DuplicateThresholds_TheFirstAuthoredWins()
+        {
+            var converter = new ThresholdColorConverter(
+                new[] { Stop(0.5f, Color.green), Stop(0.5f, Color.blue) },
+                fallback: Color.red);
+
+            AssertColor(Color.green, converter.Convert(0.5f));
+        }
+
+        // Same tie-break on the upper side, where it decides which colour is blended towards:
+        // green wins, so blue never reaches the result and the blue channel stays at zero.
+        [Test]
+        public void Convert_Interpolating_DuplicateUpperThresholds_TheFirstAuthoredWins()
+        {
+            var converter = new ThresholdColorConverter(
+                new[] { Stop(0f, Color.black), Stop(1f, Color.green), Stop(1f, Color.blue) },
+                fallback: Color.white,
+                interpolate: true);
+
+            AssertColor(new Color(0f, 0.5f, 0f, 1f), converter.Convert(0.5f));
+        }
+
+        [Test]
+        public void Convert_NullStops_ReturnsTheFallbackEvenWhenInterpolating() =>
+            AssertColor(Color.red, new ThresholdColorConverter(null, Color.red, interpolate: true).Convert(5f));
+
+        [Test]
+        public void Convert_EmptyStops_ReturnsTheFallbackEvenWhenInterpolating() =>
+            AssertColor(
+                Color.red,
+                new ThresholdColorConverter(Array.Empty<ColorStop>(), Color.red, interpolate: true).Convert(5f));
+
+        #endregion
+
+        private static Color Uniform(float channel) => new Color(channel, channel, channel, channel);
+
+        private static ColorStop Stop(float threshold, Color color) =>
+            new ColorStop { Threshold = threshold, Color = color };
+
+        private static ColorLerpConverter Unclamped(Color from, Color to) =>
+            With(new ColorLerpConverter(from, to), "_clamp", false);
+
+        private static ColorLerpConverter Unclamped(Color from, Color to, AnimationCurve curve) =>
+            With(new ColorLerpConverter(from, to, curve), "_clamp", false);
+
+        // Color.Equals compares the four floats exactly, so every assertion goes through a per
+        // channel delta instead — a blended colour is arithmetic, not a copied constant.
+        private static void AssertColor(Color expected, Color actual)
+        {
+            Assert.AreEqual(expected.r, actual.r, Delta, $"red: expected {expected}, was {actual}");
+            Assert.AreEqual(expected.g, actual.g, Delta, $"green: expected {expected}, was {actual}");
+            Assert.AreEqual(expected.b, actual.b, Delta, $"blue: expected {expected}, was {actual}");
+            Assert.AreEqual(expected.a, actual.a, Delta, $"alpha: expected {expected}, was {actual}");
+        }
+
+        // The clamp is Inspector state with no constructor overload, so the tests set it the way the
+        // Inspector does. A renamed field throws here rather than leaving the default in place,
+        // which would let the unclamped assertions pass for the wrong reason.
+        private static T With<T>(T converter, string field, object value)
+            where T : class
+        {
+            const BindingFlags flags = BindingFlags.Instance | BindingFlags.NonPublic;
+
+            var info = converter.GetType().GetField(field, flags);
+            if (info is null) throw new InvalidOperationException($"{converter.GetType().Name} has no {field} field.");
+
+            info.SetValue(converter, value);
+            return converter;
+        }
+    }
+}

--- a/Aspid.MVVM/Packages/tech.aspid.mvvm/Tests/Editor/Converters/Colors/ColorConverterAdditionsTests.cs
+++ b/Aspid.MVVM/Packages/tech.aspid.mvvm/Tests/Editor/Converters/Colors/ColorConverterAdditionsTests.cs
@@ -12,16 +12,11 @@ namespace Aspid.MVVM.StarterKit.Tests
     /// and <see cref="ThresholdColorConverter"/> blending over stops authored out of order.
     /// </summary>
     /// <remarks>
-    /// The mistake this fixture guards against is always "a channel that should not have moved,
-    /// moved": a mask compared with <c>==</c> instead of <c>HasFlag</c>, a clamp applied to channels
-    /// the mask never wrote, a curve consulted for an amount it cannot answer for, and a threshold
-    /// search that assumes the Inspector left the stops sorted.
-    /// <para>
-    /// Several assertions pin behaviour the XML docs do not describe, or describe loosely — the
-    /// clamp reaching only written channels, a curve keeping the endpoints away from the two stops,
-    /// and the fallback never taking part in a blend. Those cases carry a comment saying which claim
-    /// they are measured against.
-    /// </para>
+    /// The mistake this fixture guards against is always "a channel that should not have moved, moved":
+    /// a mask compared with <c>==</c> instead of <c>HasFlag</c>, a clamp applied to channels the mask
+    /// never wrote, a curve consulted for an amount it cannot answer for, a threshold search assuming
+    /// sorted stops. Several assertions pin behaviour the XML docs describe loosely and carry a comment
+    /// saying which claim they are measured against.
     /// </remarks>
     [TestFixture]
     internal sealed class ColorConverterAdditionsTests

--- a/Aspid.MVVM/Packages/tech.aspid.mvvm/Tests/Editor/Converters/Colors/ColorConverterAdditionsTests.cs.meta
+++ b/Aspid.MVVM/Packages/tech.aspid.mvvm/Tests/Editor/Converters/Colors/ColorConverterAdditionsTests.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 603cac9857e8841459fe2e8866126f58

--- a/Aspid.MVVM/Packages/tech.aspid.mvvm/Tests/Editor/Converters/Colors/ColorInteropConverterTests.cs
+++ b/Aspid.MVVM/Packages/tech.aspid.mvvm/Tests/Editor/Converters/Colors/ColorInteropConverterTests.cs
@@ -9,18 +9,12 @@ namespace Aspid.MVVM.StarterKit.Tests
     /// <see cref="Color"/>/<see cref="Color32"/> pair.
     /// </summary>
     /// <remarks>
-    /// These are the converters where an assumption about range costs the most. The exposure maths is
-    /// unclamped on purpose and a well-meaning <c>Clamp01</c> would silently kill every bloom that
-    /// depends on it; the <see cref="Vector4"/> pair must stay a plain channel copy, because a
-    /// colour-space conversion sneaked into either half would break the round trip the docs promise;
-    /// and the <see cref="Color32"/> pair rides Unity's implicit operators, whose clamping and
-    /// rounding are easy to mis-describe from memory. Every expectation below is the value the
-    /// conversion actually produces, so a later tidy-up that clamps a channel, drops the alpha or
-    /// swaps rounding for truncation fails here rather than in a scene.
-    /// <para>
-    /// No converter in this file logs or allocates a Unity object, so the fixture needs neither
-    /// <c>LogAssert</c> nor a teardown.
-    /// </para>
+    /// These are the converters where an assumption about range costs the most: the exposure maths is
+    /// unclamped on purpose and a well-meaning <c>Clamp01</c> would kill every bloom that depends on it;
+    /// the <see cref="Vector4"/> pair must stay a plain channel copy, or the round trip the docs promise
+    /// breaks; and the <see cref="Color32"/> pair rides Unity's implicit operators, whose clamping and
+    /// rounding are easy to mis-describe from memory. Every expectation is the value the conversion
+    /// actually produces.
     /// </remarks>
     [TestFixture]
     internal sealed class ColorInteropConverterTests

--- a/Aspid.MVVM/Packages/tech.aspid.mvvm/Tests/Editor/Converters/Colors/ColorInteropConverterTests.cs
+++ b/Aspid.MVVM/Packages/tech.aspid.mvvm/Tests/Editor/Converters/Colors/ColorInteropConverterTests.cs
@@ -1,0 +1,228 @@
+using UnityEngine;
+using NUnit.Framework;
+
+namespace Aspid.MVVM.StarterKit.Tests
+{
+    /// <summary>
+    /// Coverage for the interop converters in <c>ColorInteropConverters.cs</c> —
+    /// <see cref="HdrIntensityConverter"/>, the <see cref="Color"/>/<see cref="Vector4"/> pair and the
+    /// <see cref="Color"/>/<see cref="Color32"/> pair.
+    /// </summary>
+    /// <remarks>
+    /// These are the converters where an assumption about range costs the most. The exposure maths is
+    /// unclamped on purpose and a well-meaning <c>Clamp01</c> would silently kill every bloom that
+    /// depends on it; the <see cref="Vector4"/> pair must stay a plain channel copy, because a
+    /// colour-space conversion sneaked into either half would break the round trip the docs promise;
+    /// and the <see cref="Color32"/> pair rides Unity's implicit operators, whose clamping and
+    /// rounding are easy to mis-describe from memory. Every expectation below is the value the
+    /// conversion actually produces, so a later tidy-up that clamps a channel, drops the alpha or
+    /// swaps rounding for truncation fails here rather than in a scene.
+    /// <para>
+    /// No converter in this file logs or allocates a Unity object, so the fixture needs neither
+    /// <c>LogAssert</c> nor a teardown.
+    /// </para>
+    /// </remarks>
+    [TestFixture]
+    internal sealed class ColorInteropConverterTests
+    {
+        // Fractional stops are reachable from a bound slider, so the factor is a power curve rather
+        // than a multiply: half a stop is 1.414, not 1.5.
+        [TestCase(0f, 0.5f, 0.5f)]
+        [TestCase(1f, 0.5f, 1f)]
+        [TestCase(2f, 0.25f, 1f)]
+        [TestCase(-1f, 0.5f, 0.25f)]
+        [TestCase(-3f, 1f, 0.125f)]
+        [TestCase(10f, 1f, 1024f)]
+        [TestCase(0.5f, 1f, 1.4142135f)]
+        public void HdrIntensity_AnyExposure_ScalesTheChannelByTwoToThatPower(
+            float intensity,
+            float channel,
+            float expected) =>
+            Assert.AreEqual(
+                expected,
+                new HdrIntensityConverter(intensity).Convert(new Color(channel, channel, channel, 1f)).r,
+                1e-5f);
+
+        [Test]
+        public void HdrIntensity_DefaultConstructed_LeavesTheColourAlone() =>
+            Assert.AreEqual(
+                new Color(0.1f, 0.2f, 0.3f, 0.4f),
+                new HdrIntensityConverter().Convert(new Color(0.1f, 0.2f, 0.3f, 0.4f)));
+
+        // The whole point of the converter: the result has to leave 0..1 so a material can bloom with
+        // it. A Clamp01 added "for safety" would make every positive exposure look like plain white.
+        [Test]
+        public void HdrIntensity_PositiveExposure_PushesChannelsPastOne()
+        {
+            var result = new HdrIntensityConverter(2f).Convert(Color.white);
+
+            Assert.AreEqual(4f, result.r, 1e-5f);
+            Assert.AreEqual(4f, result.g, 1e-5f);
+            Assert.AreEqual(4f, result.b, 1e-5f);
+        }
+
+        // Exposure is brightness, not opacity. Multiplying alpha too would fade a glowing sprite out
+        // as it charges up, which is the opposite of what the binding is for.
+        [TestCase(3f)]
+        [TestCase(-3f)]
+        public void HdrIntensity_AnyExposure_LeavesAlphaUntouched(float intensity) =>
+            Assert.AreEqual(
+                0.4f,
+                new HdrIntensityConverter(intensity).Convert(new Color(1f, 1f, 1f, 0.4f)).a,
+                1e-6f);
+
+        // Color's constructor does not clamp, so a negative channel survives the multiply with its
+        // sign intact — the converter never reaches for Abs or Max.
+        [Test]
+        public void HdrIntensity_NegativeChannel_KeepsItsSign() =>
+            Assert.AreEqual(
+                -2f,
+                new HdrIntensityConverter(2f).Convert(new Color(-0.5f, 0f, 0f, 1f)).r,
+                1e-5f);
+
+        // 2^200 is past float.MaxValue, so an exposure bound to a runaway value yields infinity rather
+        // than saturating. Anything downstream that averages or lerps channels then produces NaN.
+        [Test]
+        public void HdrIntensity_AbsurdExposure_OverflowsToInfinity()
+        {
+            var result = new HdrIntensityConverter(200f).Convert(Color.white);
+
+            Assert.IsTrue(float.IsPositiveInfinity(result.r));
+            Assert.AreEqual(1f, result.a, 1e-6f);
+        }
+
+        // Distinct channels, so a converter that transposed two of them could not pass.
+        [Test]
+        public void ColorToVector4_AnyColour_CopiesRgbaIntoXyzw()
+        {
+            var result = new ColorToVector4Converter().Convert(new Color(0.1f, 0.2f, 0.3f, 0.4f));
+
+            Assert.AreEqual(0.1f, result.x, 1e-6f);
+            Assert.AreEqual(0.2f, result.y, 1e-6f);
+            Assert.AreEqual(0.3f, result.z, 1e-6f);
+            Assert.AreEqual(0.4f, result.w, 1e-6f);
+        }
+
+        [Test]
+        public void Vector4ToColor_AnyVector_CopiesXyzwIntoRgba()
+        {
+            var result = new Vector4ToColorConverter().Convert(new Vector4(0.1f, 0.2f, 0.3f, 0.4f));
+
+            Assert.AreEqual(0.1f, result.r, 1e-6f);
+            Assert.AreEqual(0.2f, result.g, 1e-6f);
+            Assert.AreEqual(0.3f, result.b, 1e-6f);
+            Assert.AreEqual(0.4f, result.a, 1e-6f);
+        }
+
+        // A vector read back off a material is not promised to sit in 0..1, and clamping it here would
+        // quietly rewrite a shader parameter that was correct.
+        [Test]
+        public void Vector4ToColor_OutOfRangeComponents_AreNotClamped()
+        {
+            var result = new Vector4ToColorConverter().Convert(new Vector4(1.5f, -0.5f, 0f, 2f));
+
+            Assert.AreEqual(1.5f, result.r, 1e-6f);
+            Assert.AreEqual(-0.5f, result.g, 1e-6f);
+            Assert.AreEqual(2f, result.a, 1e-6f);
+        }
+
+        // Asserted with the exact-equality overload rather than a delta: the docs promise this trip is
+        // lossless, and only bit equality actually proves no gamma or sRGB step crept in.
+        [Test]
+        public void Vector4RoundTrip_AwkwardChannels_IsBitExact()
+        {
+            var color = new Color(0.1f, 0.7f, 0.13f, 0.37f);
+            var result = new Vector4ToColorConverter().Convert(new ColorToVector4Converter().Convert(color));
+
+            Assert.AreEqual(color, result);
+        }
+
+        [TestCase((byte)0, 0f)]
+        [TestCase((byte)1, 0.003921569f)]
+        [TestCase((byte)64, 0.2509804f)]
+        [TestCase((byte)128, 0.5019608f)]
+        [TestCase((byte)255, 1f)]
+        public void Color32ToColor_AnyByte_DividesByTwoHundredFiftyFive(byte channel, float expected) =>
+            Assert.AreEqual(
+                expected,
+                new Color32ToColorConverter().Convert(new Color32(channel, channel, channel, 255)).r,
+                1e-6f);
+
+        // A widening that forgot alpha would turn a fully transparent stored colour into opaque black.
+        [Test]
+        public void Color32ToColor_ZeroAlpha_StaysTransparent() =>
+            Assert.AreEqual(0f, new Color32ToColorConverter().Convert(new Color32(0, 0, 0, 0)).a, 1e-6f);
+
+        // The discriminating cases are 0.5 and 0.25: Unity's implicit operator adds a half before the
+        // byte cast, so they land on 128 and 64. A hand-rolled (byte)(c.r * 255f) would give 127 and 63
+        // and drift every colour a step darker on each save/load cycle.
+        [TestCase(0f, 0)]
+        [TestCase(0.2f, 51)]
+        [TestCase(0.25f, 64)]
+        [TestCase(0.5f, 128)]
+        [TestCase(0.6f, 153)]
+        [TestCase(0.75f, 191)]
+        [TestCase(1f, 255)]
+        public void ColorToColor32_AnyChannel_RoundsRatherThanTruncates(float channel, int expected) =>
+            Assert.AreEqual(
+                expected,
+                new ColorToColor32Converter().Convert(new Color(channel, channel, channel, 1f)).r);
+
+        [TestCase(2f, 255)]
+        [TestCase(5f, 255)]
+        [TestCase(-1f, 0)]
+        public void ColorToColor32_OutOfRangeChannel_IsClampedNotWrapped(float channel, int expected) =>
+            Assert.AreEqual(
+                expected,
+                new ColorToColor32Converter().Convert(new Color(channel, channel, channel, 1f)).r);
+
+        [Test]
+        public void ColorToColor32_FractionalAlpha_NarrowsLikeAnyOtherChannel() =>
+            Assert.AreEqual(128, new ColorToColor32Converter().Convert(new Color(1f, 1f, 1f, 0.5f)).a);
+
+        // The lossy direction the remarks warn about, pinned to the value it actually returns: a
+        // mid-grey comes back as 128/255, not as the 0.5 that went in. Anything comparing a colour
+        // before and after a save round trip with == on floats will therefore see a change.
+        [Test]
+        public void ColorRoundTrip_ThroughColor32_ReturnsTheQuantisedChannel()
+        {
+            var result = new Color32ToColorConverter().Convert(
+                new ColorToColor32Converter().Convert(new Color(0.5f, 0.5f, 0.5f, 1f)));
+
+            Assert.AreEqual(128f / 255f, result.r, 1e-6f);
+            Assert.AreNotEqual(0.5f, result.r);
+        }
+
+        // The other direction is the one that must survive intact: vertex colours and save-file
+        // colours make this trip on every load, and a channel drifting by one per pass would show up
+        // as a mesh that slowly fades.
+        [Test]
+        public void Color32RoundTrip_ThroughColor_IsExactForEveryByte()
+        {
+            var widen = new Color32ToColorConverter();
+            var narrow = new ColorToColor32Converter();
+
+            for (var channel = 0; channel <= 255; channel++)
+            {
+                var source = new Color32((byte)channel, (byte)channel, (byte)channel, (byte)channel);
+                var result = narrow.Convert(widen.Convert(source));
+
+                Assert.AreEqual(channel, (int)result.r, $"Byte {channel} did not survive the round trip.");
+                Assert.AreEqual(channel, (int)result.a, $"Alpha {channel} did not survive the round trip.");
+            }
+        }
+
+        // Why the remarks send an HDR colour to a material rather than to anything byte-backed: one
+        // stop and five stops are already indistinguishable once narrowed, while the unexposed grey
+        // still carries its value. The glow is not dimmed by the trip, it is gone.
+        [Test]
+        public void HdrIntensity_NarrowedToColor32_CollapsesEveryGlowToWhite()
+        {
+            var narrow = new ColorToColor32Converter();
+
+            Assert.AreEqual(128, narrow.Convert(Color.gray).r);
+            Assert.AreEqual(255, narrow.Convert(new HdrIntensityConverter(1f).Convert(Color.gray)).r);
+            Assert.AreEqual(255, narrow.Convert(new HdrIntensityConverter(5f).Convert(Color.gray)).r);
+        }
+    }
+}

--- a/Aspid.MVVM/Packages/tech.aspid.mvvm/Tests/Editor/Converters/Colors/ColorInteropConverterTests.cs.meta
+++ b/Aspid.MVVM/Packages/tech.aspid.mvvm/Tests/Editor/Converters/Colors/ColorInteropConverterTests.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 4709e346e7cc24b65a869488833bb702

--- a/Aspid.MVVM/Packages/tech.aspid.mvvm/Tests/Editor/Converters/Enums/Channel.cs
+++ b/Aspid.MVVM/Packages/tech.aspid.mvvm/Tests/Editor/Converters/Enums/Channel.cs
@@ -1,0 +1,14 @@
+using System;
+
+namespace Aspid.MVVM.StarterKit.Tests
+{
+    // A signed backing type whose member holds the sign bit: reading it as bits sign-extends to
+    // 0xFFFF_FFFF_FFFF_FF80, so a complement leaves every bit above the enum's own width set.
+    [Flags]
+    internal enum Channel : sbyte
+    {
+        Silent = 0,
+        Left = 1,
+        Muted = -128,
+    }
+}

--- a/Aspid.MVVM/Packages/tech.aspid.mvvm/Tests/Editor/Converters/Enums/Channel.cs.meta
+++ b/Aspid.MVVM/Packages/tech.aspid.mvvm/Tests/Editor/Converters/Enums/Channel.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: e25df2a046b826283ce482c7be77152f

--- a/Aspid.MVVM/Packages/tech.aspid.mvvm/Tests/Editor/Converters/Enums/Element.cs
+++ b/Aspid.MVVM/Packages/tech.aspid.mvvm/Tests/Editor/Converters/Enums/Element.cs
@@ -1,0 +1,20 @@
+using System;
+
+namespace Aspid.MVVM.StarterKit.Tests
+{
+    // Hazard ([Flags] None/Fire/Ice/Shock), Medal (sparse, not [Flags]) and Quest (label attributes)
+    // are declared in EnumConverterAdditionsTests.cs and reused here.
+
+    // A composite declared FIRST on purpose. Enum.GetValues sorts by unsigned underlying value, and a
+    // composite ORs its parts so it can never sort ahead of them — the value is written as a literal
+    // rather than as Fire | Ice | Poison to keep the declaration order visible.
+    [Flags]
+    internal enum Element
+    {
+        All = 7,
+        None = 0,
+        Fire = 1,
+        Ice = 2,
+        Poison = 4,
+    }
+}

--- a/Aspid.MVVM/Packages/tech.aspid.mvvm/Tests/Editor/Converters/Enums/Element.cs.meta
+++ b/Aspid.MVVM/Packages/tech.aspid.mvvm/Tests/Editor/Converters/Enums/Element.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 22fa357df04fcd5f8e2b4d10c6fd7c91

--- a/Aspid.MVVM/Packages/tech.aspid.mvvm/Tests/Editor/Converters/Enums/EnumFlagsConverterTests.cs
+++ b/Aspid.MVVM/Packages/tech.aspid.mvvm/Tests/Editor/Converters/Enums/EnumFlagsConverterTests.cs
@@ -10,28 +10,13 @@ namespace Aspid.MVVM.StarterKit.Tests
     /// passthrough, the four mask operations and the size-one cache both converters keep.
     /// </summary>
     /// <remarks>
-    /// The mistake guarded against is reading a plain enum as a set of bits. Its number is one
-    /// member's value, so masking it either blanks it or produces a number no member declares, and
-    /// splitting it names whichever members happen to sit inside it — in both cases the View is
-    /// handed a value no <c>switch</c> in the game has a case for. Every non-[Flags] assertion below
-    /// is paired with the same operation on a [Flags] enum, so the passthrough cannot pass by being
-    /// a no-op everywhere.
+    /// The mistake guarded against is reading a plain enum as a set of bits: masking it either blanks it
+    /// or produces a number no member declares. Every non-[Flags] assertion is paired with the same
+    /// operation on a [Flags] enum, so the passthrough cannot pass by being a no-op everywhere.
     /// <para>
-    /// The second class of mistake is naming a composite member instead of its parts. A composite
-    /// carries every bit its parts carry, so it always sorts after them and each part consumes its
-    /// own bits first; a composite is named only when the bits it covers are not declared members.
-    /// The consequence is that a bit reachable only through a composite has no name at all, and a
-    /// composite spanning one declared and one undeclared bit under-reports.
-    /// </para>
-    /// <para>
-    /// Three assertions pin behaviour the documentation reads against.
-    /// <c>EnumFlagsToStringConverter</c> documents an <see cref="ArgumentOutOfRangeException"/> for
-    /// an undeclared name source, but the source is only consulted once a flag has to be named, so a
-    /// zero value returns the empty text instead of throwing. <c>EnumMaskConverter</c> documents the
-    /// same exception for an undeclared operation, and never reaches the switch at all on a
-    /// non-[Flags] enum. And the empty text is documented as covering "a value that names no flags",
-    /// yet under <see cref="EnumNameSource.Raw"/> on a non-[Flags] enum an undeclared value is
-    /// written as its number and the empty text goes unused.
+    /// The second is naming a composite member instead of its parts — a bit reachable only through a
+    /// composite ends up with no name at all. The third is documentation: three assertions pin behaviour
+    /// the XML docs read against, and are named to say so.
     /// </para>
     /// </remarks>
     [TestFixture]

--- a/Aspid.MVVM/Packages/tech.aspid.mvvm/Tests/Editor/Converters/Enums/EnumFlagsConverterTests.cs
+++ b/Aspid.MVVM/Packages/tech.aspid.mvvm/Tests/Editor/Converters/Enums/EnumFlagsConverterTests.cs
@@ -1,0 +1,356 @@
+using System;
+using UnityEngine;
+using NUnit.Framework;
+
+namespace Aspid.MVVM.StarterKit.Tests
+{
+    /// <summary>
+    /// Coverage for <see cref="EnumFlagsToStringConverter{TEnum}"/> and
+    /// <see cref="EnumMaskConverter{TEnum}"/> — flag naming, composite members, the non-[Flags]
+    /// passthrough, the four mask operations and the size-one cache both converters keep.
+    /// </summary>
+    /// <remarks>
+    /// The mistake guarded against is reading a plain enum as a set of bits. Its number is one
+    /// member's value, so masking it either blanks it or produces a number no member declares, and
+    /// splitting it names whichever members happen to sit inside it — in both cases the View is
+    /// handed a value no <c>switch</c> in the game has a case for. Every non-[Flags] assertion below
+    /// is paired with the same operation on a [Flags] enum, so the passthrough cannot pass by being
+    /// a no-op everywhere.
+    /// <para>
+    /// The second class of mistake is naming a composite member instead of its parts. A composite
+    /// carries every bit its parts carry, so it always sorts after them and each part consumes its
+    /// own bits first; a composite is named only when the bits it covers are not declared members.
+    /// The consequence is that a bit reachable only through a composite has no name at all, and a
+    /// composite spanning one declared and one undeclared bit under-reports.
+    /// </para>
+    /// <para>
+    /// Three assertions pin behaviour the documentation reads against.
+    /// <c>EnumFlagsToStringConverter</c> documents an <see cref="ArgumentOutOfRangeException"/> for
+    /// an undeclared name source, but the source is only consulted once a flag has to be named, so a
+    /// zero value returns the empty text instead of throwing. <c>EnumMaskConverter</c> documents the
+    /// same exception for an undeclared operation, and never reaches the switch at all on a
+    /// non-[Flags] enum. And the empty text is documented as covering "a value that names no flags",
+    /// yet under <see cref="EnumNameSource.Raw"/> on a non-[Flags] enum an undeclared value is
+    /// written as its number and the empty text goes unused.
+    /// </para>
+    /// </remarks>
+    [TestFixture]
+    internal sealed class EnumFlagsConverterTests
+    {
+        private const Hazard FireAndIce = Hazard.Fire | Hazard.Ice;
+        private const Hazard FireAndShock = Hazard.Fire | Hazard.Shock;
+        private const Hazard IceAndShock = Hazard.Ice | Hazard.Shock;
+        private const Hazard EveryHazard = Hazard.Fire | Hazard.Ice | Hazard.Shock;
+
+        // A bit no member declares, and the same bit beside a real flag.
+        private const Hazard UnnamedBit = (Hazard)8;
+        private const Hazard FireAndUnnamedBit = (Hazard)9;
+
+        private const Element TwoElements = Element.Fire | Element.Ice;
+        private const Permission ReadWriteAndExecute = Permission.ReadWrite | Permission.Execute;
+
+        // Bit 1 of Permission is reachable only through ReadWrite, and bit 1 beside Execute.
+        private const Permission HalfOfReadWrite = (Permission)1;
+        private const Permission HalfOfReadWriteAndExecute = (Permission)5;
+
+        private const Status BurningAndPoisoned = Status.Burning | Status.Poisoned;
+        private const Channel LeftAndMuted = Channel.Left | Channel.Muted;
+        private const Medal MissingMedal = (Medal)99;
+
+        // -------------------------------------------------------------------------------------------
+        // EnumFlagsToStringConverter — a [Flags] enum
+        // -------------------------------------------------------------------------------------------
+
+        [TestCase(Hazard.Fire, "Fire")]
+        [TestCase(FireAndIce, "Fire, Ice")]
+        [TestCase(IceAndShock, "Ice, Shock")]
+        [TestCase(EveryHazard, "Fire, Ice, Shock")]
+        public void Convert_Flags_NamesEveryFlagInAscendingValueOrder(Hazard value, string expected) =>
+            Assert.AreEqual(expected, new EnumFlagsToStringConverter<Hazard>().Convert(value));
+
+        [Test]
+        public void Convert_Flags_UsesTheAuthoredSeparator() =>
+            Assert.AreEqual("Fire + Ice + Shock", new EnumFlagsToStringConverter<Hazard>(" + ").Convert(EveryHazard));
+
+        // The zero member is skipped by value, not by name: matched like any other it would be named
+        // by every value, since every value has all zero of its bits.
+        [Test]
+        public void Convert_Flags_ZeroValue_ReturnsTheNoneTextRatherThanTheZeroMembersName() =>
+            Assert.AreEqual("Nothing", Hazards("Nothing").Convert(Hazard.None));
+
+        [Test]
+        public void Convert_DefaultConstructed_JoinsWithCommasAndHasAnEmptyNoneText()
+        {
+            Assert.AreEqual("Fire, Ice", new EnumFlagsToStringConverter<Hazard>().Convert(FireAndIce));
+            Assert.AreEqual(string.Empty, new EnumFlagsToStringConverter<Hazard>().Convert(Hazard.None));
+        }
+
+        // A bit no member declares has no name to give. Writing the leftover number would put
+        // something in the middle of a sentence that reads as a bug rather than as data.
+        [Test]
+        public void Convert_Flags_UndeclaredBitAlone_ReturnsTheNoneText() =>
+            Assert.AreEqual("Nothing", Hazards("Nothing").Convert(UnnamedBit));
+
+        // The undeclared half is dropped in silence — the text under-reports rather than refusing.
+        [Test]
+        public void Convert_Flags_UndeclaredBitBesideADeclaredOne_NamesOnlyTheDeclaredOne() =>
+            Assert.AreEqual("Fire", Hazards("Nothing").Convert(FireAndUnnamedBit));
+
+        // -------------------------------------------------------------------------------------------
+        // EnumFlagsToStringConverter — composite members
+        // -------------------------------------------------------------------------------------------
+
+        // All is declared first and still loses to its parts: Enum.GetValues sorts by value, and 7
+        // cannot sort ahead of 1, 2 and 4. Moving a composite up the enum therefore changes nothing.
+        [Test]
+        public void Convert_Flags_CompositeWhoseBitsAreDeclared_NamesThePartsRegardlessOfDeclarationOrder()
+        {
+            Assert.AreEqual("Fire, Ice, Poison", new EnumFlagsToStringConverter<Element>().Convert(Element.All));
+            Assert.AreEqual("Fire, Ice", new EnumFlagsToStringConverter<Element>().Convert(TwoElements));
+        }
+
+        // Nothing consumes bits 1 and 2 before ReadWrite is reached, so the composite is the name.
+        [TestCase(Permission.ReadWrite, "ReadWrite")]
+        [TestCase(ReadWriteAndExecute, "ReadWrite, Execute")]
+        public void Convert_Flags_CompositeWhoseBitsAreNotDeclared_NamesTheComposite(Permission value, string expected) =>
+            Assert.AreEqual(expected, Permissions().Convert(value));
+
+        // The flip side of the rule above: a member is named only when EVERY bit it covers is still
+        // unclaimed, so half of a composite matches nothing and the text falls to the empty case.
+        [Test]
+        public void Convert_Flags_BitReachableOnlyThroughAComposite_HasNoNameOfItsOwn()
+        {
+            Assert.AreEqual("Nothing", Permissions().Convert(HalfOfReadWrite));
+            Assert.AreEqual("Execute", Permissions().Convert(HalfOfReadWriteAndExecute));
+        }
+
+        // Ping consumes bit 1 first, leaving PingAndPong unmatchable and bit 2 unnamed — so the whole
+        // value reads as "Ping", which is half of what it carries.
+        [Test]
+        public void Convert_Flags_CompositeOverOneDeclaredAndOneUndeclaredBit_NamesTheDeclaredPartOnly() =>
+            Assert.AreEqual("Ping", new EnumFlagsToStringConverter<Signal>(", ", EnumNameSource.Name, "Nothing").Convert(Signal.PingAndPong));
+
+        // -------------------------------------------------------------------------------------------
+        // EnumFlagsToStringConverter — the name source
+        // -------------------------------------------------------------------------------------------
+
+        // Each flag is named on its own, so a member's attribute reads here exactly as it does through
+        // EnumToStringConverter — including the fall back to the member name when it is absent.
+        [Test]
+        public void Convert_Flags_NameSource_IsAskedForEachFlagSeparately()
+        {
+            Assert.AreEqual("Burning, Poisoned", new EnumFlagsToStringConverter<Status>().Convert(BurningAndPoisoned));
+            Assert.AreEqual("On fire, Poisoned", new EnumFlagsToStringConverter<Status>(", ", EnumNameSource.InspectorName).Convert(BurningAndPoisoned));
+            Assert.AreEqual("Burning, Losing health slowly", new EnumFlagsToStringConverter<Status>(", ", EnumNameSource.Description).Convert(BurningAndPoisoned));
+        }
+
+        // Raw is the one source that writes an undeclared value as its number. Reached one flag at a
+        // time it never sees an undeclared value, so the number cannot leak into the text: the same
+        // input through EnumToStringConverter reads "9".
+        [Test]
+        public void Convert_Flags_Raw_NamesEachFlagAndNeverWritesTheNumber()
+        {
+            Assert.AreEqual("Fire", new EnumFlagsToStringConverter<Hazard>(", ", EnumNameSource.Raw, "Nothing").Convert(FireAndUnnamedBit));
+            Assert.AreEqual("9", new EnumToStringConverter<Hazard>(EnumNameSource.Raw).Convert(FireAndUnnamedBit));
+        }
+
+        // Documented as "thrown when the name source is not a declared value" without qualification.
+        // The source is only consulted once a flag has to be named, so a value carrying none returns
+        // the empty text from the same instance that just threw.
+        [Test]
+        public void Convert_UndeclaredNameSource_ThrowsOnlyWhenAFlagHasToBeNamed()
+        {
+            var converter = new EnumFlagsToStringConverter<Hazard>(", ", (EnumNameSource)99, "Nothing");
+
+            Assert.Throws<ArgumentOutOfRangeException>(() => converter.Convert(Hazard.Fire));
+            Assert.AreEqual("Nothing", converter.Convert(Hazard.None));
+        }
+
+        // -------------------------------------------------------------------------------------------
+        // EnumFlagsToStringConverter — an enum that is not [Flags]
+        // -------------------------------------------------------------------------------------------
+
+        // The separator is authored on the same object either way, and a value split into bits here
+        // would name whichever members happen to sit inside the number.
+        [TestCase(Medal.None, "None")]
+        [TestCase(Medal.Bronze, "Bronze")]
+        [TestCase(Medal.Silver, "Silver")]
+        public void Convert_NonFlags_NamesTheWholeValueAndLeavesTheSeparatorUnused(Medal value, string expected) =>
+            Assert.AreEqual(expected, Medals().Convert(value));
+
+        // The pair that shows the two paths really are different code: zero is the absence of every
+        // flag on one enum and a member with a name on the other.
+        [Test]
+        public void Convert_ZeroValue_IsTheNoneTextOnAFlagsEnumAndAMemberNameOtherwise()
+        {
+            Assert.AreEqual("Nothing", Hazards("Nothing").Convert(Hazard.None));
+            Assert.AreEqual("None", Medals().Convert(Medal.None));
+        }
+
+        [Test]
+        public void Convert_NonFlags_UndeclaredValue_ReturnsTheNoneText() =>
+            Assert.AreEqual("n/a", Medals().Convert(MissingMedal));
+
+        // Documented as the text shown "when the value names no flags". Under Raw the inner converter
+        // answers with the number, which is not empty, so the empty text is never reached — the View
+        // gets "99" where every other source gives "n/a".
+        [Test]
+        public void Convert_NonFlags_Raw_UndeclaredValue_WritesTheNumberInsteadOfTheNoneText() =>
+            Assert.AreEqual("99", new EnumFlagsToStringConverter<Medal>("###", EnumNameSource.Raw, "n/a").Convert(MissingMedal));
+
+        [Test]
+        public void Convert_NonFlags_InspectorName_ReadsTheAttribute() =>
+            Assert.AreEqual("In progress", new EnumFlagsToStringConverter<Quest>("###", EnumNameSource.InspectorName).Convert(Quest.Active));
+
+        // -------------------------------------------------------------------------------------------
+        // EnumFlagsToStringConverter — the cache
+        // -------------------------------------------------------------------------------------------
+
+        // A binder pushes on every notification rather than on every change, so a summary rebuilt per
+        // push would allocate a string per push. Same value in, same instance out.
+        [Test]
+        public void Convert_SameValueTwice_ReturnsTheSameStringInstance()
+        {
+            var converter = new EnumFlagsToStringConverter<Hazard>();
+
+            Assert.AreSame(converter.Convert(FireAndIce), converter.Convert(FireAndIce));
+        }
+
+        // Only the last value is remembered. A cache keyed on anything less than the value would hand
+        // the third push the text built for the first.
+        [Test]
+        public void Convert_AlternatingBetweenTwoValues_AnswersForTheValueItWasGiven()
+        {
+            var converter = new EnumFlagsToStringConverter<Hazard>();
+
+            Assert.AreEqual("Fire", converter.Convert(Hazard.Fire));
+            Assert.AreEqual("Fire, Ice", converter.Convert(FireAndIce));
+            Assert.AreEqual("Fire", converter.Convert(Hazard.Fire));
+        }
+
+        // -------------------------------------------------------------------------------------------
+        // EnumMaskConverter — a [Flags] enum
+        // -------------------------------------------------------------------------------------------
+
+        [TestCase(EnumMaskOperation.And, Hazard.Fire)]
+        [TestCase(EnumMaskOperation.Or, EveryHazard)]
+        [TestCase(EnumMaskOperation.Xor, IceAndShock)]
+        [TestCase(EnumMaskOperation.Clear, Hazard.Ice)]
+        public void MaskConvert_Flags_AppliesTheOperation(EnumMaskOperation operation, Hazard expected) =>
+            Assert.AreEqual(expected, new EnumMaskConverter<Hazard>(FireAndShock, operation).Convert(FireAndIce));
+
+        // The empty mask is what an unauthored converter carries, and And is its default operation —
+        // so a converter dropped on a binder and left alone blanks the value it is given. This is the
+        // behaviour the non-[Flags] passthrough below exists to avoid.
+        [Test]
+        public void MaskConvert_DefaultConstructed_AndsWithAnEmptyMaskAndBlanksTheValue() =>
+            Assert.AreEqual(Hazard.None, new EnumMaskConverter<Hazard>().Convert(FireAndIce));
+
+        // A combination is a legal value the member list does not hold, so the result is not checked
+        // against it — including when the value carries a bit no member declares.
+        [Test]
+        public void MaskConvert_Flags_ResultNeedNotBeADeclaredMember()
+        {
+            Assert.AreEqual(FireAndIce, new EnumMaskConverter<Hazard>(Hazard.Ice, EnumMaskOperation.Or).Convert(Hazard.Fire));
+            Assert.AreEqual(FireAndUnnamedBit, new EnumMaskConverter<Hazard>(Hazard.Fire, EnumMaskOperation.Or).Convert(UnnamedBit));
+        }
+
+        [Test]
+        public void MaskConvert_Flags_UndeclaredOperation_Throws() =>
+            Assert.Throws<ArgumentOutOfRangeException>(() =>
+                new EnumMaskConverter<Hazard>(Hazard.Fire, (EnumMaskOperation)99).Convert(FireAndIce));
+
+        // -------------------------------------------------------------------------------------------
+        // EnumMaskConverter — an enum that is not [Flags]
+        // -------------------------------------------------------------------------------------------
+
+        [TestCase(EnumMaskOperation.And)]
+        [TestCase(EnumMaskOperation.Or)]
+        [TestCase(EnumMaskOperation.Xor)]
+        [TestCase(EnumMaskOperation.Clear)]
+        public void MaskConvert_NonFlags_PassesTheValueThroughUnchanged(EnumMaskOperation operation) =>
+            Assert.AreEqual(Medal.Silver, new EnumMaskConverter<Medal>(Medal.Bronze, operation).Convert(Medal.Silver));
+
+        // Both masks reduce Silver's 20 to 0 when read as bits, which would hand the View Medal.None —
+        // a medal the player does not have, indistinguishable from the real thing.
+        [TestCase(EnumMaskOperation.And, Medal.None)]     // 20 & 0 == 0
+        [TestCase(EnumMaskOperation.Clear, Medal.Silver)] // 20 & ~20 == 0
+        public void MaskConvert_NonFlags_MaskThatWouldBlankTheValue_LeavesItAlone(EnumMaskOperation operation, Medal mask) =>
+            Assert.AreEqual(Medal.Silver, new EnumMaskConverter<Medal>(mask, operation).Convert(Medal.Silver));
+
+        // 20 against 10 gives 30 under both operations, and no medal holds 30 — a value every switch
+        // in the game would fall through.
+        [TestCase(EnumMaskOperation.Or)]  // 20 | 10 == 30
+        [TestCase(EnumMaskOperation.Xor)] // 20 ^ 10 == 30
+        public void MaskConvert_NonFlags_MaskThatWouldProduceAnUndeclaredNumber_LeavesItAlone(EnumMaskOperation operation) =>
+            Assert.AreEqual(Medal.Silver, new EnumMaskConverter<Medal>(Medal.Bronze, operation).Convert(Medal.Silver));
+
+        [Test]
+        public void MaskConvert_NonFlags_UndeclaredValue_PassesThroughUnchanged() =>
+            Assert.AreEqual(MissingMedal, new EnumMaskConverter<Medal>(Medal.Bronze).Convert(MissingMedal));
+
+        // Documented as "thrown when the operation is not a declared value". The passthrough happens
+        // before the switch, so the same broken operation that throws on Hazard is never read here.
+        [Test]
+        public void MaskConvert_NonFlags_UndeclaredOperation_DoesNotThrow() =>
+            Assert.AreEqual(Medal.Silver, new EnumMaskConverter<Medal>(Medal.Bronze, (EnumMaskOperation)99).Convert(Medal.Silver));
+
+        // -------------------------------------------------------------------------------------------
+        // EnumMaskConverter — a signed enum holding the sign bit
+        // -------------------------------------------------------------------------------------------
+
+        // Muted reads as 0xFFFF_FFFF_FFFF_FF80, so every route below leaves bits set above the sbyte
+        // the enum is backed by. Building the result truncates to that width, the same way an
+        // assignment in code would; without the truncation none of these are a member at all.
+        [TestCase(EnumMaskOperation.And, Channel.Muted)]
+        [TestCase(EnumMaskOperation.Clear, Channel.Left)]
+        [TestCase(EnumMaskOperation.Xor, Channel.Left)]
+        public void MaskConvert_SignedEnumHoldingTheSignBit_TruncatesToTheEnumsWidth(EnumMaskOperation operation, Channel mask) =>
+            Assert.AreEqual(Channel.Muted, new EnumMaskConverter<Channel>(mask, operation).Convert(LeftAndMuted));
+
+        [Test]
+        public void MaskConvert_SignedEnumHoldingTheSignBit_Or_KeepsBothMembers() =>
+            Assert.AreEqual(LeftAndMuted, new EnumMaskConverter<Channel>(Channel.Muted, EnumMaskOperation.Or).Convert(Channel.Left));
+
+        [Test]
+        public void Convert_SignedEnumHoldingTheSignBit_NamesBothMembers() =>
+            Assert.AreEqual("Left, Muted", new EnumFlagsToStringConverter<Channel>().Convert(LeftAndMuted));
+
+        // -------------------------------------------------------------------------------------------
+        // EnumMaskConverter — the cache and the chain
+        // -------------------------------------------------------------------------------------------
+
+        // The result is cached because an enum has no non-boxing route back from its bits. Only the
+        // last input is remembered, so the third call has to be answered from scratch.
+        [Test]
+        public void MaskConvert_AlternatingBetweenTwoValues_AnswersForTheValueItWasGiven()
+        {
+            var converter = new EnumMaskConverter<Hazard>(FireAndIce, EnumMaskOperation.And);
+
+            Assert.AreEqual(Hazard.Fire, converter.Convert(FireAndShock));
+            Assert.AreEqual(Hazard.Ice, converter.Convert(IceAndShock));
+            Assert.AreEqual(Hazard.Fire, converter.Convert(FireAndShock));
+        }
+
+        // What the mask is for: one panel names the elemental part of a value another panel names in
+        // full, off the same property, with the choice authored beside the panel it belongs to.
+        [Test]
+        public void MaskConvert_ChainedIntoTheStringConverter_NarrowsWhatTheTextNames()
+        {
+            var mask = new EnumMaskConverter<Hazard>(FireAndIce, EnumMaskOperation.And);
+            var text = new EnumFlagsToStringConverter<Hazard>();
+
+            Assert.AreEqual("Fire, Ice", text.Convert(mask.Convert(EveryHazard)));
+            Assert.AreEqual("Fire, Ice, Shock", text.Convert(EveryHazard));
+        }
+
+        private static EnumFlagsToStringConverter<Hazard> Hazards(string noneText) =>
+            new(", ", EnumNameSource.Name, noneText);
+
+        private static EnumFlagsToStringConverter<Permission> Permissions() =>
+            new(", ", EnumNameSource.Name, "Nothing");
+
+        private static EnumFlagsToStringConverter<Medal> Medals() =>
+            new("###", EnumNameSource.Name, "n/a");
+    }
+}

--- a/Aspid.MVVM/Packages/tech.aspid.mvvm/Tests/Editor/Converters/Enums/EnumFlagsConverterTests.cs.meta
+++ b/Aspid.MVVM/Packages/tech.aspid.mvvm/Tests/Editor/Converters/Enums/EnumFlagsConverterTests.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: c85fe75f76c6f498791319ed3f941776

--- a/Aspid.MVVM/Packages/tech.aspid.mvvm/Tests/Editor/Converters/Enums/Permission.cs
+++ b/Aspid.MVVM/Packages/tech.aspid.mvvm/Tests/Editor/Converters/Enums/Permission.cs
@@ -1,0 +1,14 @@
+using System;
+
+namespace Aspid.MVVM.StarterKit.Tests
+{
+    // A composite over two bits neither of which is a member of its own, so nothing can consume them
+    // before the composite is reached.
+    [Flags]
+    internal enum Permission
+    {
+        None = 0,
+        ReadWrite = 3,
+        Execute = 4,
+    }
+}

--- a/Aspid.MVVM/Packages/tech.aspid.mvvm/Tests/Editor/Converters/Enums/Permission.cs.meta
+++ b/Aspid.MVVM/Packages/tech.aspid.mvvm/Tests/Editor/Converters/Enums/Permission.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: bd02af8618b4f76dbd52adda39b9b280

--- a/Aspid.MVVM/Packages/tech.aspid.mvvm/Tests/Editor/Converters/Enums/Signal.cs
+++ b/Aspid.MVVM/Packages/tech.aspid.mvvm/Tests/Editor/Converters/Enums/Signal.cs
@@ -1,0 +1,14 @@
+using System;
+
+namespace Aspid.MVVM.StarterKit.Tests
+{
+    // A composite over one declared bit and one undeclared one: the declared part is consumed first
+    // and the composite never matches what is left.
+    [Flags]
+    internal enum Signal
+    {
+        None = 0,
+        Ping = 1,
+        PingAndPong = 3,
+    }
+}

--- a/Aspid.MVVM/Packages/tech.aspid.mvvm/Tests/Editor/Converters/Enums/Signal.cs.meta
+++ b/Aspid.MVVM/Packages/tech.aspid.mvvm/Tests/Editor/Converters/Enums/Signal.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: babe7d9b1f4629af5a7719759cb5729a

--- a/Aspid.MVVM/Packages/tech.aspid.mvvm/Tests/Editor/Converters/Enums/Status.cs
+++ b/Aspid.MVVM/Packages/tech.aspid.mvvm/Tests/Editor/Converters/Enums/Status.cs
@@ -1,0 +1,21 @@
+using System;
+using UnityEngine;
+using NUnit.Framework;
+
+namespace Aspid.MVVM.StarterKit.Tests
+{
+    [Flags]
+    internal enum Status
+    {
+        None = 0,
+
+        [InspectorName("On fire")]
+        Burning = 1,
+
+        // A Description and no InspectorName, so the two sources have to part ways on this member.
+        [System.ComponentModel.Description("Losing health slowly")]
+        Poisoned = 2,
+
+        Frozen = 4,
+    }
+}

--- a/Aspid.MVVM/Packages/tech.aspid.mvvm/Tests/Editor/Converters/Enums/Status.cs.meta
+++ b/Aspid.MVVM/Packages/tech.aspid.mvvm/Tests/Editor/Converters/Enums/Status.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 90ca0f4e9f2e6f39acd47e31f03a7b50

--- a/Aspid.MVVM/Packages/tech.aspid.mvvm/Tests/Editor/Converters/Rotations.meta
+++ b/Aspid.MVVM/Packages/tech.aspid.mvvm/Tests/Editor/Converters/Rotations.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 00b920ccb44c24e64a27276404af64a6
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Aspid.MVVM/Packages/tech.aspid.mvvm/Tests/Editor/Converters/Rotations/RotationAdditionsTests.cs
+++ b/Aspid.MVVM/Packages/tech.aspid.mvvm/Tests/Editor/Converters/Rotations/RotationAdditionsTests.cs
@@ -1,0 +1,511 @@
+using System;
+using UnityEngine;
+using NUnit.Framework;
+
+namespace Aspid.MVVM.StarterKit.Tests
+{
+    /// <summary>
+    /// Coverage for the members added to <c>RotationConverters.cs</c> in the latest catalogue wave —
+    /// <see cref="RotationAxis.Custom"/> on <see cref="AngleToQuaternionConverter"/> in both
+    /// directions, <see cref="QuaternionToAngleConverter"/>, <see cref="AngleDifferenceConverter"/>,
+    /// <see cref="RadiansToDegreesConverter"/>, <see cref="QuaternionSlerpConverter"/> and the
+    /// <see cref="QuaternionToVector4Converter"/>/<see cref="Vector4ToQuaternionConverter"/> pair.
+    /// </summary>
+    /// <remarks>
+    /// The mistakes guarded against here are the ones a rotation converter makes silently: an angle
+    /// that reads 358° when it moved two degrees the other way, a mirror-image converter that was
+    /// copy-pasted the wrong way round and multiplies by 0.0175 where it should multiply by 57.3, a
+    /// quaternion rebuilt from four numbers that were never unit length and so scales and shears
+    /// whatever it lands on, and a custom axis whose sign is taken from the wrong end.
+    /// <para>
+    /// The expectations were taken by working the arithmetic through, not from the XML docs, and two
+    /// of them contradict what those docs promise. <c>CustomAngle</c> — shared verbatim by
+    /// <see cref="AngleToQuaternionConverter"/> and <see cref="QuaternionToAngleConverter"/> — does
+    /// not project onto the custom axis at all: it returns the whole turn <c>ToAngleAxis</c> reports
+    /// and only borrows a sign from the dot, so a rotation about a perpendicular axis reads as its
+    /// full angle rather than as zero. And <see cref="QuaternionSlerpConverter"/> always takes the
+    /// short arc, so a gauge authored to sweep from 0° to 350° runs ten degrees backwards instead of
+    /// most of the way round. Each such test pins the behaviour and says so where it stands, so a
+    /// later fix has to change the test deliberately.
+    /// </para>
+    /// <para>
+    /// One outright defect is pinned rather than fixed, because fixing it belongs to the source and
+    /// not to a test: <see cref="AngleToQuaternionConverter"/> negates for <c>clockwise</c> after
+    /// reading <c>eulerAngles</c>, which Unity reports in 0..360, so a clockwise round trip of 30°
+    /// comes back as -330 — the right rotation named by a number a whole turn away from the one that
+    /// went in. The Custom branch escapes it because it reads a signed angle to begin with.
+    /// </para>
+    /// <para>
+    /// Two serialized fields have no constructor parameter and no setter —
+    /// <c>QuaternionSlerpConverter._clamp</c> and <c>QuaternionToAngleConverter._customAxis</c> — so
+    /// the unclamped slerp branch and a custom axis other than up are only reachable through the
+    /// Inspector and are not covered here.
+    /// </para>
+    /// </remarks>
+    [TestFixture]
+    internal sealed class RotationAdditionsTests
+    {
+        #region AngleToQuaternionConverter — RotationAxis.Custom, forward
+
+        // Quaternion.AngleAxis normalises the axis itself, so an axis nobody bothered to normalise
+        // must produce the same rotation as the unit one — not a longer turn and not a scaled
+        // quaternion. The 0.001 row is the same claim at the other end of the scale.
+        [TestCase(0f, 1f, 0f)]
+        [TestCase(0f, 5f, 0f)]
+        [TestCase(0f, 0.001f, 0f)]
+        public void AngleToQuaternion_Custom_NormalisesTheAuthoredAxis(float x, float y, float z) =>
+            AssertSameRotation(
+                Quaternion.Euler(0f, 90f, 0f),
+                new AngleToQuaternionConverter(new Vector3(x, y, z)).Convert(90f),
+                $"90° about ({x}, {y}, {z})");
+
+        // An axis nobody filled in is the ordinary way to reach this branch, and the identity comes
+        // back as the literal Quaternion.identity, so an exact comparison is the right one here.
+        [Test]
+        public void AngleToQuaternion_Custom_ZeroAxis_IsTheIdentity() =>
+            Assert.AreEqual(Quaternion.identity, new AngleToQuaternionConverter(Vector3.zero).Convert(90f));
+
+        // The offset is added after the clockwise flip, so an input of 0 lands on the offset itself
+        // and the flip never touches it. An implementation that negated the sum would answer -30°.
+        [Test]
+        public void AngleToQuaternion_Custom_Clockwise_LeavesTheOffsetUnflipped() =>
+            AssertSameRotation(
+                Quaternion.Euler(0f, 30f, 0f),
+                new AngleToQuaternionConverter(Vector3.up, offset: 30f, clockwise: true).Convert(0f),
+                "an input of zero with a 30° offset");
+
+        [Test]
+        public void AngleToQuaternion_Custom_Clockwise_TurnsTheOtherWay() =>
+            AssertSameRotation(
+                Quaternion.Euler(0f, -90f, 0f),
+                new AngleToQuaternionConverter(Vector3.up, clockwise: true).Convert(90f),
+                "90° clockwise about up");
+
+        #endregion
+
+        #region AngleToQuaternionConverter — RotationAxis.Custom, back
+
+        // ToAngleAxis always reports a positive turn and flips the axis when that is what it takes,
+        // so the same rotation is describable two ways and the converter has to pick the one the
+        // author asked for. Negative angles are the rows that fail if the dot test is dropped.
+        [TestCase(0f)]
+        [TestCase(45f)]
+        [TestCase(90f)]
+        [TestCase(-45f)]
+        [TestCase(-90f)]
+        [TestCase(179f)]
+        public void AngleToQuaternion_Custom_RoundTrips(float angle)
+        {
+            var converter = new AngleToQuaternionConverter(new Vector3(1f, 1f, 0f));
+
+            Assert.AreEqual(angle, converter.ConvertBack(converter.Convert(angle)), 1e-2f);
+        }
+
+        [TestCase(45f)]
+        [TestCase(-90f)]
+        public void AngleToQuaternion_Custom_RoundTripsThroughOffsetAndClockwise(float angle)
+        {
+            var converter = new AngleToQuaternionConverter(Vector3.up, offset: 30f, clockwise: true);
+
+            Assert.AreEqual(angle, converter.ConvertBack(converter.Convert(angle)), 1e-2f);
+        }
+
+        // A rotation built about the opposite axis is the case the dot test exists for: ToAngleAxis
+        // hands back +90° about down, and only the sign flip turns that into the -90° the author of
+        // an up axis meant.
+        [Test]
+        public void AngleToQuaternion_Custom_RotationAboutTheOppositeAxis_ReadsBackNegative() =>
+            Assert.AreEqual(
+                -90f,
+                new AngleToQuaternionConverter(Vector3.up).ConvertBack(Quaternion.AngleAxis(90f, Vector3.down)),
+                1e-2f);
+
+        // Contradicts the summary "reads the angle back off a rotation" for a chosen axis: nothing
+        // is projected onto the axis. A rotation entirely about Z, which carries no turn about the
+        // authored up axis at all, reads as its full 90° because the dot is zero and zero is not
+        // negative. The right answer for an axis reading would be 0.
+        [Test]
+        public void AngleToQuaternion_Custom_PerpendicularRotation_ReportsTheWholeTurnNotZero() =>
+            Assert.AreEqual(
+                90f,
+                new AngleToQuaternionConverter(Vector3.up).ConvertBack(Quaternion.Euler(0f, 0f, 90f)),
+                1e-2f);
+
+        // The Custom branch is signed where the Euler branches are not: it reads ToAngleAxis and
+        // keeps the sign, while X/Y/Z read eulerAngles, which Unity reports in 0..360. The same
+        // rotation therefore reads -30 through a custom Z axis and 330 through RotationAxis.Z — the
+        // two answers differ by a whole turn, and a ViewModel bound through the wrong one of them
+        // sees a value it never wrote.
+        [Test]
+        public void AngleToQuaternion_Custom_ConvertBackIsSignedWhereTheEulerAxesAreNot()
+        {
+            var rotation = Quaternion.Euler(0f, 0f, -30f);
+
+            Assert.AreEqual(-30f, new AngleToQuaternionConverter(Vector3.forward).ConvertBack(rotation), 1e-2f);
+            Assert.AreEqual(330f, new AngleToQuaternionConverter(RotationAxis.Z).ConvertBack(rotation), 1e-2f);
+        }
+
+        // A TwoWay binding whose axis was never filled in does not report "no angle": Convert throws
+        // the value away and ConvertBack answers the offset with the clockwise flip applied to it,
+        // so the ViewModel is written a constant that looks like a real reading.
+        [TestCase(false, -30f)]
+        [TestCase(true, 30f)]
+        public void AngleToQuaternion_Custom_ZeroAxis_ConvertBackReportsTheOffsetAlone(bool clockwise, float expected) =>
+            Assert.AreEqual(
+                expected,
+                new AngleToQuaternionConverter(Vector3.zero, offset: 30f, clockwise: clockwise)
+                    .ConvertBack(Quaternion.Euler(0f, 90f, 0f)),
+                1e-4f);
+
+        [Test]
+        public void AngleToQuaternion_UndeclaredAxis_Throws() =>
+            Assert.Throws<ArgumentOutOfRangeException>(
+                () => new AngleToQuaternionConverter((RotationAxis)99).Convert(45f));
+
+        #endregion
+
+        #region QuaternionToAngleConverter
+
+        // The Euler branches read one component of eulerAngles, which Unity reports in 0..360, and
+        // the converter folds that into ±180. The 350° rows are the ones that matter: a needle a
+        // degree below zero has to read -10, not 350. The last row is the contrast with the custom
+        // branch below — a turn about a different axis reads as zero here.
+        [TestCase(RotationAxis.X, 30f, 0f, 0f, 30f)]
+        [TestCase(RotationAxis.Y, 0f, 30f, 0f, 30f)]
+        [TestCase(RotationAxis.Z, 0f, 0f, 30f, 30f)]
+        [TestCase(RotationAxis.X, 350f, 0f, 0f, -10f)]
+        [TestCase(RotationAxis.Z, 0f, 0f, 350f, -10f)]
+        [TestCase(RotationAxis.X, 0f, 0f, 90f, 0f)]
+        public void QuaternionToAngle_ReadsTheChosenAxisAsSigned180(
+            RotationAxis axis,
+            float x,
+            float y,
+            float z,
+            float expected) =>
+            Assert.AreEqual(expected, new QuaternionToAngleConverter(axis).Convert(Quaternion.Euler(x, y, z)), 1e-2f);
+
+        [TestCase(0f, 0f, 350f, 350f)]
+        [TestCase(0f, 0f, -10f, 350f)]
+        [TestCase(0f, 0f, 10f, 10f)]
+        public void QuaternionToAngle_Unsigned_ReportsZeroToThreeSixty(float x, float y, float z, float expected) =>
+            Assert.AreEqual(
+                expected,
+                new QuaternionToAngleConverter(RotationAxis.Z, signed: false).Convert(Quaternion.Euler(x, y, z)),
+                1e-2f);
+
+        // No constructor reaches _customAxis, so Custom reads around the serialized default of up.
+        // The negative row is where this converter differs from AngleToQuaternionConverter's
+        // ConvertBack: the raw -90 from ToAngleAxis is folded through Mathf.Repeat into 270 first,
+        // and only the signed flag brings it back to -90.
+        [TestCase(90f, true, 90f)]
+        [TestCase(-90f, true, -90f)]
+        [TestCase(90f, false, 90f)]
+        [TestCase(-90f, false, 270f)]
+        public void QuaternionToAngle_Custom_ReadsAroundTheDefaultUpAxis(float angle, bool signed, float expected) =>
+            Assert.AreEqual(
+                expected,
+                new QuaternionToAngleConverter(RotationAxis.Custom, signed)
+                    .Convert(Quaternion.AngleAxis(angle, Vector3.up)),
+                1e-2f);
+
+        // The same divergence from the docs as on AngleToQuaternionConverter, and worth pinning on
+        // both because the two copies of CustomAngle can drift apart: a rotation about Z carries no
+        // turn about up, and the converter reports its full 90° anyway.
+        [Test]
+        public void QuaternionToAngle_Custom_PerpendicularRotation_ReportsTheWholeTurnNotZero() =>
+            Assert.AreEqual(
+                90f,
+                new QuaternionToAngleConverter(RotationAxis.Custom).Convert(Quaternion.Euler(0f, 0f, 90f)),
+                1e-2f);
+
+        // The class remarks promise this: it is not AngleToQuaternionConverter's ConvertBack under
+        // another name. It carries no offset to undo, so the two disagree by exactly the offset —
+        // the trap for anyone who puts this converter on the OneWay leg of a pair.
+        [Test]
+        public void QuaternionToAngle_DoesNotUndoAnAngleToQuaternionOffset()
+        {
+            var source = new AngleToQuaternionConverter(RotationAxis.Z, offset: 30f);
+            var rotation = source.Convert(0f);
+
+            Assert.AreEqual(0f, source.ConvertBack(rotation), 1e-2f);
+            Assert.AreEqual(30f, new QuaternionToAngleConverter().Convert(rotation), 1e-2f);
+        }
+
+        // The other flag, and the more alarming half. AngleToQuaternionConverter reads the Euler
+        // axes off eulerAngles, which Unity reports in 0..360, so a clockwise 30° comes back as
+        // -(330) = -330 rather than the 30 that went in: the round trip is off by a whole turn, and
+        // only for clockwise, because the negation is applied after the 0..360 reading rather than
+        // before. This converter folds to ±180 first and answers the -30 the rotation actually is.
+        [Test]
+        public void QuaternionToAngle_ReadsClockwiseWhereAngleToQuaternionOvershootsByAFullTurn()
+        {
+            var source = new AngleToQuaternionConverter(RotationAxis.Z, clockwise: true);
+            var rotation = source.Convert(30f);
+
+            Assert.AreEqual(-330f, source.ConvertBack(rotation), 1e-2f);
+            Assert.AreEqual(-30f, new QuaternionToAngleConverter().Convert(rotation), 1e-2f);
+        }
+
+        [Test]
+        public void QuaternionToAngle_UndeclaredAxis_Throws() =>
+            Assert.Throws<ArgumentOutOfRangeException>(
+                () => new QuaternionToAngleConverter((RotationAxis)99).Convert(Quaternion.identity));
+
+        #endregion
+
+        #region AngleDifferenceConverter
+
+        // The whole reason the converter is not a subtraction. Rows 2 and 3 straddle zero, where the
+        // plain difference reads ±340 for what is twenty degrees the other way.
+        [TestCase(0f, 10f, 10f)]
+        [TestCase(350f, 10f, 20f)]
+        [TestCase(10f, 350f, -20f)]
+        [TestCase(-170f, 170f, -20f)]
+        [TestCase(170f, -170f, 20f)]
+        // A full turn is no difference at all, however many times it was taken.
+        [TestCase(0f, 360f, 0f)]
+        [TestCase(0f, 720f, 0f)]
+        [TestCase(45f, -315f, 0f)]
+        public void AngleDifference_Signed_TakesTheShortWayRound(float reference, float value, float expected) =>
+            Assert.AreEqual(expected, new AngleDifferenceConverter(reference).Convert(value), 1e-3f);
+
+        // The wrap across 180, where the sign changes hands. Exactly half a turn is reported as
+        // +180 and not -180 — Mathf.DeltaAngle's fold is `> 180`, not `>=` — and a half turn taken
+        // the other way (-180) folds onto that same +180. One degree past the boundary in either
+        // direction is where the answer jumps the full 358° to the opposite sign.
+        [TestCase(0f, 180f, 180f)]
+        [TestCase(0f, -180f, 180f)]
+        [TestCase(0f, 179f, 179f)]
+        [TestCase(0f, 181f, -179f)]
+        [TestCase(0f, -181f, 179f)]
+        [TestCase(90f, 270f, 180f)]
+        [TestCase(90f, 271f, -179f)]
+        [TestCase(90f, 269f, 179f)]
+        public void AngleDifference_Signed_HalfATurnStaysPositiveAndFlipsOneDegreeLater(
+            float reference,
+            float value,
+            float expected) =>
+            Assert.AreEqual(expected, new AngleDifferenceConverter(reference).Convert(value), 1e-3f);
+
+        // Unsigned is the magnitude of the signed answer, so the ±179 pair collapses onto one number
+        // and the half turn survives as 180 — the largest value this converter can ever report.
+        [TestCase(0f, 181f, 179f)]
+        [TestCase(0f, -181f, 179f)]
+        [TestCase(0f, 180f, 180f)]
+        [TestCase(0f, 190f, 170f)]
+        [TestCase(10f, 350f, 20f)]
+        [TestCase(350f, 10f, 20f)]
+        public void AngleDifference_Unsigned_ReportsHowFarOffWhicheverWay(float reference, float value, float expected) =>
+            Assert.AreEqual(expected, new AngleDifferenceConverter(reference, signed: false).Convert(value), 1e-3f);
+
+        [TestCase(45f, 45f)]
+        [TestCase(-45f, -45f)]
+        [TestCase(350f, -10f)]
+        public void AngleDifference_DefaultConstructed_MeasuresFromZero(float value, float expected) =>
+            Assert.AreEqual(expected, new AngleDifferenceConverter().Convert(value), 1e-3f);
+
+        #endregion
+
+        #region RadiansToDegreesConverter
+
+        // The trap this converter exists to fall into: it is the mirror of DegreesToRadiansConverter
+        // and a copy-paste that kept the old body would answer 0.0175 here instead of 57.3. The
+        // numbers are large enough that the two directions cannot be confused.
+        [TestCase(0f, 0f)]
+        [TestCase(1f, 57.29578f)]
+        [TestCase(3.1415927f, 180f)]
+        [TestCase(0.7853982f, 45f)]
+        [TestCase(-1.5707964f, -90f)]
+        public void RadiansToDegrees_Convert_TurnsRadiansIntoDegrees(float value, float expected) =>
+            Assert.AreEqual(expected, new RadiansToDegreesConverter().Convert(value), 1e-3f);
+
+        [TestCase(0f, 0f)]
+        [TestCase(180f, 3.1415927f)]
+        [TestCase(90f, 1.5707964f)]
+        [TestCase(-45f, -0.7853982f)]
+        public void RadiansToDegrees_ConvertBack_TurnsDegreesIntoRadians(float value, float expected) =>
+            Assert.AreEqual(expected, new RadiansToDegreesConverter().ConvertBack(value), 1e-6f);
+
+        // Same statement from the other side, and the one that would catch a class wired up as an
+        // alias of the converter it mirrors: the two must cross, not agree.
+        [TestCase(1f)]
+        [TestCase(90f)]
+        [TestCase(-2.5f)]
+        public void RadiansToDegrees_IsDegreesToRadiansTheOtherWayRound(float value)
+        {
+            var radiansToDegrees = new RadiansToDegreesConverter();
+            var degreesToRadians = new DegreesToRadiansConverter();
+
+            Assert.AreEqual(degreesToRadians.ConvertBack(value), radiansToDegrees.Convert(value), 1e-6f);
+            Assert.AreEqual(degreesToRadians.Convert(value), radiansToDegrees.ConvertBack(value), 1e-6f);
+        }
+
+        [TestCase(0f)]
+        [TestCase(1f)]
+        [TestCase(-6.2831855f)]
+        public void RadiansToDegrees_RoundTrips(float value)
+        {
+            var converter = new RadiansToDegreesConverter();
+
+            Assert.AreEqual(value, converter.ConvertBack(converter.Convert(value)), 1e-5f);
+        }
+
+        #endregion
+
+        #region QuaternionSlerpConverter
+
+        [TestCase(0f, 0f)]
+        [TestCase(0.5f, 45f)]
+        [TestCase(1f, 90f)]
+        public void QuaternionSlerp_ReadsTheRotationAtTheAmount(float amount, float expectedZ) =>
+            AssertSameRotation(Quaternion.Euler(0f, 0f, expectedZ), Slerp().Convert(amount), $"an amount of {amount}");
+
+        // The clamp is on and cannot be turned off from code. An unclamped slerp would answer 180°
+        // for an amount of 2 and -90° for -1, so these two rows are what tells the branches apart.
+        [TestCase(2f, 90f)]
+        [TestCase(-1f, 0f)]
+        public void QuaternionSlerp_HoldsTheAmountInsideZeroToOne(float amount, float expectedZ) =>
+            AssertSameRotation(Quaternion.Euler(0f, 0f, expectedZ), Slerp().Convert(amount), $"an amount of {amount}");
+
+        // The curve is consulted before the turn, so a constant curve pins the rotation wherever it
+        // says regardless of the incoming amount — and a constant beyond the range is still clamped.
+        [TestCase(1f, 0f, 90f)]
+        [TestCase(0f, 1f, 0f)]
+        [TestCase(0.5f, 0f, 45f)]
+        [TestCase(2f, 0f, 90f)]
+        [TestCase(-1f, 1f, 0f)]
+        public void QuaternionSlerp_Curve_ShapesTheAmountBeforeTheTurn(float constant, float amount, float expectedZ) =>
+            AssertSameRotation(
+                Quaternion.Euler(0f, 0f, expectedZ),
+                Slerp(AnimationCurve.Constant(0f, 1f, constant)).Convert(amount),
+                $"a curve constant at {constant} evaluated at {amount}");
+
+        [Test]
+        public void QuaternionSlerp_LinearCurve_LeavesTheAmountAlone() =>
+            AssertSameRotation(
+                Quaternion.Euler(0f, 0f, 45f),
+                Slerp(AnimationCurve.Linear(0f, 0f, 1f, 1f)).Convert(0.5f),
+                "a linear curve at the halfway amount");
+
+        // An unassigned curve deserializes as an empty one rather than as null, and Evaluate on an
+        // empty curve returns zero — which would pin the rotation at the starting end for every
+        // amount. Both spellings of "no curve" have to reach the same place, so an amount of 1 has
+        // to land on the far end and not on the near one.
+        [Test]
+        public void QuaternionSlerp_EmptyCurve_IsTreatedAsNoCurve() =>
+            AssertSameRotation(Quaternion.Euler(0f, 0f, 90f), Slerp(new AnimationCurve()).Convert(1f), "an empty curve");
+
+        [Test]
+        public void QuaternionSlerp_NullCurve_IsTreatedAsNoCurve() =>
+            AssertSameRotation(Quaternion.Euler(0f, 0f, 90f), Slerp(null).Convert(1f), "a null curve");
+
+        // Contradicts what "a gauge that sweeps between two stops" leads an author to expect: slerp
+        // takes the short arc, so a dial authored 0° → 350° travels ten degrees backwards and its
+        // midpoint is 355°, not the 175° that sweeping the long way round would give.
+        [Test]
+        public void QuaternionSlerp_TakesTheShortArcEvenWhenTheEndsSayOtherwise()
+        {
+            var converter = new QuaternionSlerpConverter(Vector3.zero, new Vector3(0f, 0f, 350f));
+
+            AssertSameRotation(Quaternion.Euler(0f, 0f, 355f), converter.Convert(0.5f), "the midpoint of 0°→350°");
+        }
+
+        [TestCase(0f)]
+        [TestCase(0.5f)]
+        [TestCase(1f)]
+        public void QuaternionSlerp_DefaultConstructed_TurnsNowhere(float amount) =>
+            AssertSameRotation(
+                Quaternion.identity,
+                new QuaternionSlerpConverter().Convert(amount),
+                $"an amount of {amount}");
+
+        #endregion
+
+        #region QuaternionToVector4Converter / Vector4ToQuaternionConverter
+
+        // Four distinct numbers, none of them a rotation: the order has to be x, y, z, w and nothing
+        // may be normalised on the way out. A w-first copy, or a normalising one, fails every row.
+        [Test]
+        public void QuaternionToVector4_CopiesTheFourNumbersInOrderWithoutNormalising()
+        {
+            var packed = new QuaternionToVector4Converter().Convert(new Quaternion(0.1f, 0.2f, 0.3f, 0.4f));
+
+            Assert.AreEqual(0.1f, packed.x, 1e-6f);
+            Assert.AreEqual(0.2f, packed.y, 1e-6f);
+            Assert.AreEqual(0.3f, packed.z, 1e-6f);
+            Assert.AreEqual(0.4f, packed.w, 1e-6f);
+            Assert.AreEqual(0.3f, packed.sqrMagnitude, 1e-6f);
+        }
+
+        // Numbers off a lerp, a text field or a lossy wire format are rarely unit length. Both rows
+        // describe the same 90° turn about Z at different scales, and normalising is what makes them
+        // agree; without it the second would scale whatever it multiplies by three.
+        [TestCase(0f, 0f, 0.5f, 0.5f)]
+        [TestCase(0f, 0f, 3f, 3f)]
+        public void Vector4ToQuaternion_NormalisesByDefault(float x, float y, float z, float w)
+        {
+            var rotation = new Vector4ToQuaternionConverter().Convert(new Vector4(x, y, z, w));
+
+            Assert.AreEqual(0.70710678f, rotation.z, 1e-5f);
+            Assert.AreEqual(0.70710678f, rotation.w, 1e-5f);
+            Assert.AreEqual(90f, rotation.eulerAngles.z, 1e-2f);
+        }
+
+        [Test]
+        public void Vector4ToQuaternion_WithoutNormalising_KeepsTheRawNumbers()
+        {
+            var rotation = new Vector4ToQuaternionConverter(normalize: false).Convert(new Vector4(0f, 0f, 0.5f, 0.5f));
+
+            Assert.AreEqual(0.5f, rotation.z, 1e-6f);
+            Assert.AreEqual(0.5f, rotation.w, 1e-6f);
+        }
+
+        [Test]
+        public void Vector4ToQuaternion_ZeroWhileNormalising_IsTheIdentity() =>
+            Assert.AreEqual(Quaternion.identity, new Vector4ToQuaternionConverter().Convert(Vector4.zero));
+
+        // The guard belongs to the normalising path only. With the flag cleared, four zeroes come
+        // through as a zero quaternion — not the identity — and a zero quaternion collapses whatever
+        // it multiplies instead of leaving it alone.
+        [Test]
+        public void Vector4ToQuaternion_ZeroWithoutNormalising_IsADegenerateRotation()
+        {
+            var rotation = new Vector4ToQuaternionConverter(normalize: false).Convert(Vector4.zero);
+
+            Assert.AreEqual(0f, rotation.w, 1e-6f);
+            Assert.AreNotEqual(Quaternion.identity, rotation);
+        }
+
+        // The pair is meant to be a round trip for a save record or a network packet, so a unit
+        // rotation has to survive it component for component — the sign of each number included,
+        // which a rotation-space comparison would hide.
+        [Test]
+        public void QuaternionAndVector4_RoundTripAUnitRotation()
+        {
+            var rotation = Quaternion.Euler(30f, 45f, 60f);
+            var packed = new QuaternionToVector4Converter().Convert(rotation);
+            var restored = new Vector4ToQuaternionConverter().Convert(packed);
+
+            Assert.AreEqual(rotation.x, restored.x, 1e-5f);
+            Assert.AreEqual(rotation.y, restored.y, 1e-5f);
+            Assert.AreEqual(rotation.z, restored.z, 1e-5f);
+            Assert.AreEqual(rotation.w, restored.w, 1e-5f);
+        }
+
+        #endregion
+
+        // Slerps from the identity to a 90° turn about Z, which is the pair every amount in this
+        // fixture is read against.
+        private static QuaternionSlerpConverter Slerp(AnimationCurve curve = null) =>
+            new(Vector3.zero, new Vector3(0f, 0f, 90f), curve);
+
+        // Quaternion.Equals is component-wise and exact, and a quaternion and its negation name the
+        // same rotation, so anything computed is compared by the turn between the two instead.
+        private static void AssertSameRotation(Quaternion expected, Quaternion actual, string what) =>
+            Assert.AreEqual(
+                0f,
+                Quaternion.Angle(expected, actual),
+                1e-2f,
+                $"{what}: expected {expected.eulerAngles}, got {actual.eulerAngles}.");
+    }
+}

--- a/Aspid.MVVM/Packages/tech.aspid.mvvm/Tests/Editor/Converters/Rotations/RotationAdditionsTests.cs
+++ b/Aspid.MVVM/Packages/tech.aspid.mvvm/Tests/Editor/Converters/Rotations/RotationAdditionsTests.cs
@@ -12,34 +12,21 @@ namespace Aspid.MVVM.StarterKit.Tests
     /// <see cref="QuaternionToVector4Converter"/>/<see cref="Vector4ToQuaternionConverter"/> pair.
     /// </summary>
     /// <remarks>
-    /// The mistakes guarded against here are the ones a rotation converter makes silently: an angle
-    /// that reads 358° when it moved two degrees the other way, a mirror-image converter that was
-    /// copy-pasted the wrong way round and multiplies by 0.0175 where it should multiply by 57.3, a
-    /// quaternion rebuilt from four numbers that were never unit length and so scales and shears
-    /// whatever it lands on, and a custom axis whose sign is taken from the wrong end.
+    /// The mistakes guarded against are the ones a rotation converter makes silently: an angle that
+    /// reads 358° when it moved two degrees the other way, a degree/radian factor copy-pasted the wrong
+    /// way round, a quaternion rebuilt from four numbers that were never unit length, a custom axis
+    /// whose sign is taken from the wrong end.
     /// <para>
-    /// The expectations were taken by working the arithmetic through, not from the XML docs, and two
-    /// of them contradict what those docs promise. <c>CustomAngle</c> — shared verbatim by
-    /// <see cref="AngleToQuaternionConverter"/> and <see cref="QuaternionToAngleConverter"/> — does
-    /// not project onto the custom axis at all: it returns the whole turn <c>ToAngleAxis</c> reports
-    /// and only borrows a sign from the dot, so a rotation about a perpendicular axis reads as its
-    /// full angle rather than as zero. And <see cref="QuaternionSlerpConverter"/> always takes the
-    /// short arc, so a gauge authored to sweep from 0° to 350° runs ten degrees backwards instead of
-    /// most of the way round. Each such test pins the behaviour and says so where it stands, so a
-    /// later fix has to change the test deliberately.
+    /// Expectations were worked through by hand, and the tests that contradict the XML docs say so in
+    /// their names: <c>CustomAngle</c> does not project onto the custom axis, and
+    /// <see cref="QuaternionSlerpConverter"/> always takes the short arc. One outright defect is pinned
+    /// rather than fixed, because the fix belongs to the source: a clockwise round trip of 30° through
+    /// <see cref="AngleToQuaternionConverter"/> comes back as -330.
     /// </para>
     /// <para>
-    /// One outright defect is pinned rather than fixed, because fixing it belongs to the source and
-    /// not to a test: <see cref="AngleToQuaternionConverter"/> negates for <c>clockwise</c> after
-    /// reading <c>eulerAngles</c>, which Unity reports in 0..360, so a clockwise round trip of 30°
-    /// comes back as -330 — the right rotation named by a number a whole turn away from the one that
-    /// went in. The Custom branch escapes it because it reads a signed angle to begin with.
-    /// </para>
-    /// <para>
-    /// Two serialized fields have no constructor parameter and no setter —
-    /// <c>QuaternionSlerpConverter._clamp</c> and <c>QuaternionToAngleConverter._customAxis</c> — so
-    /// the unclamped slerp branch and a custom axis other than up are only reachable through the
-    /// Inspector and are not covered here.
+    /// <c>QuaternionSlerpConverter._clamp</c> and <c>QuaternionToAngleConverter._customAxis</c> have no
+    /// constructor parameter and no setter, so those branches are reachable only through the Inspector
+    /// and are not covered here.
     /// </para>
     /// </remarks>
     [TestFixture]

--- a/Aspid.MVVM/Packages/tech.aspid.mvvm/Tests/Editor/Converters/Rotations/RotationAdditionsTests.cs.meta
+++ b/Aspid.MVVM/Packages/tech.aspid.mvvm/Tests/Editor/Converters/Rotations/RotationAdditionsTests.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: cbc2b2d8dbe934bce9a387e1e82446e1

--- a/Aspid.MVVM/Packages/tech.aspid.mvvm/Tests/Editor/Converters/Strings/ParseAdditionsTests.cs
+++ b/Aspid.MVVM/Packages/tech.aspid.mvvm/Tests/Editor/Converters/Strings/ParseAdditionsTests.cs
@@ -16,23 +16,18 @@ namespace Aspid.MVVM.StarterKit.Tests
     /// <see cref="StringToVector3Converter"/> — plus the clamp bounds every numeric parser shares.
     /// </summary>
     /// <remarks>
-    /// The mistakes guarded against here are the ones that only appear on somebody else's machine:
-    /// a decimal separator that collides with the separator between vector components, a fallback
-    /// authored once in the Inspector and then read under a locale that spells numbers differently,
-    /// and a pair of clamp bounds an author can transpose with nothing to validate them.
+    /// The mistakes guarded against are the ones that only appear on somebody else's machine: a decimal
+    /// separator colliding with the separator between vector components, a fallback authored under one
+    /// locale and read under another, a pair of clamp bounds an author can transpose.
     /// <para>
     /// The bounds, the failure mode and the decimal fallback are Inspector state with no constructor
-    /// overload, so they are set through <see cref="With{T}"/> the way the Inspector would set them.
-    /// The thread culture is pinned to invariant for the duration of each test and restored after,
-    /// because every one of these converters resolves its culture at call time.
+    /// overload, so they are set through <see cref="With{T}"/>; the thread culture is pinned to invariant
+    /// per test, because these converters resolve their culture at call time.
     /// </para>
     /// <para>
-    /// Every expectation below was taken from running the implementation rather than from its
-    /// documentation. One contradicts it: the clamp comment repeated across the numeric parsers says
-    /// "a reversed pair reads as the minimum", and it only does so below the minimum — from the
-    /// minimum upward the same pair reads as the maximum, so a transposed pair lets nothing through
-    /// unchanged. <see cref="StringToDouble_ReversedClampBounds_PinInsteadOfThrowing"/> pins both
-    /// halves of that.
+    /// Expectations come from running the implementation. One contradicts the docs: a reversed clamp pair
+    /// reads as the minimum only below the minimum and as the maximum from there up, so it lets nothing
+    /// through unchanged.
     /// </para>
     /// </remarks>
     [TestFixture]

--- a/Aspid.MVVM/Packages/tech.aspid.mvvm/Tests/Editor/Converters/Strings/ParseAdditionsTests.cs
+++ b/Aspid.MVVM/Packages/tech.aspid.mvvm/Tests/Editor/Converters/Strings/ParseAdditionsTests.cs
@@ -1,0 +1,505 @@
+using System;
+using UnityEngine;
+using NUnit.Framework;
+using System.Threading;
+using System.Reflection;
+using System.Globalization;
+using UnityEngine.TestTools;
+using System.Text.RegularExpressions;
+
+namespace Aspid.MVVM.StarterKit.Tests
+{
+    /// <summary>
+    /// Coverage for the parsing converters added after <see cref="ParseConverterTests"/> —
+    /// <see cref="StringToDoubleConverter"/>, <see cref="StringToDecimalConverter"/>,
+    /// <see cref="StringToTimeSpanConverter"/>, <see cref="StringToVector2Converter"/> and
+    /// <see cref="StringToVector3Converter"/> — plus the clamp bounds every numeric parser shares.
+    /// </summary>
+    /// <remarks>
+    /// The mistakes guarded against here are the ones that only appear on somebody else's machine:
+    /// a decimal separator that collides with the separator between vector components, a fallback
+    /// authored once in the Inspector and then read under a locale that spells numbers differently,
+    /// and a pair of clamp bounds an author can transpose with nothing to validate them.
+    /// <para>
+    /// The bounds, the failure mode and the decimal fallback are Inspector state with no constructor
+    /// overload, so they are set through <see cref="With{T}"/> the way the Inspector would set them.
+    /// The thread culture is pinned to invariant for the duration of each test and restored after,
+    /// because every one of these converters resolves its culture at call time.
+    /// </para>
+    /// <para>
+    /// Every expectation below was taken from running the implementation rather than from its
+    /// documentation. One contradicts it: the clamp comment repeated across the numeric parsers says
+    /// "a reversed pair reads as the minimum", and it only does so below the minimum — from the
+    /// minimum upward the same pair reads as the maximum, so a transposed pair lets nothing through
+    /// unchanged. <see cref="StringToDouble_ReversedClampBounds_PinInsteadOfThrowing"/> pins both
+    /// halves of that.
+    /// </para>
+    /// </remarks>
+    [TestFixture]
+    internal sealed class ParseAdditionsTests
+    {
+        private CultureInfo _previous;
+
+        [SetUp]
+        public void UseInvariantCulture()
+        {
+            _previous = Thread.CurrentThread.CurrentCulture;
+            Thread.CurrentThread.CurrentCulture = CultureInfo.InvariantCulture;
+        }
+
+        [TearDown]
+        public void RestoreCulture() =>
+            Thread.CurrentThread.CurrentCulture = _previous;
+
+        #region StringToDoubleConverter — reading, clamping and the failure modes
+
+        // NumberStyles.Float carries AllowExponent and the surrounding whitespace, and the family
+        // adds AllowThousands on top: "1,000.5" is a spelling of a number rather than a mistake.
+        [TestCase("1.5", 1.5d)]
+        [TestCase("-0.25", -0.25d)]
+        [TestCase("1E5", 100000d)]
+        [TestCase("-1.5e-2", -0.015d)]
+        [TestCase("1,000.5", 1000.5d)]
+        [TestCase("  2.5  ", 2.5d)]
+        public void StringToDouble_ReadsTheNumber(string value, double expected) =>
+            Assert.AreEqual(expected, new StringToDoubleConverter().Convert(value), delta: 1e-12);
+
+        // Blank text is an unfilled field rather than a malformed number, so it must not reach the
+        // console — an empty input in a scene would otherwise report on the first push.
+        [TestCase("")]
+        [TestCase("   ")]
+        [TestCase(null)]
+        public void StringToDouble_BlankText_TakesTheFallbackQuietly(string value)
+        {
+            Assert.AreEqual(7.5d, new StringToDoubleConverter(7.5d).Convert(value), delta: 1e-12);
+            LogAssert.NoUnexpectedReceived();
+        }
+
+        [Test]
+        public void StringToDouble_UnreadableText_FallsBackAndReports()
+        {
+            LogAssert.Expect(LogType.Error, new Regex("StringToDoubleConverter"));
+
+            Assert.AreEqual(7.5d, new StringToDoubleConverter(7.5d).Convert("abc"), delta: 1e-12);
+        }
+
+        // A binder pushes on every notification, not on every change, and Debug.LogError captures a
+        // stack trace: a field left holding bad text would cost a trace per push.
+        [Test]
+        public void StringToDouble_UnreadableText_ReportsOncePerInstance()
+        {
+            LogAssert.Expect(LogType.Error, new Regex("StringToDoubleConverter"));
+
+            var converter = new StringToDoubleConverter();
+            converter.Convert("abc");
+            converter.Convert("abc");
+            converter.Convert("still not a number");
+        }
+
+        // 2^24 + 1 is the smallest whole number a float cannot hold; it is the reason the double
+        // converter exists next to the float one, and the reason "id that arrived as text" is in
+        // its remarks.
+        [Test]
+        public void StringToDouble_KeepsAWholeNumberTheFloatSiblingRounds()
+        {
+            Assert.AreEqual(16777217d, new StringToDoubleConverter().Convert("16777217"), delta: 0d);
+            Assert.AreEqual(16777216f, new StringToFloatConverter().Convert("16777217"));
+        }
+
+        [TestCase("42", 10d)]
+        [TestCase("-1", 0d)]
+        [TestCase("5", 5d)]
+        public void StringToDouble_Clamp_HoldsTheResultInsideTheBounds(string value, double expected) =>
+            Assert.AreEqual(
+                expected,
+                Clamped(new StringToDoubleConverter(), 0d, 10d).Convert(value),
+                delta: 1e-12);
+
+        // Math.Clamp throws when max is authored below min, and these are Inspector fields with
+        // nothing to validate them. Note that the source comment ("a reversed pair reads as the
+        // minimum") only holds below min: anything from min upward is pinned to max instead, so a
+        // transposed pair never lets a value through — it snaps to one bound or the other.
+        [TestCase("5", 10d)]
+        [TestCase("0", 10d)]
+        [TestCase("10", 0d)]
+        [TestCase("20", 0d)]
+        public void StringToDouble_ReversedClampBounds_PinInsteadOfThrowing(string value, double expected) =>
+            Assert.AreEqual(
+                expected,
+                Clamped(new StringToDoubleConverter(), 10d, 0d).Convert(value),
+                delta: 1e-12);
+
+        // The clamp sits after the parse, so the fallback is returned raw: a fallback authored
+        // outside the bounds comes out outside them.
+        [Test]
+        public void StringToDouble_Clamp_DoesNotApplyToTheFallback()
+        {
+            LogAssert.Expect(LogType.Error, new Regex("StringToDoubleConverter"));
+
+            Assert.AreEqual(0d, Clamped(new StringToDoubleConverter(), 5d, 10d).Convert("abc"), delta: 1e-12);
+        }
+
+        // NaN fails both comparisons, so clamping does not fence it in — the bounds hold numbers,
+        // not everything a double can be.
+        [Test]
+        public void StringToDouble_Clamp_LetsNaNThrough() =>
+            Assert.IsTrue(double.IsNaN(Clamped(new StringToDoubleConverter(), 0d, 1d).Convert("NaN")));
+
+        // ReturnInput cannot be honoured when the input is text and the output is not; the tooltip
+        // promises it behaves as ReturnFallback.
+        [Test]
+        public void StringToDouble_ReturnInput_BehavesAsReturnFallback()
+        {
+            LogAssert.Expect(LogType.Error, new Regex("StringToDoubleConverter"));
+
+            var converter = With(new StringToDoubleConverter(7.5d), "_onFailure", ConverterFailureMode.ReturnInput);
+
+            Assert.AreEqual(7.5d, converter.Convert("abc"), delta: 1e-12);
+        }
+
+        [Test]
+        public void StringToDouble_Throw_RaisesFormatException()
+        {
+            var converter = With(new StringToDoubleConverter(), "_onFailure", ConverterFailureMode.Throw);
+
+            Assert.Throws<FormatException>(() => converter.Convert("abc"));
+        }
+
+        // Both halves resolve the culture at call time from the same field, so the pair agrees on a
+        // device that writes one and a half as "1,5".
+        [Test]
+        public void StringToDouble_RoundTripsUnderACommaDecimalCulture()
+        {
+            UseGermanDevice();
+            var converter = new StringToDoubleConverter(0d, CultureInfoMode.CurrentCulture);
+
+            var text = converter.ConvertBack(1.5d);
+
+            Assert.AreEqual("1,5", text);
+            Assert.AreEqual(1.5d, converter.Convert(text), delta: 1e-12);
+        }
+
+        #endregion
+
+        #region StringToDecimalConverter — exponents and the invariant fallback
+
+        // AllowExponent on top of Number: a backend that serializes 1E5 would otherwise be readable
+        // by the converter with less precision and not by the exact one.
+        [TestCase("1E5", 100000)]
+        [TestCase("1.5E2", 150)]
+        [TestCase("-2e3", -2000)]
+        public void StringToDecimal_ReadsAnExponent(string value, int expected) =>
+            Assert.AreEqual((decimal)expected, new StringToDecimalConverter().Convert(value));
+
+        [Test]
+        public void StringToDecimal_ReadsAFractionalExponent() =>
+            Assert.AreEqual(0.02m, new StringToDecimalConverter().Convert("2E-2"));
+
+        // NumberStyles.Number carries AllowThousands, so the player-facing read matches the rest of
+        // the family even though the fallback below refuses the same character.
+        [Test]
+        public void StringToDecimal_ReadsGroupedText() =>
+            Assert.AreEqual(1000.5m, new StringToDecimalConverter().Convert("1,000.5"));
+
+        // Eighteen significant digits: the reason to reach for this over the double converter.
+        [Test]
+        public void StringToDecimal_KeepsDigitsADoubleWouldRound() =>
+            Assert.AreEqual(1234567890.12345678m, new StringToDecimalConverter().Convert("1234567890.12345678"));
+
+        // decimal.MaxValue + 1. Out of range is a parse failure like any other rather than an
+        // OverflowException escaping the push.
+        [Test]
+        public void StringToDecimal_OutOfRangeText_FallsBackAndReports()
+        {
+            LogAssert.Expect(LogType.Error, new Regex("StringToDecimalConverter"));
+
+            Assert.AreEqual(
+                decimal.Zero,
+                new StringToDecimalConverter().Convert("79228162514264337593543950336"));
+        }
+
+        // The fallback is authored text read as invariant, where the comma is the GROUP separator:
+        // read with NumberStyles.Number it would come back as fifteen — ten times the value the
+        // author meant, silently, for every player. Float refuses it and says so instead.
+        [Test]
+        public void StringToDecimal_CommaInTheFallback_IsRefusedRatherThanReadAsFifteen()
+        {
+            LogAssert.Expect(LogType.Error, new Regex("StringToDecimalConverter"));
+
+            var converter = With(new StringToDecimalConverter(), "_fallback", "1,5");
+
+            Assert.AreEqual(decimal.Zero, converter.Convert(null));
+        }
+
+        // The fallback is authored once and the player's text is typed every time, so the two are
+        // read with different cultures on purpose: "1.5" in the field, "1,5" from a German player.
+        [Test]
+        public void StringToDecimal_Fallback_IsInvariantWhilePlayerTextIsNot()
+        {
+            UseGermanDevice();
+            var converter = With(new StringToDecimalConverter(), "_fallback", "1.5");
+
+            Assert.AreEqual(1.5m, converter.Convert(null));
+            Assert.AreEqual(1.5m, converter.Convert("1,5"));
+            LogAssert.NoUnexpectedReceived();
+        }
+
+        // The parsed fallback is cached against the string it came from by reference, so a field
+        // edited while the game runs must not keep serving the old reading.
+        [Test]
+        public void StringToDecimal_Fallback_IsRereadWhenTheFieldChanges()
+        {
+            var converter = With(new StringToDecimalConverter(), "_fallback", "1.5");
+            Assert.AreEqual(1.5m, converter.Convert(null));
+
+            With(converter, "_fallback", "2.5");
+            Assert.AreEqual(2.5m, converter.Convert(null));
+        }
+
+        [Test]
+        public void StringToDecimal_Throw_RaisesFormatException()
+        {
+            var converter = With(new StringToDecimalConverter(), "_onFailure", ConverterFailureMode.Throw);
+
+            Assert.Throws<FormatException>(() => converter.Convert("abc"));
+        }
+
+        [Test]
+        public void StringToDecimal_RoundTripsUnderACommaDecimalCulture()
+        {
+            UseGermanDevice();
+            var converter = new StringToDecimalConverter(0m, CultureInfoMode.CurrentCulture);
+
+            var text = converter.ConvertBack(1.5m);
+
+            Assert.AreEqual("1,5", text);
+            Assert.AreEqual(1.5m, converter.Convert(text));
+        }
+
+        #endregion
+
+        #region StringToTimeSpanConverter — the shapes TimeSpan accepts
+
+        [TestCase("00:01:30", 90)]
+        [TestCase("00:00:01", 1)]
+        [TestCase("1:00:00", 3600)]
+        [TestCase("-00:00:30", -30)]
+        public void StringToTimeSpan_ReadsAClockDuration(string value, int seconds) =>
+            Assert.AreEqual(TimeSpan.FromSeconds(seconds), new StringToTimeSpanConverter().Convert(value));
+
+        [Test]
+        public void StringToTimeSpan_ReadsTheInvariantDayForm() =>
+            Assert.AreEqual(new TimeSpan(1, 2, 3, 4), new StringToTimeSpanConverter().Convert("1.02:03:04"));
+
+        // The trap this converter is most often walked into: TimeSpan reads a bare number as DAYS,
+        // so text that counts seconds wants StringToFloat + SecondsToTimeSpan instead.
+        [Test]
+        public void StringToTimeSpan_ABareNumber_IsDaysRatherThanSeconds() =>
+            Assert.AreEqual(TimeSpan.FromDays(90), new StringToTimeSpanConverter().Convert("90"));
+
+        [Test]
+        public void StringToTimeSpan_ExactFormat_ReadsTheShapeItAsksFor() =>
+            Assert.AreEqual(
+                TimeSpan.FromSeconds(90),
+                new StringToTimeSpanConverter("hh\\:mm\\:ss").Convert("00:01:30"));
+
+        // A single-digit hour is a different shape: TryParseExact wants both digits, and the
+        // converter reports rather than quietly accepting the loose reading TryParse would allow.
+        [Test]
+        public void StringToTimeSpan_ExactFormat_RefusesALooserShape()
+        {
+            LogAssert.Expect(LogType.Error, new Regex("StringToTimeSpanConverter"));
+
+            Assert.AreEqual(
+                TimeSpan.FromMinutes(5),
+                new StringToTimeSpanConverter("hh\\:mm\\:ss", TimeSpan.FromMinutes(5)).Convert("0:01:30"));
+        }
+
+        [TestCase("")]
+        [TestCase("   ")]
+        [TestCase(null)]
+        public void StringToTimeSpan_BlankText_TakesTheFallbackQuietly(string value)
+        {
+            Assert.AreEqual(
+                TimeSpan.FromMinutes(5),
+                new StringToTimeSpanConverter(string.Empty, TimeSpan.FromMinutes(5)).Convert(value));
+            LogAssert.NoUnexpectedReceived();
+        }
+
+        [Test]
+        public void StringToTimeSpan_UnreadableText_ReportsOncePerInstance()
+        {
+            LogAssert.Expect(LogType.Error, new Regex("StringToTimeSpanConverter"));
+
+            var converter = new StringToTimeSpanConverter();
+            converter.Convert("soon");
+            converter.Convert("later");
+        }
+
+        [Test]
+        public void StringToTimeSpan_Throw_RaisesFormatException()
+        {
+            var converter = With(new StringToTimeSpanConverter(), "_onFailure", ConverterFailureMode.Throw);
+
+            Assert.Throws<FormatException>(() => converter.Convert("soon"));
+        }
+
+        #endregion
+
+        #region StringToVector2Converter / StringToVector3Converter — the round trip and its cache
+
+        // The collision the two halves have to agree about: a German device writes one and a half
+        // as "1,5", and the separator between the components is a comma too. Written with the
+        // device culture the pair would come out "1,5,2,5", which no split recovers — both halves
+        // step back to the invariant reading so that what ConvertBack writes, Convert reads.
+        [Test]
+        public void StringToVector2_RoundTripsWhenTheCultureCollidesWithTheSeparator()
+        {
+            UseGermanDevice();
+            var converter = new StringToVector2Converter(",", default, CultureInfoMode.CurrentCulture);
+
+            var text = converter.ConvertBack(new Vector2(1.5f, 2.5f));
+
+            Assert.AreEqual("1.5,2.5", text);
+            Assert.AreEqual(new Vector2(1.5f, 2.5f), converter.Convert(text));
+        }
+
+        [Test]
+        public void StringToVector3_RoundTripsWhenTheCultureCollidesWithTheSeparator()
+        {
+            UseGermanDevice();
+            var converter = new StringToVector3Converter(",", default, CultureInfoMode.CurrentCulture);
+
+            var text = converter.ConvertBack(new Vector3(1.5f, 2.5f, 3.5f));
+
+            Assert.AreEqual("1.5,2.5,3.5", text);
+            Assert.AreEqual(new Vector3(1.5f, 2.5f, 3.5f), converter.Convert(text));
+        }
+
+        // The other side of the same branch: with a separator the culture's decimal separator does
+        // not collide with, the chosen culture is kept rather than always forced to invariant.
+        [Test]
+        public void StringToVector2_NonCollidingSeparator_KeepsTheChosenCulture()
+        {
+            UseGermanDevice();
+            var converter = new StringToVector2Converter("; ", default, CultureInfoMode.CurrentCulture);
+
+            var text = converter.ConvertBack(new Vector2(1.5f, 2.5f));
+
+            Assert.AreEqual("1,5; 2,5", text);
+            Assert.AreEqual(new Vector2(1.5f, 2.5f), converter.Convert(text));
+        }
+
+        // Text copied out of a console or a log arrives wrapped, with a space after the comma.
+        [Test]
+        public void StringToVector2_ReadsWhatVectorToStringWrites() =>
+            Assert.AreEqual(new Vector2(1f, 2f), new StringToVector2Converter().Convert("(1.00, 2.00)"));
+
+        [Test]
+        public void StringToVector3_ReadsWhatVectorToStringWrites() =>
+            Assert.AreEqual(new Vector3(1f, 2f, 3f), new StringToVector3Converter().Convert("(1.00, 2.00, 3.00)"));
+
+        // The Inspector can clear the separator field, and the stand-in has to be the same on both
+        // halves: a write that joined with nothing would put "12" on screen for (1, 2).
+        [Test]
+        public void StringToVector2_EmptySeparator_StandsInAComma()
+        {
+            var converter = new StringToVector2Converter(string.Empty);
+
+            var text = converter.ConvertBack(new Vector2(1f, 2f));
+
+            Assert.AreEqual("1,2", text);
+            Assert.AreEqual(new Vector2(1f, 2f), converter.Convert(text));
+        }
+
+        // Thousands are refused inside a component: the group separator and the separator between
+        // components are the same character in most cultures, so accepting both would make "1,5"
+        // a vector in one reading and fifteen thousand in the other.
+        [Test]
+        public void StringToVector2_GroupedComponent_IsRefused()
+        {
+            LogAssert.Expect(LogType.Error, new Regex("StringToVector2Converter"));
+
+            Assert.AreEqual(Vector2.zero, new StringToVector2Converter(";").Convert("1,000;2"));
+        }
+
+        // Three numbers are not a Vector2: the tail is read as one component and refused, rather
+        // than the extra being dropped and a wrong-but-plausible vector pushed on.
+        [Test]
+        public void StringToVector2_ExtraComponent_IsRefused()
+        {
+            LogAssert.Expect(LogType.Error, new Regex("StringToVector2Converter"));
+
+            Assert.AreEqual(Vector2.zero, new StringToVector2Converter().Convert("1,2,3"));
+        }
+
+        [Test]
+        public void StringToVector3_MissingComponent_IsRefused()
+        {
+            LogAssert.Expect(LogType.Error, new Regex("StringToVector3Converter"));
+
+            Assert.AreEqual(Vector3.zero, new StringToVector3Converter().Convert("1,2"));
+        }
+
+        [TestCase("")]
+        [TestCase("   ")]
+        [TestCase(null)]
+        public void StringToVector2_BlankText_TakesTheFallbackQuietly(string value)
+        {
+            Assert.AreEqual(
+                new Vector2(9f, 9f),
+                new StringToVector2Converter(",", new Vector2(9f, 9f)).Convert(value));
+            LogAssert.NoUnexpectedReceived();
+        }
+
+        // The last reading is cached because splitting allocates on every push. The separator is
+        // part of the key: it is editable while the game runs, and a hit that ignored it would
+        // freeze the old reading in.
+        [Test]
+        public void StringToVector2_CachedReading_IsDroppedWhenTheSeparatorChanges()
+        {
+            var converter = new StringToVector2Converter();
+            Assert.AreEqual(new Vector2(1f, 2f), converter.Convert("1,2"));
+
+            With(converter, "_separator", ";");
+            LogAssert.Expect(LogType.Error, new Regex("StringToVector2Converter"));
+
+            Assert.AreEqual(Vector2.zero, converter.Convert("1,2"));
+        }
+
+        [Test]
+        public void StringToVector2_Throw_RaisesFormatException()
+        {
+            var converter = With(new StringToVector2Converter(), "_onFailure", ConverterFailureMode.Throw);
+
+            Assert.Throws<FormatException>(() => converter.Convert("not a vector"));
+        }
+
+        #endregion
+
+        private static void UseGermanDevice() =>
+            Thread.CurrentThread.CurrentCulture = CultureInfo.GetCultureInfo("de-DE");
+
+        // The clamp is three Inspector fields with no constructor overload, and the transposed pair
+        // is the whole point of the test that uses it, so it cannot be authored any other way.
+        private static T Clamped<T>(T converter, object min, object max)
+            where T : class
+        {
+            With(converter, "_clamp", true);
+            With(converter, "_min", min);
+            With(converter, "_max", max);
+
+            return converter;
+        }
+
+        private static T With<T>(T converter, string field, object value)
+            where T : class
+        {
+            var info = converter.GetType().GetField(field, BindingFlags.Instance | BindingFlags.NonPublic);
+            Assert.IsNotNull(info, $"{converter.GetType().Name} has no field {field}");
+
+            info!.SetValue(converter, value);
+            return converter;
+        }
+    }
+}

--- a/Aspid.MVVM/Packages/tech.aspid.mvvm/Tests/Editor/Converters/Strings/ParseAdditionsTests.cs.meta
+++ b/Aspid.MVVM/Packages/tech.aspid.mvvm/Tests/Editor/Converters/Strings/ParseAdditionsTests.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 4ccebff4436ad4c00b7f44d928b64380

--- a/Aspid.MVVM/Packages/tech.aspid.mvvm/Tests/Editor/Converters/Textures.meta
+++ b/Aspid.MVVM/Packages/tech.aspid.mvvm/Tests/Editor/Converters/Textures.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 87a0c9c9f182a410c910881cd03b44f4
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Aspid.MVVM/Packages/tech.aspid.mvvm/Tests/Editor/Converters/Textures/TextureAdditionsTests.cs
+++ b/Aspid.MVVM/Packages/tech.aspid.mvvm/Tests/Editor/Converters/Textures/TextureAdditionsTests.cs
@@ -14,13 +14,11 @@ namespace Aspid.MVVM.StarterKit.Tests
     /// <see cref="Vector2CombineConverter"/>.
     /// </summary>
     /// <remarks>
-    /// The mistakes here all look the same from the Inspector and only differ once something is
-    /// running: a lookup that is quietly wrong for a key nobody typed the way the map spells it, a
-    /// diagnostic that fires per push instead of per converter, and an emptiness check written as
-    /// <c>is null</c> — which sees a managed reference that outlived its native object, so a
-    /// destroyed texture reaches <see cref="Texture.width"/> and throws. Every expectation below was
-    /// taken from the code rather than from the XML docs; where the two disagree the code is what is
-    /// pinned, and the comment on the case says so.
+    /// The mistakes here all look the same from the Inspector and differ only once something is running:
+    /// a lookup quietly wrong for a key nobody typed the way the map spells it, a diagnostic firing per
+    /// push instead of per converter, and an emptiness check written as <c>is null</c> — which sees a
+    /// managed reference that outlived its native object, so a destroyed texture throws. Where code and
+    /// XML docs disagree the code is what is pinned, and the comment on the case says so.
     /// </remarks>
     [TestFixture]
     internal sealed class TextureAdditionsTests

--- a/Aspid.MVVM/Packages/tech.aspid.mvvm/Tests/Editor/Converters/Textures/TextureAdditionsTests.cs
+++ b/Aspid.MVVM/Packages/tech.aspid.mvvm/Tests/Editor/Converters/Textures/TextureAdditionsTests.cs
@@ -1,0 +1,321 @@
+using System;
+using UnityEngine;
+using NUnit.Framework;
+using UnityEngine.TestTools;
+using System.Collections.Generic;
+using System.Text.RegularExpressions;
+
+namespace Aspid.MVVM.StarterKit.Tests
+{
+    /// <summary>
+    /// Coverage for the texture converters the catalogue-wide fixture leaves alone —
+    /// <see cref="StringToSpriteConverter"/> and <see cref="TextureToSpriteRectConverter"/> — plus
+    /// the missing-target degrade of the 2D combine converters built on
+    /// <see cref="Vector2CombineConverter"/>.
+    /// </summary>
+    /// <remarks>
+    /// The mistakes here all look the same from the Inspector and only differ once something is
+    /// running: a lookup that is quietly wrong for a key nobody typed the way the map spells it, a
+    /// diagnostic that fires per push instead of per converter, and an emptiness check written as
+    /// <c>is null</c> — which sees a managed reference that outlived its native object, so a
+    /// destroyed texture reaches <see cref="Texture.width"/> and throws. Every expectation below was
+    /// taken from the code rather than from the XML docs; where the two disagree the code is what is
+    /// pinned, and the comment on the case says so.
+    /// </remarks>
+    [TestFixture]
+    internal sealed class TextureAdditionsTests
+    {
+        private const string MissedKey = "missing_key";
+        private const string MappedKey = "sword_iron";
+
+        private readonly List<UnityEngine.Object> _created = new();
+
+        [TearDown]
+        public void DestroyCreatedObjects()
+        {
+            // Unity's implicit bool is false for the ones a test destroyed on purpose, and for a
+            // sprite whose texture went first.
+            foreach (var created in _created)
+            {
+                if (created) UnityEngine.Object.DestroyImmediate(created);
+            }
+
+            _created.Clear();
+        }
+
+        [Test]
+        public void StringToSprite_KeyInTheMap_ReturnsThatSprite()
+        {
+            var icon = NewSprite();
+            var converter = new StringToSpriteConverter(new[] { Entry(MappedKey, icon) }, NewSprite());
+
+            Assert.AreSame(icon, converter.Convert(MappedKey));
+        }
+
+        // The scan is linear and returns on the first match, so a map that names the same key twice
+        // resolves to whichever entry is higher in the array rather than to the last word.
+        [Test]
+        public void StringToSprite_DuplicateKeys_TakesTheFirstEntry()
+        {
+            var first = NewSprite();
+            var second = NewSprite();
+            var converter = new StringToSpriteConverter(new[] { Entry(MappedKey, first), Entry(MappedKey, second) });
+
+            Assert.AreSame(first, converter.Convert(MappedKey));
+        }
+
+        [Test]
+        public void StringToSprite_IgnoreCase_MatchesADifferentlyCasedKey()
+        {
+            var icon = NewSprite();
+            var converter = new StringToSpriteConverter(new[] { Entry(MappedKey, icon) }, NewSprite(), ignoreCase: true);
+
+            Assert.AreSame(icon, converter.Convert(MappedKey.ToUpperInvariant()));
+        }
+
+        // The half that keeps the option honest: with it off the comparison is Ordinal, so a backend
+        // that shouts its ids is a miss and not a silent match.
+        [Test]
+        public void StringToSprite_CaseSensitiveByDefault_TreatsADifferentCaseAsAMiss()
+        {
+            LogAssert.Expect(LogType.Error, new Regex("no sprite is mapped to \"SWORD_IRON\""));
+
+            var fallback = NewSprite();
+            var converter = new StringToSpriteConverter(new[] { Entry(MappedKey, NewSprite()) }, fallback);
+
+            Assert.AreSame(fallback, converter.Convert(MappedKey.ToUpperInvariant()));
+        }
+
+        // A converter sits inside a binder's value push, so a key the map never held would otherwise
+        // call Debug.LogError on every notification — each one paying for a stack trace.
+        [Test]
+        public void StringToSprite_RepeatedMiss_ReportsOnce()
+        {
+            LogAssert.Expect(LogType.Error, new Regex("no sprite is mapped"));
+
+            var fallback = NewSprite();
+            var converter = new StringToSpriteConverter(null, fallback);
+
+            Assert.AreSame(fallback, converter.Convert("a"));
+            Assert.AreSame(fallback, converter.Convert("b"));
+            Assert.AreSame(fallback, converter.Convert("c"));
+        }
+
+        // ...and the flag is per instance, not per type. A static one would silence every other
+        // converter in the project after the first bad key anywhere.
+        [Test]
+        public void StringToSprite_SecondInstance_ReportsItsOwnMiss()
+        {
+            LogAssert.Expect(LogType.Error, new Regex("no sprite is mapped"));
+            LogAssert.Expect(LogType.Error, new Regex("no sprite is mapped"));
+
+            new StringToSpriteConverter(null).Convert(MissedKey);
+            new StringToSpriteConverter(null).Convert(MissedKey);
+        }
+
+        // A ViewModel with nothing selected pushes an empty id, which is a state and not a mistake.
+        // No LogAssert.Expect here on purpose: an error would fail the test, and that is the
+        // assertion — silence cannot be asserted any other way.
+        [TestCase((string)null)]
+        [TestCase("")]
+        public void StringToSprite_BlankKey_ReturnsTheFallbackWithoutReporting(string key)
+        {
+            var fallback = NewSprite();
+            var converter = new StringToSpriteConverter(new[] { Entry(MappedKey, NewSprite()) }, fallback);
+
+            Assert.AreSame(fallback, converter.Convert(key));
+        }
+
+        // The blank test is IsNullOrEmpty and not IsNullOrWhiteSpace, so a key that is only spaces —
+        // a trimmed-off id, a stray cell in an imported table — is a reported failure. Both paths
+        // return the fallback, so the log is the only thing that tells them apart.
+        [Test]
+        public void StringToSprite_WhitespaceKey_IsReportedAsAMissRatherThanTreatedAsBlank()
+        {
+            LogAssert.Expect(LogType.Error, new Regex("no sprite is mapped"));
+
+            var fallback = NewSprite();
+
+            Assert.AreSame(fallback, new StringToSpriteConverter(null, fallback).Convert(" "));
+        }
+
+        // "Leave it empty to map a key to nothing" is a hit, not a failure: it returns null instead
+        // of falling through to the fallback, which is how a map hides an icon for one id.
+        [Test]
+        public void StringToSprite_KeyMappedToNothing_ReturnsNullRatherThanTheFallback()
+        {
+            var converter = new StringToSpriteConverter(new[] { Entry("hidden", null) }, NewSprite());
+
+            Assert.IsNull(converter.Convert("hidden"));
+        }
+
+        // Undocumented and invisible in the Inspector: an entry authored with an empty key can never
+        // be reached, because the blank-input test returns the fallback before the scan begins.
+        [Test]
+        public void StringToSprite_EntryWithAnEmptyKey_IsUnreachable()
+        {
+            var mapped = NewSprite();
+            var fallback = NewSprite();
+            var converter = new StringToSpriteConverter(new[] { Entry(string.Empty, mapped) }, fallback);
+
+            Assert.AreSame(fallback, converter.Convert(string.Empty));
+        }
+
+        [Test]
+        public void TextureToSpriteRect_Texture_MeasuresTheWholePixelRect() =>
+            Assert.AreEqual(new Rect(0f, 0f, 8f, 4f), new TextureToSpriteRectConverter().Convert(NewTexture(8, 4)));
+
+        [Test]
+        public void TextureToSpriteRect_Null_ReturnsZero() =>
+            Assert.AreEqual(Rect.zero, new TextureToSpriteRectConverter().Convert(null));
+
+        // The case the null check exists for. An asset unloaded under a bound RawImage leaves a live
+        // managed reference behind, so `is null` and `??` both wave it through and the width read
+        // throws inside the binder's push. Only Unity's overloaded == catches it.
+        [Test]
+        public void TextureToSpriteRect_DestroyedTexture_ReturnsZeroRatherThanThrowing()
+        {
+            var texture = NewTexture(8, 4);
+            var converter = new TextureToSpriteRectConverter();
+
+            // While it is alive it has to measure, or the zero below would prove nothing.
+            Assert.AreEqual(new Rect(0f, 0f, 8f, 4f), converter.Convert(texture));
+
+            UnityEngine.Object.DestroyImmediate(texture);
+
+            Assert.AreEqual(Rect.zero, converter.Convert(texture));
+        }
+
+        // Typed on Texture rather than Texture2D so a render target measures the same way — the
+        // reason a RawImage-facing ViewModel can hold the base type.
+        [Test]
+        public void TextureToSpriteRect_RenderTexture_MeasuresTheSameWay()
+        {
+            var texture = new RenderTexture(16, 8, 0);
+            _created.Add(texture);
+
+            Assert.AreEqual(new Rect(0f, 0f, 16f, 8f), new TextureToSpriteRectConverter().Convert(texture));
+        }
+
+        // The docs promise a Texture2D-typed binder still takes it. That holds only while IConverter
+        // keeps its `in` on the input, so this assignment is the real assertion — losing the variance
+        // annotation breaks the compile here rather than in a project's binder.
+        [Test]
+        public void TextureToSpriteRect_AssignedToATexture2DTypedConverter_StillMeasures()
+        {
+            IConverter<Texture2D, Rect> converter = new TextureToSpriteRectConverter();
+
+            Assert.AreEqual(new Rect(0f, 0f, 2f, 2f), converter.Convert(NewTexture(2, 2)));
+        }
+
+        // An unassigned Inspector reference is the normal state of a half-built prefab. Reading the
+        // collider's offset would throw and take every binder queued behind this one down with it.
+        [Test]
+        public void BoxCollider2DOffsetCombine_MissingTarget_ReturnsTheInputRatherThanThrowing()
+        {
+            // Named in full: the message has to say which converter is empty, and GetType().Name is
+            // what makes it the subclass rather than the shared base.
+            LogAssert.Expect(LogType.Error, new Regex("BoxCollider2DOffsetCombineConverter: no target assigned"));
+
+            var value = new Vector2(1f, 2f);
+
+            Assert.AreEqual(value, new BoxCollider2DOffsetCombineConverter().Convert(value));
+        }
+
+        [Test]
+        public void BoxCollider2DOffsetCombine_MissingTarget_ReportsOnce()
+        {
+            LogAssert.Expect(LogType.Error, new Regex("no target assigned"));
+
+            var converter = new BoxCollider2DOffsetCombineConverter();
+            converter.Convert(new Vector2(1f, 2f));
+            converter.Convert(new Vector2(3f, 4f));
+            converter.Convert(new Vector2(5f, 6f));
+        }
+
+        // The Vector3 entry point degrades to the *narrowed* input: z is dropped at the call, so what
+        // comes back is not the value that was pushed.
+        [Test]
+        public void BoxCollider2DOffsetCombine_Vector3_MissingTarget_ReturnsTheInputWithoutItsZ()
+        {
+            LogAssert.Expect(LogType.Error, new Regex("no target assigned"));
+
+            Assert.AreEqual(
+                new Vector2(1f, 2f),
+                new BoxCollider2DOffsetCombineConverter().Convert(new Vector3(1f, 2f, 3f)));
+        }
+
+        // The pair below is what stops the degrade assertion from being vacuous. Every shipped 2D
+        // converter keeps its target in a private [SerializeField] and exposes no mode, so a live
+        // target and a mode other than XY can only come from a stub.
+        [Test]
+        public void Vector2Combine_ModeX_LiveTarget_TakesYFromTheReferenceVector()
+        {
+            var target = NewGameObject(nameof(Vector2Combine_ModeX_LiveTarget_TakesYFromTheReferenceVector));
+            var converter = new CombineStub(target.transform, new Vector2(10f, 20f), Vector2CombineConverter.Mode.X);
+
+            Assert.AreEqual(new Vector2(1f, 20f), converter.Convert(new Vector2(1f, 2f)));
+        }
+
+        // Same mode, no target: the y that a live reference would have supplied stays as it arrived,
+        // so "returns the input" is a genuine degrade and not the identity XY gives for free.
+        [Test]
+        public void Vector2Combine_ModeX_MissingTarget_KeepsTheInputY()
+        {
+            LogAssert.Expect(LogType.Error, new Regex("no target assigned"));
+
+            var converter = new CombineStub(null, new Vector2(10f, 20f), Vector2CombineConverter.Mode.X);
+
+            Assert.AreEqual(new Vector2(1f, 2f), converter.Convert(new Vector2(1f, 2f)));
+        }
+
+        private static SpriteMapEntry Entry(string key, Sprite sprite) =>
+            new() { Key = key, Sprite = sprite };
+
+        private Sprite NewSprite()
+        {
+            var texture = NewTexture(4, 4);
+            var sprite = Sprite.Create(texture, new Rect(0f, 0f, 4f, 4f), new Vector2(0.5f, 0.5f));
+            _created.Add(sprite);
+
+            return sprite;
+        }
+
+        private Texture2D NewTexture(int width, int height)
+        {
+            var texture = new Texture2D(width, height);
+            _created.Add(texture);
+
+            return texture;
+        }
+
+        // Hidden and unsaved so that a failing assertion cannot leave a stray object in the editor scene.
+        private GameObject NewGameObject(string name)
+        {
+            var gameObject = new GameObject(name) { hideFlags = HideFlags.HideAndDontSave };
+            _created.Add(gameObject);
+
+            return gameObject;
+        }
+
+        private sealed class CombineStub : Vector2CombineConverter
+        {
+            private readonly Vector2 _to;
+            private readonly Component _target;
+
+            public CombineStub(Component target, Vector2 to, Mode mode)
+                : base(mode)
+            {
+                _target = target;
+                _to = to;
+            }
+
+            protected override Component Target => _target;
+
+            // Throws when there is no target, so a guard that ran after the read would fail here
+            // instead of passing by accident.
+            protected override Vector2 VectorTo =>
+                _target == null ? throw new NullReferenceException(nameof(VectorTo)) : _to;
+        }
+    }
+}

--- a/Aspid.MVVM/Packages/tech.aspid.mvvm/Tests/Editor/Converters/Textures/TextureAdditionsTests.cs.meta
+++ b/Aspid.MVVM/Packages/tech.aspid.mvvm/Tests/Editor/Converters/Textures/TextureAdditionsTests.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 3691ada9a184543ec91facc3572477d4

--- a/Aspid.MVVM/Packages/tech.aspid.mvvm/Tests/Editor/Converters/Vectors/VectorInteropConverterTests.cs
+++ b/Aspid.MVVM/Packages/tech.aspid.mvvm/Tests/Editor/Converters/Vectors/VectorInteropConverterTests.cs
@@ -1,0 +1,245 @@
+using System;
+using UnityEngine;
+using NUnit.Framework;
+using Comp = Aspid.MVVM.StarterKit.Vector4Component;
+
+namespace Aspid.MVVM.StarterKit.Tests
+{
+    /// <summary>
+    /// Coverage for the interop converters that move numbers between differently shaped structs —
+    /// <see cref="Vector3ToVector4Converter"/>, <see cref="Vector4ToVector3Converter"/>,
+    /// <see cref="Vector4SwizzleConverter"/>, <see cref="Vector4ToRectConverter"/>,
+    /// <see cref="RectToVector4Converter"/>, <see cref="BoundsCenterConverter"/>,
+    /// <see cref="BoundsSizeConverter"/> and <see cref="BoundsToRectConverter"/>.
+    /// </summary>
+    /// <remarks>
+    /// Guards against slot-shuffling mistakes, which are the failure mode this whole file invites:
+    /// a converter that reads the wrong component still returns a value of the right type and never
+    /// throws, so the bug surfaces only as a rectangle in the wrong place or a swapped axis on
+    /// screen. Three particular traps are pinned here — Unity's implicit <see cref="Vector3"/> to
+    /// <see cref="Vector4"/> conversion already zeroes <c>w</c>, so a default-<c>w</c> assertion
+    /// alone cannot tell the converter from doing nothing; <see cref="Rect"/> stores a corner plus a
+    /// size while <see cref="Bounds"/> stores a centre plus extents, so "the same four numbers"
+    /// means different geometry on each side; and neither the rectangle nor the bounding-box
+    /// converters normalise, so an inverted input stays inverted.
+    /// </remarks>
+    [TestFixture]
+    internal sealed class VectorInteropConverterTests
+    {
+        [Test]
+        public void Vector3ToVector4_Convert_WritesTheConfiguredW() =>
+            Assert.AreEqual(
+                new Vector4(1f, 2f, 3f, 9f),
+                new Vector3ToVector4Converter(9f).Convert(new Vector3(1f, 2f, 3f)));
+
+        // Unity's own implicit Vector3 -> Vector4 conversion already zeroes w, so this case would
+        // pass against a converter that did nothing at all. It is the 9f case above that proves the
+        // serialized field is read; this one only pins the default.
+        [Test]
+        public void Vector3ToVector4_DefaultConstructed_WritesZeroW() =>
+            Assert.AreEqual(
+                new Vector4(1f, 2f, 3f, 0f),
+                new Vector3ToVector4Converter().Convert(new Vector3(1f, 2f, 3f)));
+
+        [TestCase(Comp.X, 2f, 3f, 4f)]
+        [TestCase(Comp.Y, 1f, 3f, 4f)]
+        [TestCase(Comp.Z, 1f, 2f, 4f)]
+        [TestCase(Comp.W, 1f, 2f, 3f)]
+        public void Vector4ToVector3_Convert_DropsTheNamedComponentAndKeepsTheRestInOrder(
+            Comp drop,
+            float x,
+            float y,
+            float z) =>
+            Assert.AreEqual(
+                new Vector3(x, y, z),
+                new Vector4ToVector3Converter(drop).Convert(new Vector4(1f, 2f, 3f, 4f)));
+
+        [Test]
+        public void Vector4ToVector3_DefaultConstructed_DropsW() =>
+            Assert.AreEqual(
+                new Vector3(1f, 2f, 3f),
+                new Vector4ToVector3Converter().Convert(new Vector4(1f, 2f, 3f, 4f)));
+
+        // The class is documented as "the way back from Vector3ToVector4Converter", which only holds
+        // for the W drop. Every other choice slides the survivors down a slot, so the padding value
+        // the widening converter added comes back as part of the position.
+        [Test]
+        public void Vector4ToVector3_DroppingAnythingButW_DoesNotUndoTheWidening()
+        {
+            var widened = new Vector3ToVector4Converter(9f).Convert(new Vector3(1f, 2f, 3f));
+
+            Assert.AreEqual(new Vector3(1f, 2f, 3f), new Vector4ToVector3Converter(Comp.W).Convert(widened));
+            Assert.AreEqual(new Vector3(2f, 3f, 9f), new Vector4ToVector3Converter(Comp.X).Convert(widened));
+        }
+
+        // The default branch looks unreachable through the enum, but Unity keeps the raw int when a
+        // serialized enum field outlives the member it named, so a renamed or reordered
+        // Vector4Component lands here at runtime.
+        [Test]
+        public void Vector4ToVector3_UndeclaredComponent_Throws() =>
+            Assert.Throws<ArgumentOutOfRangeException>(
+                () => new Vector4ToVector3Converter((Comp)4).Convert(Vector4.zero));
+
+        [Test]
+        public void Vector4Swizzle_DefaultConstructed_ReordersNothing() =>
+            Assert.AreEqual(
+                new Vector4(1f, 2f, 3f, 4f),
+                new Vector4SwizzleConverter().Convert(new Vector4(1f, 2f, 3f, 4f)));
+
+        // The argument position names the destination slot and the enum value names the source. The
+        // sibling Vector2ToVector3Converter.Mode uses its enum value for the destination axes
+        // instead, so the family is not consistent and this direction is easy to invert by mistake.
+        [TestCase(Comp.X, 1f)]
+        [TestCase(Comp.Y, 2f)]
+        [TestCase(Comp.Z, 3f)]
+        [TestCase(Comp.W, 4f)]
+        public void Vector4Swizzle_FirstArgument_NamesTheSourceOfX(Comp source, float expected) =>
+            Assert.AreEqual(
+                expected,
+                new Vector4SwizzleConverter(source, Comp.Y, Comp.Z, Comp.W)
+                    .Convert(new Vector4(1f, 2f, 3f, 4f)).x,
+                1e-6f);
+
+        [Test]
+        public void Vector4Swizzle_Convert_Reverses() =>
+            Assert.AreEqual(
+                new Vector4(4f, 3f, 2f, 1f),
+                new Vector4SwizzleConverter(Comp.W, Comp.Z, Comp.Y, Comp.X)
+                    .Convert(new Vector4(1f, 2f, 3f, 4f)));
+
+        // Reading one source into every slot is supported on purpose. A fixture that only tested
+        // permutations would not notice a duplicate-rejecting guard being added later.
+        [Test]
+        public void Vector4Swizzle_RepeatedSource_BroadcastsIt() =>
+            Assert.AreEqual(
+                new Vector4(2f, 2f, 2f, 2f),
+                new Vector4SwizzleConverter(Comp.Y, Comp.Y, Comp.Y, Comp.Y)
+                    .Convert(new Vector4(1f, 2f, 3f, 4f)));
+
+        // The undeclared value sits in the last slot, so this fails if only the first slot is
+        // validated rather than every one.
+        [Test]
+        public void Vector4Swizzle_UndeclaredComponentInTheLastSlot_Throws() =>
+            Assert.Throws<ArgumentOutOfRangeException>(
+                () => new Vector4SwizzleConverter(Comp.X, Comp.Y, Comp.Z, (Comp)4).Convert(Vector4.zero));
+
+        // z becomes the width and w the height: the four numbers are a corner plus a size, never a
+        // pair of corners. xMax is asserted because that is the value that would differ had z been
+        // read as the far edge instead.
+        [Test]
+        public void Vector4ToRect_Convert_ReadsXYWidthHeight()
+        {
+            var rect = new Vector4ToRectConverter().Convert(new Vector4(1f, 2f, 3f, 4f));
+
+            Assert.AreEqual(new Rect(1f, 2f, 3f, 4f), rect);
+            Assert.AreEqual(4f, rect.xMax, 1e-6f);
+            Assert.AreEqual(6f, rect.yMax, 1e-6f);
+        }
+
+        [Test]
+        public void RectToVector4_Convert_ReadsXYWidthHeight() =>
+            Assert.AreEqual(
+                new Vector4(1f, 2f, 3f, 4f),
+                new RectToVector4Converter().Convert(new Rect(1f, 2f, 3f, 4f)));
+
+        // MinMaxRect is built from two corners, but the vector carries a size, so the 5 and 6 that
+        // went in come back out as 4 and 4.
+        [Test]
+        public void RectToVector4_MinMaxRect_CarriesTheSizeNotTheFarCorner() =>
+            Assert.AreEqual(
+                new Vector4(1f, 2f, 4f, 4f),
+                new RectToVector4Converter().Convert(Rect.MinMaxRect(1f, 2f, 5f, 6f)));
+
+        [Test]
+        public void Vector4AndRect_RoundTripInBothDirections()
+        {
+            var vector = new Vector4(1f, 2f, 3f, 4f);
+            var rect = new Rect(5f, 6f, 7f, 8f);
+
+            Assert.AreEqual(
+                vector,
+                new RectToVector4Converter().Convert(new Vector4ToRectConverter().Convert(vector)));
+            Assert.AreEqual(
+                rect,
+                new Vector4ToRectConverter().Convert(new RectToVector4Converter().Convert(rect)));
+        }
+
+        // Neither direction normalises, so an inverted rectangle survives intact rather than being
+        // flipped positive — xMax ends up below xMin.
+        [Test]
+        public void Vector4AndRect_NegativeSize_IsNotNormalised()
+        {
+            var rect = new Vector4ToRectConverter().Convert(new Vector4(1f, 2f, -3f, -4f));
+
+            Assert.AreEqual(new Rect(1f, 2f, -3f, -4f), rect);
+            Assert.AreEqual(-2f, rect.xMax, 1e-6f);
+            Assert.AreEqual(new Vector4(1f, 2f, -3f, -4f), new RectToVector4Converter().Convert(rect));
+        }
+
+        // Bounds' second constructor argument is the size, not the extents. Any test box whose size
+        // equalled its extents would hide a converter reading the wrong one of the two.
+        [Test]
+        public void BoundsCenter_Convert_ReadsTheCentre() =>
+            Assert.AreEqual(new Vector3(10f, 20f, 30f), new BoundsCenterConverter().Convert(Box()));
+
+        [Test]
+        public void BoundsSize_DefaultConstructed_ReadsTheFullSize() =>
+            Assert.AreEqual(new Vector3(2f, 4f, 6f), new BoundsSizeConverter().Convert(Box()));
+
+        [Test]
+        public void BoundsSize_Extents_ReadsHalfTheSize() =>
+            Assert.AreEqual(new Vector3(1f, 2f, 3f), new BoundsSizeConverter(extents: true).Convert(Box()));
+
+        // Bounds stores a negative size as negative extents without clamping, and the converter
+        // reports it as it found it.
+        [Test]
+        public void BoundsSize_NegativeSize_StaysNegative() =>
+            Assert.AreEqual(
+                new Vector3(-2f, -2f, -2f),
+                new BoundsSizeConverter().Convert(new Bounds(Vector3.zero, new Vector3(-2f, -2f, -2f))));
+
+        // For XZ and YZ the box's z lands in the rectangle's y, because a Rect has no third axis to
+        // keep it in. The position comes from Bounds.min, not from the centre.
+        [TestCase(BoundsPlane.XY, 9f, 18f, 2f, 4f)]
+        [TestCase(BoundsPlane.XZ, 9f, 27f, 2f, 6f)]
+        [TestCase(BoundsPlane.YZ, 18f, 27f, 4f, 6f)]
+        public void BoundsToRect_Convert_AnchorsAtTheMinCornerOfTheChosenPlane(
+            BoundsPlane plane,
+            float x,
+            float y,
+            float width,
+            float height) =>
+            Assert.AreEqual(new Rect(x, y, width, height), new BoundsToRectConverter(plane).Convert(Box()));
+
+        [Test]
+        public void BoundsToRect_DefaultConstructed_FlattensOntoXY() =>
+            Assert.AreEqual(new Rect(9f, 18f, 2f, 4f), new BoundsToRectConverter().Convert(Box()));
+
+        // Anchoring at the corner is exactly what makes the two centres agree; a rectangle placed at
+        // Bounds.center would sit half a box off, at (11, 22).
+        [Test]
+        public void BoundsToRect_Centre_MatchesTheBoxCentreOnThePlane() =>
+            Assert.AreEqual(
+                new Vector2(10f, 20f),
+                new BoundsToRectConverter(BoundsPlane.XY).Convert(Box()).center);
+
+        // A negative size gives negative extents, which puts Bounds.min above Bounds.max. The
+        // converter passes both through unchanged, so the documented "lower corner" is the upper one
+        // here and the rectangle comes out inverted rather than normalised.
+        [Test]
+        public void BoundsToRect_NegativeSize_AnchorsAboveTheBoxAndStaysInverted() =>
+            Assert.AreEqual(
+                new Rect(1f, 1f, -2f, -2f),
+                new BoundsToRectConverter(BoundsPlane.XY)
+                    .Convert(new Bounds(Vector3.zero, new Vector3(-2f, -2f, -2f))));
+
+        [Test]
+        public void BoundsToRect_UndeclaredPlane_Throws() =>
+            Assert.Throws<ArgumentOutOfRangeException>(
+                () => new BoundsToRectConverter((BoundsPlane)3).Convert(new Bounds()));
+
+        // Centre (10, 20, 30) with size (2, 4, 6) puts min at (9, 18, 27). No two of the nine
+        // numbers a flattening converter could pick up are equal, so a wrong axis cannot pass.
+        private static Bounds Box() => new Bounds(new Vector3(10f, 20f, 30f), new Vector3(2f, 4f, 6f));
+    }
+}

--- a/Aspid.MVVM/Packages/tech.aspid.mvvm/Tests/Editor/Converters/Vectors/VectorInteropConverterTests.cs
+++ b/Aspid.MVVM/Packages/tech.aspid.mvvm/Tests/Editor/Converters/Vectors/VectorInteropConverterTests.cs
@@ -13,15 +13,11 @@ namespace Aspid.MVVM.StarterKit.Tests
     /// <see cref="BoundsSizeConverter"/> and <see cref="BoundsToRectConverter"/>.
     /// </summary>
     /// <remarks>
-    /// Guards against slot-shuffling mistakes, which are the failure mode this whole file invites:
-    /// a converter that reads the wrong component still returns a value of the right type and never
-    /// throws, so the bug surfaces only as a rectangle in the wrong place or a swapped axis on
-    /// screen. Three particular traps are pinned here — Unity's implicit <see cref="Vector3"/> to
-    /// <see cref="Vector4"/> conversion already zeroes <c>w</c>, so a default-<c>w</c> assertion
-    /// alone cannot tell the converter from doing nothing; <see cref="Rect"/> stores a corner plus a
-    /// size while <see cref="Bounds"/> stores a centre plus extents, so "the same four numbers"
-    /// means different geometry on each side; and neither the rectangle nor the bounding-box
-    /// converters normalise, so an inverted input stays inverted.
+    /// A converter that reads the wrong component still returns a value of the right type and never
+    /// throws, so the bug surfaces only as a rectangle in the wrong place. Three traps are pinned here:
+    /// Unity's implicit <see cref="Vector3"/> to <see cref="Vector4"/> conversion already zeroes
+    /// <c>w</c>; <see cref="Rect"/> stores a corner plus a size while <see cref="Bounds"/> stores a
+    /// centre plus extents; and neither converter normalises, so an inverted input stays inverted.
     /// </remarks>
     [TestFixture]
     internal sealed class VectorInteropConverterTests

--- a/Aspid.MVVM/Packages/tech.aspid.mvvm/Tests/Editor/Converters/Vectors/VectorInteropConverterTests.cs.meta
+++ b/Aspid.MVVM/Packages/tech.aspid.mvvm/Tests/Editor/Converters/Vectors/VectorInteropConverterTests.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 9fbb0ee86830b4b519510a2d9c79068a

--- a/Aspid.MVVM/Packages/tech.aspid.mvvm/Tests/Editor/Converters/Vectors/VectorMathAdditionsTests.cs
+++ b/Aspid.MVVM/Packages/tech.aspid.mvvm/Tests/Editor/Converters/Vectors/VectorMathAdditionsTests.cs
@@ -1,0 +1,655 @@
+using System;
+using UnityEngine;
+using NUnit.Framework;
+using UnityEngine.TestTools;
+using System.Collections.Generic;
+
+namespace Aspid.MVVM.StarterKit.Tests
+{
+    /// <summary>
+    /// Coverage for the members added to <c>VectorMathConverters.cs</c> in the vector wave — the
+    /// <see cref="Vector2ToFloatConverter"/> and its <see cref="Vector2Component.Dot"/> reading,
+    /// <see cref="Vector2ArithmeticConverter"/>, the ordered-bounds fix shared by
+    /// <see cref="VectorClampMagnitudeConverter"/> and <see cref="Vector2ClampMagnitudeConverter"/>,
+    /// the component clamps, the round pair, the normalise pair,
+    /// <see cref="VectorDistanceConverter"/> and the curve on <see cref="VectorLerpConverter"/>.
+    /// </summary>
+    /// <remarks>
+    /// The class of mistake guarded here is a converter that silently stops honouring its own
+    /// contract on input an Inspector can legitimately produce: a min/max pair typed the wrong way
+    /// round, so a clamp breaks both of its bounds at once; a negative ceiling, so a length clamp
+    /// turns the vector around; a negative grid step, so Floor rounds up; a direction that was never
+    /// normalised, so a dot product silently scales its reading; a target Transform destroyed
+    /// mid-session, so a distance either throws or measures to a corpse.
+    /// <para>
+    /// Every expectation below was taken from the arithmetic the source actually performs, not from
+    /// the XML docs, and three of them contradict what a reader would assume. <c>Mathf.Round</c> is
+    /// banker's rounding, so an exact half goes to the even neighbour rather than away from zero.
+    /// Unity's <c>normalized</c> has a length floor of 1e-5, so a very short vector answers zero
+    /// rather than a unit vector. And <see cref="VectorLerpConverter"/>'s "hold the incoming amount
+    /// inside 0..1" is done by <c>Vector3.Lerp</c> on the amount the curve produced — the incoming
+    /// value itself is never clamped. Each such test pins the behaviour and says so where it stands.
+    /// </para>
+    /// </remarks>
+    [TestFixture]
+    internal sealed class VectorMathAdditionsTests
+    {
+        private static readonly Vector3 From = new(2f, 0f, 0f);
+        private static readonly Vector3 To = new(12f, 0f, 0f);
+
+        private readonly List<GameObject> _created = new();
+
+        [TearDown]
+        public void DestroyCreatedObjects()
+        {
+            // Unity's implicit bool is false for the one the destroyed-target test already removed.
+            foreach (var gameObject in _created)
+            {
+                if (gameObject) UnityEngine.Object.DestroyImmediate(gameObject);
+            }
+
+            _created.Clear();
+        }
+
+        #region Vector2ToFloatConverter and the Dot component
+
+        [TestCase(Vector2Component.X, 3f)]
+        [TestCase(Vector2Component.Y, 4f)]
+        [TestCase(Vector2Component.Magnitude, 5f)]
+        [TestCase(Vector2Component.SqrMagnitude, 25f)]
+        // Dot reached through the component-only ctor leaves the direction at its default, which is
+        // up rather than right — so the reading is the y, and a converter that defaulted to right
+        // would answer 3 here.
+        [TestCase(Vector2Component.Dot, 4f)]
+        public void Vector2ToFloat_Measures(Vector2Component component, float expected) =>
+            Assert.AreEqual(expected, new Vector2ToFloatConverter(component).Convert(new Vector2(3f, 4f)), 1e-4f);
+
+        [Test]
+        public void Vector2ToFloat_DefaultConstructed_MeasuresLength() =>
+            Assert.AreEqual(5f, new Vector2ToFloatConverter().Convert(new Vector2(3f, 4f)), 1e-4f);
+
+        // The direction is used raw, not normalised: a direction of unit length reads as the signed
+        // distance along it, one twice as long doubles that reading, and an unset one reads zero for
+        // every input. The negative row is the one that proves the reading is signed rather than a
+        // distance.
+        [TestCase(1f, 0f, 3f)]
+        [TestCase(0f, 1f, 4f)]
+        [TestCase(-1f, 0f, -3f)]
+        [TestCase(0f, 2f, 8f)]
+        [TestCase(0f, 0f, 0f)]
+        public void Vector2ToFloat_Dot_IsTheRawProductWithTheAuthoredDirection(float x, float y, float expected) =>
+            Assert.AreEqual(
+                expected,
+                new Vector2ToFloatConverter(new Vector2(x, y)).Convert(new Vector2(3f, 4f)),
+                1e-4f);
+
+        // Passing a direction is the only way to select Dot without also naming the component, so the
+        // ctor has to set the component itself — otherwise the converter still measures length and
+        // the authored direction is never read.
+        [Test]
+        public void Vector2ToFloat_DirectionCtor_SelectsDotWithoutBeingTold() =>
+            Assert.AreEqual(3f, new Vector2ToFloatConverter(Vector2.right).Convert(new Vector2(3f, 4f)), 1e-4f);
+
+        [TestCase(0f, 1f, 0f, 4f)]
+        [TestCase(0f, 0f, 2f, 10f)]
+        [TestCase(-1f, 0f, 0f, -3f)]
+        public void Vector3ToFloat_Dot_IsTheRawProductWithTheAuthoredDirection(
+            float x,
+            float y,
+            float z,
+            float expected) =>
+            Assert.AreEqual(
+                expected,
+                new Vector3ToFloatConverter(new Vector3(x, y, z)).Convert(new Vector3(3f, 4f, 5f)),
+                1e-4f);
+
+        [Test]
+        public void Vector3ToFloat_Dot_DefaultDirectionIsUp() =>
+            Assert.AreEqual(4f, new Vector3ToFloatConverter(VectorComponent.Dot).Convert(new Vector3(3f, 4f, 5f)), 1e-4f);
+
+        // Declaration order is the number Unity stores in the scene, so Dot had to be appended rather
+        // than filed next to the axes it belongs with. Filing it after Z would repoint every field
+        // already authored as Magnitude or SqrMagnitude, silently, on load.
+        [TestCase(VectorComponent.X, 0)]
+        [TestCase(VectorComponent.Y, 1)]
+        [TestCase(VectorComponent.Z, 2)]
+        [TestCase(VectorComponent.Magnitude, 3)]
+        [TestCase(VectorComponent.SqrMagnitude, 4)]
+        [TestCase(VectorComponent.Dot, 5)]
+        public void VectorComponent_StoredValue_KeepsDotAppendedLast(VectorComponent component, int stored) =>
+            Assert.AreEqual(stored, (int)component);
+
+        [TestCase(Vector2Component.X, 0)]
+        [TestCase(Vector2Component.Y, 1)]
+        [TestCase(Vector2Component.Magnitude, 2)]
+        [TestCase(Vector2Component.SqrMagnitude, 3)]
+        [TestCase(Vector2Component.Dot, 4)]
+        public void Vector2Component_StoredValue_HasNoZAxisToSkip(Vector2Component component, int stored) =>
+            Assert.AreEqual(stored, (int)component);
+
+        [Test]
+        public void Vector2ToFloat_UndeclaredComponent_Throws() =>
+            Assert.Throws<ArgumentOutOfRangeException>(
+                () => new Vector2ToFloatConverter((Vector2Component)99).Convert(Vector2.one));
+
+        #endregion
+
+        #region Vector2ArithmeticConverter
+
+        [TestCase(VectorOperation.Add, 11f, 22f)]
+        [TestCase(VectorOperation.Subtract, -9f, -18f)]
+        [TestCase(VectorOperation.Scale, 10f, 40f)]
+        [TestCase(VectorOperation.Divide, 0.1f, 0.1f)]
+        public void Vector2Arithmetic_AppliesTheOperation(VectorOperation operation, float x, float y) =>
+            AssertClose(
+                new Vector2(x, y),
+                new Vector2ArithmeticConverter(operation, new Vector2(10f, 20f)).Convert(new Vector2(1f, 2f)));
+
+        // What a freshly added [SerializeReference] entry does before anything is typed into it: Add
+        // with a zero operand, which has to be an identity rather than a collapse to zero.
+        [Test]
+        public void Vector2Arithmetic_DefaultConstructed_LeavesTheVectorAlone() =>
+            AssertClose(new Vector2(1f, 2f), new Vector2ArithmeticConverter().Convert(new Vector2(1f, 2f)));
+
+        // Matches the Vector3 converter: a zero axis in the operand leaves that axis alone instead of
+        // handing a binder an infinity. The x is in the case to prove the division still happens on
+        // the axis that can take one.
+        [Test]
+        public void Vector2Arithmetic_DivideByAZeroAxis_LeavesThatAxisAlone() =>
+            AssertClose(
+                new Vector2(0.5f, 2f),
+                new Vector2ArithmeticConverter(VectorOperation.Divide, new Vector2(2f, 0f)).Convert(new Vector2(1f, 2f)));
+
+        // The zero guard is `== 0f`, so an ordinary negative divisor is not caught by it and the sign
+        // travels through the division as arithmetic says it should.
+        [Test]
+        public void Vector2Arithmetic_DivideByANegativeAxis_KeepsTheSignChange() =>
+            AssertClose(
+                new Vector2(-0.5f, -0.5f),
+                new Vector2ArithmeticConverter(VectorOperation.Divide, new Vector2(-2f, -4f))
+                    .Convert(new Vector2(1f, 2f)));
+
+        // The bounce a wall gives: the part along the normal is inverted, the part along the wall is
+        // kept. A Reflect implemented as a plain negation would answer (-1, 1) here.
+        [Test]
+        public void Vector2Arithmetic_Reflect_BouncesOffTheOperandAsANormal() =>
+            AssertClose(
+                new Vector2(1f, 1f),
+                new Vector2ArithmeticConverter(VectorOperation.Reflect, Vector2.up).Convert(new Vector2(1f, -1f)));
+
+        // Vector2.Reflect does not normalise its normal, and neither does the converter, so a normal
+        // authored twice as long as unit quadruples the part it reflects. Typing (0, 2) into the
+        // operand field does not mean "up" — it means "up, four times over".
+        [Test]
+        public void Vector2Arithmetic_Reflect_DoesNotNormaliseTheOperand() =>
+            AssertClose(
+                new Vector2(1f, 7f),
+                new Vector2ArithmeticConverter(VectorOperation.Reflect, new Vector2(0f, 2f))
+                    .Convert(new Vector2(1f, -1f)));
+
+        // An unset operand is a zero normal, whose reflection factor is zero, so the value walks
+        // through unchanged — the opposite of what Scale does with the same unset operand.
+        [Test]
+        public void Vector2Arithmetic_Reflect_ZeroOperand_ReturnsTheInput() =>
+            AssertClose(
+                new Vector2(1f, -1f),
+                new Vector2ArithmeticConverter(VectorOperation.Reflect, Vector2.zero).Convert(new Vector2(1f, -1f)));
+
+        [Test]
+        public void Vector2Arithmetic_Scale_ZeroOperand_CollapsesTheVector() =>
+            AssertClose(
+                Vector2.zero,
+                new Vector2ArithmeticConverter(VectorOperation.Scale, Vector2.zero).Convert(new Vector2(1f, -1f)));
+
+        [Test]
+        public void Vector2Arithmetic_UndeclaredOperation_Throws() =>
+            Assert.Throws<ArgumentOutOfRangeException>(
+                () => new Vector2ArithmeticConverter((VectorOperation)99, Vector2.one).Convert(Vector2.one));
+
+        #endregion
+
+        #region ClampMagnitude — reversed bounds and a negative ceiling
+
+        // The shared scale, which both magnitude clamps route through. Note the argument order is
+        // (magnitude, min, max) here while the constructors take (max, min) — the rows name the
+        // bounds so the two orders cannot be confused.
+        //
+        // Ordinary pairs first: too long is pulled back to the ceiling, too short is pushed out to
+        // the floor, and anything between them is left alone.
+        [TestCase(10f, 0f, 1f, 0.1f)]
+        [TestCase(0.5f, 2f, 10f, 4f)]
+        [TestCase(5f, 0f, 10f, 1f)]
+        // The review fix. A pair typed the wrong way round is read in the order that holds the vector
+        // inside both bounds: 1 and 5 mean 1..5 whichever field they were typed into. Taken raw, the
+        // first of these rows would scale a length of 10 down to 1 — under the floor of 5 — so one
+        // instance would break both of its own bounds at once.
+        [TestCase(10f, 5f, 1f, 0.5f)]
+        [TestCase(0.5f, 5f, 1f, 2f)]
+        // The other half of the fix. Scaling by a negative ceiling turns the vector around, which is
+        // the one thing a length clamp must never do; zero is the nearest legal length.
+        [TestCase(5f, 0f, -2f, 0f)]
+        [TestCase(5f, -5f, -1f, 0f)]
+        // With one bound negative the survivor becomes the ceiling, and the floor goes with it — so a
+        // short vector is left short rather than being stretched to the 3 that was typed as the floor.
+        [TestCase(5f, 3f, -2f, 0.6f)]
+        [TestCase(1f, 3f, -2f, 1f)]
+        // A ceiling of zero is a real instruction and not "unset"; only the floor reads zero that way.
+        [TestCase(5f, 0f, 0f, 0f)]
+        [TestCase(5f, 10f, 10f, 2f)]
+        public void ClampScale_OrdersThePairAndHoldsItAtZero(
+            float magnitude,
+            float min,
+            float max,
+            float expected) =>
+            Assert.AreEqual(expected, VectorClampMagnitudeConverter.ClampScale(magnitude, min, max), 1e-4f);
+
+        // End to end on a real vector: length 10 with the pair typed backwards is held at 5, not at
+        // the 1 that a raw ceiling would give, and the direction is untouched.
+        [Test]
+        public void VectorClampMagnitude_ReversedBounds_ClampsToTheLargerOfThePair() =>
+            AssertClose(
+                new Vector3(3f, 4f, 0f),
+                new VectorClampMagnitudeConverter(maxMagnitude: 1f, minMagnitude: 5f).Convert(new Vector3(6f, 8f, 0f)));
+
+        [Test]
+        public void VectorClampMagnitude_ReversedBounds_RaisesToTheSmallerOfThePair() =>
+            AssertClose(
+                new Vector3(0.6f, 0.8f, 0f),
+                new VectorClampMagnitudeConverter(maxMagnitude: 1f, minMagnitude: 5f)
+                    .Convert(new Vector3(0.3f, 0.4f, 0f)));
+
+        // Exactly zero, not the (-1.2, -1.6, 0) that scaling by -2/5 would produce: the result must
+        // not point the other way.
+        [Test]
+        public void VectorClampMagnitude_NegativeCeiling_CollapsesToZeroRatherThanReversing() =>
+            Assert.AreEqual(
+                Vector3.zero,
+                new VectorClampMagnitudeConverter(maxMagnitude: -2f).Convert(new Vector3(3f, 4f, 0f)));
+
+        [Test]
+        public void Vector2ClampMagnitude_ReversedBounds_ReadsThePairInOrder()
+        {
+            var converter = new Vector2ClampMagnitudeConverter(maxMagnitude: 1f, minMagnitude: 5f);
+
+            AssertClose(new Vector2(3f, 4f), converter.Convert(new Vector2(6f, 8f)));
+            AssertClose(new Vector2(0.6f, 0.8f), converter.Convert(new Vector2(0.3f, 0.4f)));
+        }
+
+        [Test]
+        public void Vector2ClampMagnitude_NegativeCeiling_CollapsesToZeroRatherThanReversing() =>
+            Assert.AreEqual(
+                Vector2.zero,
+                new Vector2ClampMagnitudeConverter(maxMagnitude: -2f).Convert(new Vector2(3f, 4f)));
+
+        [Test]
+        public void Vector2ClampMagnitude_KeepsTheDirectionWhileShorteningTheVector() =>
+            AssertClose(new Vector2(0.6f, 0.8f), new Vector2ClampMagnitudeConverter(1f).Convert(new Vector2(3f, 4f)));
+
+        // A floor of zero means "no floor" — the default — so a short vector stays short instead of
+        // being stretched to the ceiling.
+        [Test]
+        public void Vector2ClampMagnitude_ZeroFloor_LeavesAShortVectorAlone() =>
+            AssertClose(new Vector2(0.3f, 0.4f), new Vector2ClampMagnitudeConverter(10f).Convert(new Vector2(0.3f, 0.4f)));
+
+        // A zero vector has no direction to stretch along, so the floor cannot be applied to it: the
+        // converter hands it back rather than inventing an axis to grow on.
+        [Test]
+        public void Vector2ClampMagnitude_ZeroVector_StaysZeroEvenWithAFloor() =>
+            Assert.AreEqual(Vector2.zero, new Vector2ClampMagnitudeConverter(10f, 2f).Convert(Vector2.zero));
+
+        #endregion
+
+        #region ClampComponents
+
+        // The shared per-axis clamp. The reversed rows are the point: Mathf.Clamp taken raw with the
+        // bounds the wrong way round answers -1 for the first and 1 for the second — both ends
+        // inverted, which reads as "the binding stopped working" rather than as a typo.
+        [TestCase(5f, -1f, 1f, 1f)]
+        [TestCase(-5f, -1f, 1f, -1f)]
+        [TestCase(0.5f, -1f, 1f, 0.5f)]
+        [TestCase(5f, 1f, -1f, 1f)]
+        [TestCase(-5f, 1f, -1f, -1f)]
+        [TestCase(0f, 1f, -1f, 0f)]
+        [TestCase(3f, 2f, 2f, 2f)]
+        public void ClampComponent_OrdersThePair(float value, float min, float max, float expected) =>
+            Assert.AreEqual(expected, VectorClampComponentsConverter.ClampComponent(value, min, max), 1e-6f);
+
+        [Test]
+        public void VectorClampComponents_DefaultConstructed_HoldsEveryAxisWithinOne() =>
+            AssertClose(
+                new Vector3(1f, -1f, 0.5f),
+                new VectorClampComponentsConverter().Convert(new Vector3(5f, -5f, 0.5f)));
+
+        // Each axis carries its own pair, so one axis typed backwards must not disturb the others:
+        // x is an ordinary 0..10, y is reversed, z is left at the default box.
+        [Test]
+        public void VectorClampComponents_OneAxisReversed_LeavesTheOtherAxesAlone() =>
+            AssertClose(
+                new Vector3(0f, 5f, 0.5f),
+                new VectorClampComponentsConverter(new Vector3(0f, 5f, -1f), new Vector3(10f, -5f, 1f))
+                    .Convert(new Vector3(-3f, 100f, 0.5f)));
+
+        [Test]
+        public void VectorClampComponents_ReversedBox_ClampsTheSameWayAsTheOrderedOne()
+        {
+            var value = new Vector3(5f, -5f, 0f);
+            var ordered = new VectorClampComponentsConverter(-Vector3.one, Vector3.one).Convert(value);
+            var reversed = new VectorClampComponentsConverter(Vector3.one, -Vector3.one).Convert(value);
+
+            AssertClose(ordered, reversed);
+
+            // Pinning the value as well as the agreement, so the pair cannot both be wrong together.
+            AssertClose(new Vector3(1f, -1f, 0f), reversed);
+        }
+
+        [Test]
+        public void Vector2ClampComponents_ReversedBox_ReadsThePairInOrder() =>
+            AssertClose(
+                new Vector2(1f, -1f),
+                new Vector2ClampComponentsConverter(Vector2.one, -Vector2.one).Convert(new Vector2(5f, -5f)));
+
+        [Test]
+        public void Vector2ClampComponents_DefaultConstructed_HoldsBothAxesWithinOne() =>
+            AssertClose(
+                new Vector2(1f, -0.25f),
+                new Vector2ClampComponentsConverter().Convert(new Vector2(5f, -0.25f)));
+
+        #endregion
+
+        #region Round
+
+        // Mathf.Round is Math.Round, which is banker's rounding: an exact half goes to the EVEN
+        // neighbour, not away from zero. 1.5 and 2.5 therefore both answer 2 — the row an
+        // implementation that "rounds up on a half" fails, and the reason the scalar
+        // RoundNumberConverter has a midpoint field that this converter does not.
+        [Test]
+        public void VectorRound_ExactHalf_GoesToTheEvenNeighbour() =>
+            AssertClose(
+                new Vector3(0f, 2f, 2f),
+                new VectorRoundConverter(RoundMode.Round).Convert(new Vector3(0.5f, 1.5f, 2.5f)));
+
+        // A step of zero is not "multiply the vector away"; it reads as "no grid" and rounds to whole
+        // numbers, which is the only thing an unset step can sensibly mean.
+        [Test]
+        public void VectorRound_DefaultConstructed_RoundsToWholeNumbers() =>
+            AssertClose(
+                new Vector3(1f, -2f, 2f),
+                new VectorRoundConverter().Convert(new Vector3(1.4f, -1.6f, 2.5f)));
+
+        // Floor and Truncate agree above zero and part company below it, which is where a converter
+        // written as a cast goes wrong. -1.5 also separates Round from both.
+        [TestCase(RoundMode.Round, 1f, -1f, -2f)]
+        [TestCase(RoundMode.Floor, 1f, -2f, -2f)]
+        [TestCase(RoundMode.Ceil, 2f, -1f, -1f)]
+        [TestCase(RoundMode.Truncate, 1f, -1f, -1f)]
+        public void VectorRound_Direction_DecidesWhereTheFractionGoes(RoundMode mode, float x, float y, float z) =>
+            AssertClose(
+                new Vector3(x, y, z),
+                new VectorRoundConverter(mode).Convert(new Vector3(1.4f, -1.4f, -1.5f)));
+
+        // The rounding happens on the value divided by the step, so the midpoint rule lands on the
+        // grid cell rather than the units place: 0.25 and 1.25 both sit exactly between two 0.5 cells
+        // and go to the even one, while 0.75 goes up.
+        [Test]
+        public void VectorRound_Step_AppliesTheMidpointRuleAtTheGridCell() =>
+            AssertClose(
+                new Vector3(0f, 1f, 1f),
+                new VectorRoundConverter(RoundMode.Round, 0.5f).Convert(new Vector3(0.25f, 0.75f, 1.25f)));
+
+        // Nothing rejects a negative step, and dividing by it mirrors the rounding: Floor rounds the
+        // result UP and Ceil rounds it down. An author who types -0.5 meaning "half a unit" gets the
+        // opposite of the direction they picked.
+        [TestCase(RoundMode.Floor, 0.5f, 0.5f)]
+        [TestCase(RoundMode.Floor, -0.5f, 1f)]
+        [TestCase(RoundMode.Ceil, 0.5f, 1f)]
+        [TestCase(RoundMode.Ceil, -0.5f, 0.5f)]
+        public void VectorRound_NegativeStep_MirrorsFloorAndCeil(RoundMode mode, float step, float expected) =>
+            AssertClose(Vector3.one * expected, new VectorRoundConverter(mode, step).Convert(Vector3.one * 0.6f));
+
+        [Test]
+        public void Vector2Round_SnapsBothAxesToTheGrid() =>
+            AssertClose(
+                new Vector2(0.5f, -0.25f),
+                new Vector2RoundConverter(RoundMode.Ceil, 0.25f).Convert(new Vector2(0.3f, -0.3f)));
+
+        [Test]
+        public void Vector2Round_DefaultConstructed_RoundsToWholeNumbers() =>
+            AssertClose(new Vector2(1f, -2f), new Vector2RoundConverter().Convert(new Vector2(1.4f, -1.6f)));
+
+        [Test]
+        public void VectorRound_UndeclaredMode_Throws() =>
+            Assert.Throws<ArgumentOutOfRangeException>(
+                () => new VectorRoundConverter((RoundMode)99).Convert(Vector3.one));
+
+        [Test]
+        public void Vector2Round_UndeclaredMode_Throws() =>
+            Assert.Throws<ArgumentOutOfRangeException>(
+                () => new Vector2RoundConverter((RoundMode)99).Convert(Vector2.one));
+
+        #endregion
+
+        #region Normalize
+
+        [Test]
+        public void Vector2Normalize_ReducesToUnitLength() =>
+            AssertClose(new Vector2(0.6f, 0.8f), new Vector2NormalizeConverter().Convert(new Vector2(3f, 4f)));
+
+        [Test]
+        public void Vector2Normalize_NegativeDirection_KeepsItsSign() =>
+            AssertClose(new Vector2(0f, -1f), new Vector2NormalizeConverter().Convert(new Vector2(0f, -4f)));
+
+        // An already-unit vector must come back untouched rather than a hair off.
+        [Test]
+        public void Vector2Normalize_UnitInput_IsUnchanged() =>
+            AssertClose(Vector2.up, new Vector2NormalizeConverter().Convert(Vector2.up));
+
+        [Test]
+        public void Vector2Normalize_ZeroStaysZeroRatherThanNaN() =>
+            Assert.AreEqual(Vector2.zero, new Vector2NormalizeConverter().Convert(Vector2.zero));
+
+        // Undocumented, and inherited from Unity rather than written here: `normalized` has a length
+        // floor of 1e-5 (Vector2.kEpsilon / Vector3.kEpsilon), below which it answers zero instead of
+        // a direction. A stick a hair off centre therefore aims nowhere rather than at full throw —
+        // which is not what "or zero for a zero-length input" in the XML docs suggests.
+        [Test]
+        public void Vector2Normalize_BelowTheLengthEpsilon_IsZeroNotAUnitVector() =>
+            Assert.AreEqual(Vector2.zero, new Vector2NormalizeConverter().Convert(new Vector2(1e-6f, 0f)));
+
+        [Test]
+        public void VectorNormalize_BelowTheLengthEpsilon_IsZeroNotAUnitVector() =>
+            Assert.AreEqual(Vector3.zero, new VectorNormalizeConverter().Convert(new Vector3(1e-6f, 0f, 0f)));
+
+        // The other side of the same threshold, which is what makes the two tests above a floor
+        // rather than a blanket "short vectors are dropped": ten times the floor and the direction
+        // survives.
+        [Test]
+        public void Vector2Normalize_JustAboveTheLengthEpsilon_KeepsTheDirection() =>
+            AssertClose(Vector2.right, new Vector2NormalizeConverter().Convert(new Vector2(1e-4f, 0f)));
+
+        #endregion
+
+        #region VectorDistanceConverter
+
+        // The flattened row is the one that matters: the height is dropped from the OFFSET, so a
+        // position 10 above the target and 5 along the ground from it reads 5, not 11.18.
+        [TestCase(3f, 4f, 0f, false, 5f)]
+        [TestCase(3f, 10f, 4f, false, 11.18034f)]
+        [TestCase(3f, 10f, 4f, true, 5f)]
+        public void VectorDistance_MeasuresToTheAuthoredPoint(
+            float x,
+            float y,
+            float z,
+            bool flattenY,
+            float expected) =>
+            Assert.AreEqual(
+                expected,
+                new VectorDistanceConverter(Vector3.zero, flattenY).Convert(new Vector3(x, y, z)),
+                1e-4f);
+
+        [Test]
+        public void VectorDistance_DefaultConstructed_MeasuresToTheOrigin() =>
+            Assert.AreEqual(5f, new VectorDistanceConverter().Convert(new Vector3(3f, 4f, 0f)), 1e-4f);
+
+        [Test]
+        public void VectorDistance_AuthoredPoint_IsTheOtherEndOfTheMeasurement() =>
+            Assert.AreEqual(
+                5f,
+                new VectorDistanceConverter(new Vector3(1f, 2f, 3f)).Convert(new Vector3(4f, 6f, 3f)),
+                1e-4f);
+
+        [Test]
+        public void VectorDistance_Transform_MeasuresToItsPosition()
+        {
+            var target = NewTarget(new Vector3(10f, 0f, 0f));
+
+            Assert.AreEqual(5f, new VectorDistanceConverter(target).Convert(new Vector3(13f, 4f, 0f)), 1e-4f);
+        }
+
+        // The position is read on every conversion rather than captured when the converter was built.
+        // A waypoint marker has to follow the thing it points at, and a converter that cached the
+        // position would pass the first assert and fail the second.
+        [Test]
+        public void VectorDistance_Transform_IsReReadOnEveryConversion()
+        {
+            var target = NewTarget(new Vector3(10f, 0f, 0f));
+            var converter = new VectorDistanceConverter(target);
+
+            Assert.AreEqual(0f, converter.Convert(new Vector3(10f, 0f, 0f)), 1e-4f);
+
+            target.position = new Vector3(20f, 0f, 0f);
+
+            Assert.AreEqual(10f, converter.Convert(new Vector3(10f, 0f, 0f)), 1e-4f);
+        }
+
+        [Test]
+        public void VectorDistance_Transform_FlattenY_DropsTheHeightDifference()
+        {
+            var target = NewTarget(new Vector3(0f, 10f, 0f));
+
+            Assert.AreEqual(
+                5f,
+                new VectorDistanceConverter(target, flattenY: true).Convert(new Vector3(3f, 0f, 4f)),
+                1e-4f);
+        }
+
+        // The emptiness check is Unity's `== null`, not `is null`, so a destroyed target is seen as
+        // empty and the converter measures to the authored point instead — zero for this ctor, hence
+        // 5. Written with `is null` it would read `position` off a destroyed object and throw on the
+        // frame the target dies; measuring to the old position would answer ~8.06.
+        [Test]
+        public void VectorDistance_DestroyedTarget_FallsBackToTheAuthoredPoint()
+        {
+            var target = NewTarget(new Vector3(10f, 0f, 0f));
+            var converter = new VectorDistanceConverter(target);
+
+            UnityEngine.Object.DestroyImmediate(target.gameObject);
+
+            Assert.AreEqual(5f, converter.Convert(new Vector3(3f, 4f, 0f)), 1e-4f);
+
+            // An empty target is an authoring choice, not a failure, so nothing may be reported.
+            LogAssert.NoUnexpectedReceived();
+        }
+
+        #endregion
+
+        #region VectorLerpConverter and the curve
+
+        [Test]
+        public void VectorLerp_NoCurve_MovesEvenly() =>
+            AssertClose(new Vector3(7f, 0f, 0f), new VectorLerpConverter(From, To).Convert(0.5f));
+
+        // Both spellings of "no curve" have to mean the same thing. An unassigned AnimationCurve
+        // deserializes as an empty one rather than as null, and Evaluate on an empty curve answers 0
+        // — which would pin every conversion at _from. The length guard is what stops that, and this
+        // is the case that fails without it.
+        [Test]
+        public void VectorLerp_EmptyCurve_IsTreatedAsNoCurve() =>
+            AssertClose(
+                new Vector3(9f, 0f, 0f),
+                new VectorLerpConverter(From, To, new AnimationCurve()).Convert(0.7f));
+
+        // The curve shapes the amount before the move, so one that runs 1 down to 0 reverses the
+        // travel: a quarter of the way in reads three quarters of the way along.
+        [Test]
+        public void VectorLerp_Curve_ShapesTheAmountBeforeTheMove() =>
+            AssertClose(
+                new Vector3(9.5f, 0f, 0f),
+                new VectorLerpConverter(From, To, AnimationCurve.Linear(0f, 1f, 1f, 0f)).Convert(0.25f),
+                1e-3f);
+
+        // A constant curve proves the incoming amount is not consulted at all once a curve is
+        // present — both conversions land on the same point.
+        [Test]
+        public void VectorLerp_ConstantCurve_IgnoresTheIncomingAmount()
+        {
+            var converter = new VectorLerpConverter(From, To, AnimationCurve.Constant(0f, 1f, 0.25f));
+
+            AssertClose(new Vector3(4.5f, 0f, 0f), converter.Convert(0f));
+            AssertClose(new Vector3(4.5f, 0f, 0f), converter.Convert(0.9f));
+        }
+
+        // The clamp belongs to Vector3.Lerp and applies to the amount the CURVE produced, not to the
+        // amount that came in — the tooltip's "hold the incoming amount inside 0..1" describes the
+        // wrong end. A curve that overshoots is held at the far end; one that undershoots, at the
+        // near end. Unclamped these would read 22 and -8.
+        [Test]
+        public void VectorLerp_CurveAboveOne_IsHeldAtTheFarEnd() =>
+            AssertClose(To, new VectorLerpConverter(From, To, AnimationCurve.Constant(0f, 1f, 2f)).Convert(0.5f));
+
+        [Test]
+        public void VectorLerp_CurveBelowZero_IsHeldAtTheNearEnd() =>
+            AssertClose(From, new VectorLerpConverter(From, To, AnimationCurve.Constant(0f, 1f, -1f)).Convert(0.5f));
+
+        [Test]
+        public void VectorLerp_AmountOutsideZeroToOne_IsHeldAtTheEnds()
+        {
+            var converter = new VectorLerpConverter(From, To);
+
+            AssertClose(To, converter.Convert(1.5f));
+            AssertClose(From, converter.Convert(-0.5f));
+        }
+
+        // _clamp has no constructor parameter, so the LerpUnclamped branch is only reachable the way
+        // a real scene reaches it — through deserialization of a [SerializeReference] field. The
+        // first assert proves the JSON landed (and, incidentally, that a deserialized instance with
+        // no curve key is not pinned at _from); the second is the branch itself, sailing half again
+        // past _to instead of stopping on it.
+        [Test]
+        public void VectorLerp_Deserialized_WithClampOff_OvershootsTheFarEnd()
+        {
+            var converter = JsonUtility.FromJson<VectorLerpConverter>(
+                "{\"_from\":{\"x\":2,\"y\":0,\"z\":0},\"_to\":{\"x\":12,\"y\":0,\"z\":0},\"_clamp\":false}");
+
+            AssertClose(new Vector3(7f, 0f, 0f), converter.Convert(0.5f));
+            AssertClose(new Vector3(17f, 0f, 0f), converter.Convert(1.5f));
+        }
+
+        #endregion
+
+        private Transform NewTarget(Vector3 position)
+        {
+            var gameObject = new GameObject(nameof(VectorMathAdditionsTests));
+            gameObject.transform.position = position;
+            _created.Add(gameObject);
+
+            return gameObject.transform;
+        }
+
+        // NUnit compares two vectors with Vector.Equals, which is exact float equality. Everything
+        // expected above is the result of arithmetic, so the components are compared with a delta
+        // instead — the exact-equality assertions are left for the cases that really are exact, such
+        // as a collapse to zero.
+        private static void AssertClose(Vector3 expected, Vector3 actual, float delta = 1e-4f)
+        {
+            Assert.AreEqual(expected.x, actual.x, delta, $"x of {actual}, expected {expected}");
+            Assert.AreEqual(expected.y, actual.y, delta, $"y of {actual}, expected {expected}");
+            Assert.AreEqual(expected.z, actual.z, delta, $"z of {actual}, expected {expected}");
+        }
+
+        private static void AssertClose(Vector2 expected, Vector2 actual, float delta = 1e-4f)
+        {
+            Assert.AreEqual(expected.x, actual.x, delta, $"x of {actual}, expected {expected}");
+            Assert.AreEqual(expected.y, actual.y, delta, $"y of {actual}, expected {expected}");
+        }
+    }
+}

--- a/Aspid.MVVM/Packages/tech.aspid.mvvm/Tests/Editor/Converters/Vectors/VectorMathAdditionsTests.cs
+++ b/Aspid.MVVM/Packages/tech.aspid.mvvm/Tests/Editor/Converters/Vectors/VectorMathAdditionsTests.cs
@@ -15,20 +15,14 @@ namespace Aspid.MVVM.StarterKit.Tests
     /// <see cref="VectorDistanceConverter"/> and the curve on <see cref="VectorLerpConverter"/>.
     /// </summary>
     /// <remarks>
-    /// The class of mistake guarded here is a converter that silently stops honouring its own
-    /// contract on input an Inspector can legitimately produce: a min/max pair typed the wrong way
-    /// round, so a clamp breaks both of its bounds at once; a negative ceiling, so a length clamp
-    /// turns the vector around; a negative grid step, so Floor rounds up; a direction that was never
-    /// normalised, so a dot product silently scales its reading; a target Transform destroyed
-    /// mid-session, so a distance either throws or measures to a corpse.
+    /// The class of mistake guarded here is a converter that stops honouring its own contract on input an
+    /// Inspector can legitimately produce: a min/max pair typed the wrong way round, a negative ceiling,
+    /// a negative grid step, a direction that was never normalised, a target destroyed mid-session.
     /// <para>
-    /// Every expectation below was taken from the arithmetic the source actually performs, not from
-    /// the XML docs, and three of them contradict what a reader would assume. <c>Mathf.Round</c> is
-    /// banker's rounding, so an exact half goes to the even neighbour rather than away from zero.
-    /// Unity's <c>normalized</c> has a length floor of 1e-5, so a very short vector answers zero
-    /// rather than a unit vector. And <see cref="VectorLerpConverter"/>'s "hold the incoming amount
-    /// inside 0..1" is done by <c>Vector3.Lerp</c> on the amount the curve produced — the incoming
-    /// value itself is never clamped. Each such test pins the behaviour and says so where it stands.
+    /// Expectations come from the arithmetic the source performs, and three contradict what a reader would
+    /// assume: <c>Mathf.Round</c> is banker's rounding, Unity's <c>normalized</c> has a length floor of
+    /// 1e-5, and <see cref="VectorLerpConverter"/> clamps the amount the curve produced rather than the
+    /// incoming value. Each such test says so where it stands.
     /// </para>
     /// </remarks>
     [TestFixture]

--- a/Aspid.MVVM/Packages/tech.aspid.mvvm/Tests/Editor/Converters/Vectors/VectorMathAdditionsTests.cs.meta
+++ b/Aspid.MVVM/Packages/tech.aspid.mvvm/Tests/Editor/Converters/Vectors/VectorMathAdditionsTests.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 8bd948848ebc34d90a7dae5f2d48ea1f


### PR DESCRIPTION
✨ The remaining 72 catalogue items — the picker goes from **164 converters to 211**, so the catalogue the audit asked for is complete.

| Group | Was | Is | Added |
|-------|-----|----|-------|
| `Aspid/Vector` | 23 | **43** | 2D half of the combine family, `Vector2` maths, `Bounds`/`Rect` interop, `Vector4` swizzles |
| `Aspid/Colour` | 14 | **21** | `ColorChannel`, `ColorBlockState`, `HdrIntensity`, `Color`↔`Vector4`, `Color`↔`Color32`, easing on `ColorLerp` |
| `Aspid/Rotation` | 9 | **15** | `QuaternionToAngle`, `AngleDifference`, `QuaternionSlerp`, `Quaternion`↔`Vector4`, `RadiansToDegrees` |
| `Aspid/Collection` | 6 | **11** | `First`, `Last`, `Take`, `DictionaryLookup`, count-to-plural-word |
| `Aspid/String` | 41 | **46** | `StringToDouble`, `Decimal`, `TimeSpan`, `Vector2`, `Vector3` |
| `Aspid/Enum` | 6 | **8** | `EnumFlagsToString`, `EnumMask` |

✅ 607 more test cases, with expectations produced by executing the converters rather than read from the docs.

## Notes for review

- 🐛 **Seven defects were found in review and fixed before the first green run**: `EnumMask` corrupting non-`[Flags]` enums, both `ClampMagnitude` converters applying bounds unordered, `ListToString` allocating per push, `StringToDecimal` misreading its own fallback, the vector parsers writing text they cannot read back, `Math.Clamp` throwing on reversed bounds, and `Pluralize` emitting the count without the word.
- 📝 **Two audit items were declined**: moving `EnumFlagsConverters` between assemblies (breaks `[SerializeReference]` like a rename) and a shim for the now-abstract `Vector2CombineConverter` (documented as a break instead).
- ✅ 2406 EditMode tests, 2404 passed, 0 failed, 2 skipped (batch mode).

<details>
<summary>🇷🇺 Описание на русском</summary>

✨ Оставшиеся 72 пункта каталога — пикер вырос со **164 конвертеров до 211**, каталог из аудита собран полностью.

| Группа | Было | Стало | Добавлено |
|--------|------|-------|-----------|
| `Aspid/Vector` | 23 | **43** | 2D-половина семейства combine, математика `Vector2`, interop `Bounds`/`Rect`, свизлы `Vector4` |
| `Aspid/Colour` | 14 | **21** | `ColorChannel`, `ColorBlockState`, `HdrIntensity`, `Color`↔`Vector4`, `Color`↔`Color32`, сглаживание у `ColorLerp` |
| `Aspid/Rotation` | 9 | **15** | `QuaternionToAngle`, `AngleDifference`, `QuaternionSlerp`, `Quaternion`↔`Vector4`, `RadiansToDegrees` |
| `Aspid/Collection` | 6 | **11** | `First`, `Last`, `Take`, `DictionaryLookup`, счётчик в словоформу |
| `Aspid/String` | 41 | **46** | `StringToDouble`, `Decimal`, `TimeSpan`, `Vector2`, `Vector3` |
| `Aspid/Enum` | 6 | **8** | `EnumFlagsToString`, `EnumMask` |

✅ Ещё 607 тестовых кейсов, ожидания получены исполнением конвертеров, а не выписаны из документации.

## Заметки для ревью

- 🐛 **Семь дефектов найдены на ревью и исправлены до первого зелёного прогона**: `EnumMask` портил enum без `[Flags]`, оба `ClampMagnitude` применяли границы неупорядоченно, `ListToString` аллоцировал на каждый push, `StringToDecimal` неверно читал собственный fallback, векторные парсеры писали текст, который сами не прочитают, `Math.Clamp` бросал на перевёрнутых границах, а `Pluralize` выдавал число без слова.
- 📝 **Два пункта аудита отклонены**: перенос `EnumFlagsConverters` между сборками (ломает `[SerializeReference]` так же, как переименование) и шим для ставшего абстрактным `Vector2CombineConverter` (слом задокументирован вместо шима).
- ✅ 2406 EditMode-тестов, 2404 прошло, 0 упало, 2 пропущено (batch mode).

</details>

